### PR TITLE
Update introducción-Marketplace-API

### DIFF
--- a/guides/marketplace/api/introduction.en.md
+++ b/guides/marketplace/api/introduction.en.md
@@ -5,12 +5,14 @@ A **MarketPlace** is a website or application that allows sellers and buyers to 
 Mercado Pago allows you to collect payments on behalf of the sellers of your platform and optionally charge a commission for the transaction.
 
 When a payment is generated, the amount is immediately divided between the seller’s account and your account, in case you charge a fee.
+_Clarification: The payment split can only be done between two Mercado Pago accounts (Marketplace and the seller associated to it), no more._
 
 > NOTE
 >
 > Note
 >
 > Mercado Pago’s fee will be deducted from the funds received by the seller.
+> First the Mercado Pago fee is discounted, and after that the Marketplace fee. 
 
 The Marketplace requires 3 steps:
 
@@ -35,9 +37,12 @@ The **credencial privada**, or *access\_token*, are used for all requests to the
 
 Initially, your application will only be able to interact with Mercado Pago in **Sandbox Mode**, an exact replica of the **Production Mode**, designed with the purpose of facilitating tests during the integration.
 
-We will provide you with test cards, so that you can simulate transactions as if they were real.
+We will provide you with [test cards](/guides/marketplace/web-checkout/testing-marketplace.en.md/), so that you can simulate transactions as if they were real.
 
