### PR TITLE
Remove stackoverflow tag link in support

### DIFF
--- a/guides/index.en.erb
+++ b/guides/index.en.erb
@@ -474,7 +474,7 @@
 
   <div class="card card-highlight grid__item">
     <h3>Support</h3>
-      <p> <b> Technical Questions </b>  <a href="https://es.stackoverflow.com/questions/tagged/mercadopago">Check out our StackOverflow Tag.</a></p>
+      <p> <b> Technical Questions </b>  <a href="https://groups.google.com/forum/#!forum/mercadopago-developers">Check out Mercado Pago developers community.</a></p>
       <p> <b> Suggestions and Ideas: </b> <a href="https://github.com/mercadopago">Send us a Pull Request.</a></p>
     </ul>
   </div>

--- a/guides/index.es.erb
+++ b/guides/index.es.erb
@@ -399,7 +399,7 @@
 
   <div class="card card-highlight grid__item">
     <h3>Soporte</h3>
-      <p> <b> Consultas Técnicas: </b>  <a href="https://es.stackoverflow.com/questions/tagged/mercadopago">Consulta nuestro tag de Stackoverflow.</a></p>
+      <p> <b> Consultas Técnicas: </b>  <a href="https://groups.google.com/forum/#!forum/mercadopago-developers">Consulta nuestra comunidad de desarrolladores de Mercado Pago.</a></p>
       <p> <b> Sugerencias e Ideas: </b> <a href="https://github.com/mercadopago">Envíanos un Pull Request.</a></p>
     </ul>
   </div>

--- a/guides/index.pt.erb
+++ b/guides/index.pt.erb
@@ -409,7 +409,7 @@
 
   <div class="card card-highlight grid__item">
     <h3>Suporte</h3>
-      <p> <b> Consultas Técnicas: </b>  <a href="https://es.stackoverflow.com/questions/tagged/mercadopago">Confira nossa tag de Stackoverflow.</a></p>
+      <p> <b> Consultas Técnicas: </b>  <a href="https://groups.google.com/forum/#!forum/mercadopago-developers">Confira nossa Mercado Pago developers community.</a></p>
       <p> <b> Sugestões e ideias: </b> <a href="https://github.com/mercadopago">Envie-nos um Pull Request.</a></p>
     </ul>
   </div>


### PR DESCRIPTION
- Replace stackoverflow tag for google developers group link