-Once you have tested your application, you must complete the [homologation process](#) and complete the “I want to go to production” form that you will find in your credentials.
+Once you have tested your application, you must complete the [homologation process](/guides/marketplace/api/goto-production.es.md/) and complete the “I want to go to production” form that you will find in your credentials.
+
+**Before you can start using your production credentials you must complete the "I want to go to production" form in order to activate them.** 
+If not, you´ll get the "Invalid use of live credentials" error.  
 
 Your application will be automatically activated. All you have to do is replace the sandbox keys with the production ones in your code.
 

--- a/guides/marketplace/api/introduction.es.md
+++ b/guides/marketplace/api/introduction.es.md
@@ -36,9 +36,9 @@ La **credencial privada**, o *access\_token*, se utiliza para todas las otras ll
 
 Inicialmente tu aplicación sólo podrá interactuar con Mercado Pago en **Modo Sandbox**, una réplica exacta de **Modo Producción**, diseñado con el objetivo de facilitar las pruebas durante la integración.
 
-Te brindaremos [tarjetas de prueba](https://www.mercadopago.com.ar/developers/es/guides/marketplace/web-checkout/testing-marketplace/), para que puedas simular transacciones como si fueran reales.
+Te brindaremos [tarjetas de prueba](/guides/marketplace/web-checkout/testing-marketplace.es.md/), para que puedas simular transacciones como si fueran reales.
 
-Una vez que hayas probado tu aplicación, deberás realizar el [proceso de homologación](https://www.mercadopago.com.ar/developers/es/guides/marketplace/api/goto-production/) y completar el formulario "Quiero ir a producción" que encontrarás en tus [credenciales](https://www.mercadopago.com/mla/account/credentials).
+Una vez que hayas probado tu aplicación, deberás realizar el [proceso de homologación](/guides/marketplace/api/goto-production.es.md/) y completar el formulario "Quiero ir a producción" que encontrarás en tus [credenciales](https://www.mercadopago.com/mla/account/credentials).
 
 **Antes de utilizar las credenciales de producción se deberá completar el formulario de "Quiero ir a producción" para activarlas.** 
 Caso contrario se recibirá el error de "Invalid use of live credentials". 

--- a/guides/marketplace/api/introduction.es.md
+++ b/guides/marketplace/api/introduction.es.md
@@ -5,12 +5,14 @@ Un **MarketPlace** es un sitio o aplicación que permite a vendedores y comprado
 Mercado Pago te permite realizar cobros a nombre de los vendedores de tu plataforma y opcionalmente cobrar una comisión por la transacción.
 
 Cuando se genera un pago, el dinero es dividido en el instante entre la cuenta de tu vendedor y la tuya, en caso de cobres una comisión.
+_Aclaración: El split del pago sólo se podrá realizar entre dos cuentas (el Marketplace y la cuenta vendedora), no más._
 
 > NOTE
 >
 > Nota
 >
 > La comisión de Mercado Pago será descontada de los fondos que reciba el vendedor.
+> Primero se descuenta la comisión de Mercado Pago, y sobre el restante se descuenta la comisión del Marketplace. 
 
 _Marketplace_ requiere de 3 pasos:
 
@@ -34,9 +36,12 @@ La **credencial privada**, o *access\_token*, se utiliza para todas las otras ll
 
 Inicialmente tu aplicación sólo podrá interactuar con Mercado Pago en **Modo Sandbox**, una réplica exacta de **Modo Producción**, diseñado con el objetivo de facilitar las pruebas durante la integración.
 
-Te brindaremos tarjetas de prueba, para que puedas simular transacciones como si fueran reales.
+Te brindaremos [tarjetas de prueba](https://www.mercadopago.com.ar/developers/es/guides/marketplace/web-checkout/testing-marketplace/), para que puedas simular transacciones como si fueran reales.
 
-Una vez que hayas probado tu aplicación, deberás realizar el [proceso de homologación](https://www.mercadopago.com/mla/account/credentials) y completar el formulario "Quiero ir a producción" que encontrarás en tus [credenciales](https://www.mercadopago.com/mla/account/credentials).
+Una vez que hayas probado tu aplicación, deberás realizar el [proceso de homologación](https://www.mercadopago.com.ar/developers/es/guides/marketplace/api/goto-production/) y completar el formulario "Quiero ir a producción" que encontrarás en tus [credenciales](https://www.mercadopago.com/mla/account/credentials).
+
+**Antes de utilizar las credenciales de producción se deberá completar el formulario de "Quiero ir a producción" para activarlas.** 
+Caso contrario se recibirá el error de "Invalid use of live credentials". 
 
 Tu aplicación será activada automáticamente. Lo único que debes hacer es reemplazar las claves de _sandbox_ por las productivas en tu código.
 

--- a/guides/marketplace/api/introduction.pt.md
+++ b/guides/marketplace/api/introduction.pt.md
@@ -1,21 +1,23 @@
-# Introdução à API do MarketPlace
+# Introdução
 
-O **MarketPlace** é um site ou aplicação que permite uma interação entre compradores e vendedores para a conclusão de uma transação comercial. O proprietário do Marketplace fornece um espaço aos vendedores para que apresentem seus produtos ou serviços, e é responsável pela gestão de todos os aspectos da transação. Por exemplo, o Mercado Livre é um Marketplace.
+O **MarketPlace** é um site ou aplicação que permite uma interação entre compradores e vendedores para a conclusão de uma transação comercial. O proprietário do _Marketplace_ fornece um espaço aos vendedores para que apresentem seus produtos ou serviços, e é responsável pela gestão de todos os aspectos da transação. Por exemplo, o Mercado Livre é um _Marketplace_.
 
-O Mercado Pago permite realizar cobranças em nome dos vendedores de sua plataforma e, opcionalmente, cobra uma taxa pela transação.
+O Mercado Pago permite realizar cobranças em nome dos vendedores de sua plataforma e, opcionalmente, cobrar uma taxa pela transação.
 
 Quando um pagamento é gerado, o dinheiro é dividido imediatamente entre a conta do seu vendedor e a sua, em caso de taxa de comissão.
 
+_Esclarecimento: A divisão do pagamento só pode ser realizada entre duas contas (o Marketplace e a conta vendedora), não mais._
 
 > NOTE
 >
 > Nota
 >
 > A comissão do Mercado Pago será descontada do valor recebido pelo vendedor.
+> Primeiro se desconta a comissão do Mercado Pago, e sobre o restante se desconta a comissão do _Marketplace_.
 
-O Marketplace requer 3 passos:
+O _Marketplace_ requer 3 passos:
 
-1. **Criar uma aplicação** Marketplace.
+1. **Criar uma aplicação** _Marketplace_.
 2. **Conectar** as contas de seus vendedores.
 3. **Efetuar** a cobrança em nome dos vendedores.
 
@@ -25,20 +27,23 @@ Após criar a aplicação, você só precisa executar o segundo e o terceiro pas
 
 Assim como na API de Pagamentos, você conta com dois pares de chaves para conectar-se com a API. Estas chaves podem ser encontradas na seção [credenciais da sua conta](https://www.mercadopago.com/mlb/account/credentials).
 
-A **chave pública**, ou *public_key*, é utilizada para acessar todos os recursos que precisará de seu frontend para coletar dados de cartão de crédito e tokenizar.
+A **chave pública**, ou *public_key*, é utilizada para acessar todos os recursos que precisará de seu frontend para coletar dados de cartão de crédito e _tokenizar_.
 
 A **chave privada**, ou *access_token*, é utilizada para todas as requisições realizadas às APIs, tais como processamento de pagamentos, reembolsos, armazenamento de cartões, etc. As chaves privadas devem ser mantidas **confidencialmente** em seus servidores de backend e nunca devem ser publicadas.
 
 > Ao clicar no botão “renovar credenciais”, você obterá novos pares de chaves e as anteriores deixarão de funcionar. Faça isso apenas se desconfiar que suas chaves privadas foram violadas ou por questões de segurança, semelhante à alteração de senha, a cada período de tempo. Lembre-se de substituir as credenciais em sua aplicação para mantê-la funcionando.
 
-## Modo Sandbox e Modo de Produção
+## Modo _Sandbox_ e Modo de Produção
 
 Inicialmente, sua aplicação poderá interagir com o Mercado Pago apenas no **Modo Sandbox**, uma réplica exata do **Modo de Produção**, desenvolvido com o objetivo de facilitar os testes durante a integração.
 
-Forneceremos cartões de teste para que possa simular transações como se fossem reais.
+Forneceremos [cartões de teste](/guides/marketplace/web-checkout/testing-marketplace.pt.md) para que possa simular transações como se fossem reais.
 
-Assim que tiver testado sua aplicação, você deverá realizar o [processo de homologação](/guides/marketplace/api/goto-production.pt.md) e preencher o formulário “Quero ir para a produção”, que pode ser encontrado em suas credenciais.
+Assim que tiver testado sua aplicação, você deverá realizar o [processo de homologação](/guides/marketplace/api/goto-production.pt.md) e preencher o formulário “Quero ir para a produção”, que pode ser encontrado em suas [credenciais](https://www.mercadopago.com/mlb/account/credentials).
 
-Sua aplicação será ativada automaticamente. Tudo o que deve fazer é substituir as chaves do sandbox pelas de produção em seu código.
+**Antes de utilizar as credenciais de produção é preciso completar o formulário de "Quero ir para produção" para ativa-las.** 
+Caso contrario se receberá o erro de "Invalid use of live credentials". 
+
+Sua aplicação será ativada automaticamente. Tudo o que deve fazer é substituir as chaves do _sandbox_ pelas de produção em seu código.
 
 #### [Começar a criar meu Marketplace](/guides/marketplace/api/create-marketplace.pt.md).

--- a/guides/marketplace/api/introduction.pt.md
+++ b/guides/marketplace/api/introduction.pt.md
@@ -1,44 +1,49 @@
-# Introdução à API do MarketPlace
+---
+  descrição: Mercado Pago conta com APIs para poder receber pagamentos de forma segura em seu web site, aplicação móvel, ou onde desejar, mantendo a experiência de compra.
+---
 
-O **MarketPlace** é um site ou aplicação que permite uma interação entre compradores e vendedores para a conclusão de uma transação comercial. O proprietário do Marketplace fornece um espaço aos vendedores para que apresentem seus produtos ou serviços, e é responsável pela gestão de todos os aspectos da transação. Por exemplo, o Mercado Livre é um Marketplace.
+# Introdução à nossa API de Pagamentos
 
-O Mercado Pago permite realizar cobranças em nome dos vendedores de sua plataforma e, opcionalmente, cobra uma taxa pela transação.
+O Mercado Pago conta com APIs para receber pagamentos de forma segura em seu site, aplicativo móvel ou onde desejar.
 
-Quando um pagamento é gerado, o dinheiro é dividido imediatamente entre a conta do seu vendedor e a sua, em caso de taxa de comissão.
+Com nossas APIs:
 
-
-> NOTE
->
-> Nota
->
-> A comissão do Mercado Pago será descontada do valor recebido pelo vendedor.
-
-O Marketplace requer 3 passos:
-
-1. **Criar uma aplicação** Marketplace.
-2. **Conectar** as contas de seus vendedores.
-3. **Efetuar** a cobrança em nome dos vendedores.
-
-Após criar a aplicação, você só precisa executar o segundo e o terceiro passos para cada fornecedor subsequente.
+* Você pode criar seu próprio checkout sem que seus compradores deixem o seu site.
+* Os dados do cartão nunca passarão por seus servidores, mantendo a segurança.
+* Você pode salvar os dados de cartão dos seus clientes para compras futuras.
 
 ## Credenciais
 
-Assim como na API de Pagamentos, você conta com dois pares de chaves para conectar-se com a API. Estas chaves podem ser encontradas na seção [credenciais da sua conta](https://www.mercadopago.com/mlb/account/credentials).
+Você conta com dois pares de chaves para conectar-se com a API, uma para um ambiente de testes e a outra para o ambiente de produção. Estas chaves podem ser encontradas na seção [credenciais da sua conta](https://www.mercadopago.com/mlb/account/credentials).
 
-A **chave pública**, ou *public_key*, é utilizada para acessar todos os recursos que precisará de seu frontend para coletar dados de cartão de crédito e tokenizar.
+A **chave pública**, ou *public key*, é utilizada para acessar todos os recursos que precisará de seu frontend para coletar dados de cartão de crédito e tokenizar.
 
-A **chave privada**, ou *access_token*, é utilizada para todas as requisições realizadas às APIs, tais como processamento de pagamentos, reembolsos, armazenamento de cartões, etc. As chaves privadas devem ser mantidas **confidencialmente** em seus servidores de backend e nunca devem ser publicadas.
+A **chave privada**, ou *access token*, é utilizada para todas as requisições realizadas às APIs, tais como processamento de pagamentos, reembolsos, armazenamento de cartões, etc. As chaves privadas devem ser mantidas **confidencialmente** em seus servidores de backend e nunca devem ser publicadas.
 
-> Ao clicar no botão “renovar credenciais”, você obterá novos pares de chaves e as anteriores deixarão de funcionar. Faça isso apenas se desconfiar que suas chaves privadas foram violadas ou por questões de segurança, semelhante à alteração de senha, a cada período de tempo. Lembre-se de substituir as credenciais em sua aplicação para mantê-la funcionando.
+> Ao clicar no botão “renovar credenciais”, obterá novos pares de chaves e as anteriores deixarão de funcionar. Faça isso apenas se desconfiar que suas chaves privadas foram violadas ou por questões de segurança, semelhante à alteração de senha, a cada período de tempo. Lembre-se de substituir as credenciais em sua aplicação para mantê-la funcionando.
 
 ## Modo Sandbox e Modo de Produção
 
 Inicialmente, sua aplicação poderá interagir com o Mercado Pago apenas no **Modo Sandbox**, uma réplica exata do **Modo de Produção**, desenvolvido com o objetivo de facilitar os testes durante a integração.
 
-Forneceremos cartões de teste para que possa simular transações como se fossem reais.
+Forneceremos [cartões de teste](/guides/marketplace/web-checkout/testing-marketplace.pt.md/), para que possa simular transações como se fossem reais.
 
-Assim que tiver testado sua aplicação, você deverá realizar o [processo de homologação](/guides/marketplace/api/goto-production.pt.md) e preencher o formulário “Quero ir para a produção”, que pode ser encontrado em suas credenciais.
+Assim que tiver testado sua aplicação, deverá realizar o [processo de homologação](/guides/marketplace/api/goto-production.pt.md/) e completar o formulário "Quero ir para produção" que se encontra juntamente com suas [credenciais](https://www.mercadopago.com/mlb/account/credentials).
 
 Sua aplicação será ativada automaticamente. Tudo o que deve fazer é substituir as chaves do sandbox pelas de produção em seu código.
 
-#### [Começar a criar meu Marketplace](/guides/marketplace/api/create-marketplace.pt.md).
+## Requisitos para ir a produção
+
+Depois de testar a sua aplicação no modo _Sandbox_, você deve completar o processo de homologação que consistindo em:
+
+* Usar o _SDK_ do mercadopago.js para verificar os métodos de pagamento, efetuar pagamentos, garantir uma boa experiência do usuário e evitar transações fraudulentas.
+* Usar o atributo `data_checkout` nas tags do `input` para manusear os dados de forma segura e evitar que eles sejam enviado para o seu servidor. Certifique-se de NÃO incluir o atributo de `name` nessas tags.
+* Tenha um certificado SSL para garantir uma navegação segura e que o formulário de pagamento seja enviado via HTTPS.
+* Comunique corretamente o resultado do pagamento ao usuário para tentar recuperar o pagamento em caso de rejeição. Para isso, [utilize os códigos de resposta](/guides/payments/api/handling-responses.pt.md).
+* Comunique as [promoções e possibilidades de parcelamento](https://www.mercadopago.com.br/promocoes/) oferecidas pelo Mercado Pago. Você pode incluir nossos [banners institucionais](https://www.mercadopago.com/mlb/com.mercadopago.web.landing.LandingController?id=banners).
+
+> Quando cumprir os requisitos, você deve preencher o formulário Eu quero ir para produção que está na seção das suas [credenciais](https://www.mercadopago.com/mlb/account/credentials)
+
+O não cumprimento destas regras pode envolver desde o não processamento do pagamento, a ações legais de acordo com os [termos e condições](https://www.mercadopago.com.br/ajuda/termos-e-condicoes_300). Você deve ter uma política de termos e condições, na qual você especifica que é responsável por todos os dados que foram inseridos em seu site.
+
+#### [Começar a integrar a API](/guides/payments/api/receiving-payment-by-card.pt.md).

--- a/guides/marketplace/api/introduction.pt.md
+++ b/guides/marketplace/api/introduction.pt.md
@@ -1,49 +1,44 @@
----
-  descrição: Mercado Pago conta com APIs para poder receber pagamentos de forma segura em seu web site, aplicação móvel, ou onde desejar, mantendo a experiência de compra.
----
+# Introdução à API do MarketPlace
 
-# Introdução à nossa API de Pagamentos
+O **MarketPlace** é um site ou aplicação que permite uma interação entre compradores e vendedores para a conclusão de uma transação comercial. O proprietário do Marketplace fornece um espaço aos vendedores para que apresentem seus produtos ou serviços, e é responsável pela gestão de todos os aspectos da transação. Por exemplo, o Mercado Livre é um Marketplace.
 
-O Mercado Pago conta com APIs para receber pagamentos de forma segura em seu site, aplicativo móvel ou onde desejar.
+O Mercado Pago permite realizar cobranças em nome dos vendedores de sua plataforma e, opcionalmente, cobra uma taxa pela transação.
 
-Com nossas APIs:
+Quando um pagamento é gerado, o dinheiro é dividido imediatamente entre a conta do seu vendedor e a sua, em caso de taxa de comissão.
 
-* Você pode criar seu próprio checkout sem que seus compradores deixem o seu site.
-* Os dados do cartão nunca passarão por seus servidores, mantendo a segurança.
-* Você pode salvar os dados de cartão dos seus clientes para compras futuras.
+
+> NOTE
+>
+> Nota
+>
+> A comissão do Mercado Pago será descontada do valor recebido pelo vendedor.
+
+O Marketplace requer 3 passos:
+
+1. **Criar uma aplicação** Marketplace.
+2. **Conectar** as contas de seus vendedores.
+3. **Efetuar** a cobrança em nome dos vendedores.
+
+Após criar a aplicação, você só precisa executar o segundo e o terceiro passos para cada fornecedor subsequente.
 
 ## Credenciais
 
-Você conta com dois pares de chaves para conectar-se com a API, uma para um ambiente de testes e a outra para o ambiente de produção. Estas chaves podem ser encontradas na seção [credenciais da sua conta](https://www.mercadopago.com/mlb/account/credentials).
+Assim como na API de Pagamentos, você conta com dois pares de chaves para conectar-se com a API. Estas chaves podem ser encontradas na seção [credenciais da sua conta](https://www.mercadopago.com/mlb/account/credentials).
 
-A **chave pública**, ou *public key*, é utilizada para acessar todos os recursos que precisará de seu frontend para coletar dados de cartão de crédito e tokenizar.
+A **chave pública**, ou *public_key*, é utilizada para acessar todos os recursos que precisará de seu frontend para coletar dados de cartão de crédito e tokenizar.
 
-A **chave privada**, ou *access token*, é utilizada para todas as requisições realizadas às APIs, tais como processamento de pagamentos, reembolsos, armazenamento de cartões, etc. As chaves privadas devem ser mantidas **confidencialmente** em seus servidores de backend e nunca devem ser publicadas.
+A **chave privada**, ou *access_token*, é utilizada para todas as requisições realizadas às APIs, tais como processamento de pagamentos, reembolsos, armazenamento de cartões, etc. As chaves privadas devem ser mantidas **confidencialmente** em seus servidores de backend e nunca devem ser publicadas.
 
-> Ao clicar no botão “renovar credenciais”, obterá novos pares de chaves e as anteriores deixarão de funcionar. Faça isso apenas se desconfiar que suas chaves privadas foram violadas ou por questões de segurança, semelhante à alteração de senha, a cada período de tempo. Lembre-se de substituir as credenciais em sua aplicação para mantê-la funcionando.
+> Ao clicar no botão “renovar credenciais”, você obterá novos pares de chaves e as anteriores deixarão de funcionar. Faça isso apenas se desconfiar que suas chaves privadas foram violadas ou por questões de segurança, semelhante à alteração de senha, a cada período de tempo. Lembre-se de substituir as credenciais em sua aplicação para mantê-la funcionando.
 
 ## Modo Sandbox e Modo de Produção
 
 Inicialmente, sua aplicação poderá interagir com o Mercado Pago apenas no **Modo Sandbox**, uma réplica exata do **Modo de Produção**, desenvolvido com o objetivo de facilitar os testes durante a integração.
 
-Forneceremos [cartões de teste](/guides/marketplace/web-checkout/testing-marketplace.pt.md/), para que possa simular transações como se fossem reais.
+Forneceremos cartões de teste para que possa simular transações como se fossem reais.
 
-Assim que tiver testado sua aplicação, deverá realizar o [processo de homologação](/guides/marketplace/api/goto-production.pt.md/) e completar o formulário "Quero ir para produção" que se encontra juntamente com suas [credenciais](https://www.mercadopago.com/mlb/account/credentials).
+Assim que tiver testado sua aplicação, você deverá realizar o [processo de homologação](/guides/marketplace/api/goto-production.pt.md) e preencher o formulário “Quero ir para a produção”, que pode ser encontrado em suas credenciais.
 
 Sua aplicação será ativada automaticamente. Tudo o que deve fazer é substituir as chaves do sandbox pelas de produção em seu código.
 
-## Requisitos para ir a produção
-
-Depois de testar a sua aplicação no modo _Sandbox_, você deve completar o processo de homologação que consistindo em:
-
-* Usar o _SDK_ do mercadopago.js para verificar os métodos de pagamento, efetuar pagamentos, garantir uma boa experiência do usuário e evitar transações fraudulentas.
-* Usar o atributo `data_checkout` nas tags do `input` para manusear os dados de forma segura e evitar que eles sejam enviado para o seu servidor. Certifique-se de NÃO incluir o atributo de `name` nessas tags.
-* Tenha um certificado SSL para garantir uma navegação segura e que o formulário de pagamento seja enviado via HTTPS.
-* Comunique corretamente o resultado do pagamento ao usuário para tentar recuperar o pagamento em caso de rejeição. Para isso, [utilize os códigos de resposta](/guides/payments/api/handling-responses.pt.md).
-* Comunique as [promoções e possibilidades de parcelamento](https://www.mercadopago.com.br/promocoes/) oferecidas pelo Mercado Pago. Você pode incluir nossos [banners institucionais](https://www.mercadopago.com/mlb/com.mercadopago.web.landing.LandingController?id=banners).
-
-> Quando cumprir os requisitos, você deve preencher o formulário Eu quero ir para produção que está na seção das suas [credenciais](https://www.mercadopago.com/mlb/account/credentials)
-
-O não cumprimento destas regras pode envolver desde o não processamento do pagamento, a ações legais de acordo com os [termos e condições](https://www.mercadopago.com.br/ajuda/termos-e-condicoes_300). Você deve ter uma política de termos e condições, na qual você especifica que é responsável por todos os dados que foram inseridos em seu site.
-
-#### [Começar a integrar a API](/guides/payments/api/receiving-payment-by-card.pt.md).
+#### [Começar a criar meu Marketplace](/guides/marketplace/api/create-marketplace.pt.md).


### PR DESCRIPTION
-Link a tarjetas de prueba y manejo de mensajes de respuesta. 
-Recordar completar el formulario de “Quiero ir a producción para las llamadas a la API. Sino no se activarán las credenciales. Ok
-Aclarar que el split solo se puede hacer entre la cuenta vendedor y la cuenta marketplace. Que no se permite hacer el split entre N cuentas.