### PR TITLE
Adición de página con detalles de la migración v0 para v1

### DIFF
--- a/guides/changelog/2018.pt.md
+++ b/guides/changelog/2018.pt.md
@@ -33,6 +33,8 @@ Migração dos seguintes recursos:
 | Busca de pagamentos     | `GET`  | /payments/search                       | /v1/payments/search              |
 | Busca de pagamentos     | `GET`  | /collections/search                    | /v1/payments/search              |
 
+Mais informações [neste artigo](/guides/migration-v0-v1/migrating-v0-v1.pt.md).
+
 ## 14 de junho 2018
 Devido a um problema de Divulgação de Informações, ocultaremos algumas informações de contato do pagador para **pagamentos não aprovados**.
 

--- a/guides/localization/migrating-v0-v1.en.md
+++ b/guides/localization/migrating-v0-v1.en.md
@@ -1,0 +1,58 @@
+# Migration from Version v0 to v1 of the Mercado Pago API
+
+At Mercado Pago we always try to optimize our platform offering the highest efficiency and security in payment processing.
+
+We are currently working on migrating our API v0 to v1 in order to maintain the highest quality standards.
+Consequently, the Mercado Pago will require the use of the new version of the API to be used as of July 30, 2018.
+
+After this deadline, v0 will be disabled and any attempt to connect using it will fail.
+
+### Points to consider
+
+* The change will impact **from July 30, 2018**
+* If you use only the payment buttons from mercado Pago, this change will not affect you.
+* If you only use Mercado Shops, this change will not affect you.
+* If you have your **own e-commerce, consult your IT staff**.
+* If you **operate with some e-commerce platform**, such as: Magento, Shopify or others **consult your technical support**.
+
+## Migrated resources
+
+The table below shows a list of migrated resources.
+
+| Use                     | Method | URI of the deprecated resource         | Resource URI equivalent          | Reference                                                       |
+|-------------------------|--------|----------------------------------------|----------------------------------|-----------------------------------------------------------------|
+| Refunds                 | `POST` | /collections/$payment_id/refunds       | /v1/payments/$payment_id/refunds |-                                                                |
+| Refunds                 | `PUT`  | /collections/$payment_id               | /v1/payments/$payment_id/        |-                                                                |
+| Payment update          | `PUT`  | /payments/$payment_id                  | /v1/payments/$payment_id/        |[access](/reference/payments/endpoints/_payments_id/put.yaml)    |
+| Payment update          | `PUT`  | /collections/$payment_id               | /v1/payments/$payment_id/        |[access](/reference/payments/endpoints/_payments_id/put.yaml)    |
+| Payments                | `GET`  | /payments/$payment_id                  | /v1/payments/$payment_id/        |[access](/reference/payments/endpoints/_payments_id/get.yaml)    |
+| Payments                | `GET`  | /collections/$payment_id               | /v1/payments/$payment_id/        |[access](/reference/payments/endpoints/_payments_id/get.yaml)    |
+| Payment notifications   | `GET`  | /collections/notifications/$payment_id | /v1/payments/$payment_id/        |[access](/reference/payments/endpoints/_payments_id/get.yaml)    |
+| Payments search         | `GET`  | /payments/search                       | /v1/payments/search              |[access](/reference/payments/endpoints/_payments_search/get.yaml)|
+| Payments search         | `GET`  | /collections/search                    | /v1/payments/search              |[access](/reference/payments/endpoints/_payments_search/get.yaml)|
+
+### Examples
+
+#### Total refund
+'''json
+curl -X POST \
+        -H "content-type: application/json" \
+        "https://api.mercadopago.com/v1/payments/:id/refunds?access_token=ENV_ACCESS_TOKEN"
+'''
+
+#### Partial refund
+
+'''curl
+curl -X POST \
+        -H 'content-type: application/json' \
+        'https://api.mercadopago.com/v1/payments/12861583/refunds?access_token=ENV_ACCESS_TOKEN' \
+        -d '{
+                "amount": 5.0
+        }'
+'''
+
+If you need to make adaptations, **it is important that you remember to make this change in a timely manner, otherwise it is very likely that your connections to the Mercado Pago will begin to fail.**
+
+If you have any questions or need help to successfully complete this change, please contact us at the following email: developers@mercadopago.com.br.
+
+Mercado Pago team.

--- a/guides/localization/migrating-v0-v1.es.md
+++ b/guides/localization/migrating-v0-v1.es.md
@@ -1,0 +1,58 @@
+# Migración de la versión v0 a v1 de la API de Mercado Pago
+
+En Mercado Pago buscamos siempre optimizar nuestra plataforma ofreciendo la más alta eficiencia y seguridad en el procesamiento de pagos.
+
+En el momento, estamos trabajando en la migración de nuestra API v0 a la v1 con el objetivo de mantener los más altos estándares de calidad.
+En consecuencia, el Mercado Pago requerirá la utilización de la nueva versión de la API que se utilice a partir del 30 de julio de 2018.
+
+Después de ese plazo, la versión v0 se desactivará y cualquier intento de conexión que se utiliza con la función fallará.
+
+### Puntos para ser tenidos en cuenta
+
+* La modificación tendrá efecto **a partir del 30 de julio de 2018.**
+* Si utiliza sólo los botones de pago de Mercado Pago, este cambio no afectará a usted.
+* Si utiliza sólo el Mercado Shops, este cambio no le afectará.
+* Si tiene su **propio e-commerce, consulte a su equipo de TI**.
+* Si **se trabaja con alguna plataforma de comercio electrónico**, por ejemplo: Magento, Shopify u otros **Consulte su soporte técnico**.
+
+## Recursos migrados
+
+La tabla siguiente trae una relación de los recursos migrados.
+
+| Uso                     | Método | URI del recurso deprecado              | URI del recurso equivalente      | Referencia                                                      |
+|-------------------------|--------|----------------------------------------|----------------------------------|-----------------------------------------------------------------|
+| Devoluciones            | `POST` | /collections/$payment_id/refunds       | /v1/payments/$payment_id/refunds |-                                                                |
+| Devoluciones            | `PUT`  | /collections/$payment_id               | /v1/payments/$payment_id/        |-                                                                |
+| Actualización de pago   | `PUT`  | /payments/$payment_id                  | /v1/payments/$payment_id/        |[visita](/reference/payments/endpoints/_payments_id/put.yaml)    |
+| Actualización de pago   | `PUT`  | /collections/$payment_id               | /v1/payments/$payment_id/        |[visita](/reference/payments/endpoints/_payments_id/put.yaml)    |
+| Pagos                   | `GET`  | /payments/$payment_id                  | /v1/payments/$payment_id/        |[visita](/reference/payments/endpoints/_payments_id/get.yaml)    |
+| Pagos                   | `GET`  | /collections/$payment_id               | /v1/payments/$payment_id/        |[visita](/reference/payments/endpoints/_payments_id/get.yaml)    |
+| Notificación de pagos   | `GET`  | /collections/notifications/$payment_id | /v1/payments/$payment_id/        |[visita](/reference/payments/endpoints/_payments_id/get.yaml)    |
+| Búsqueda de pagos       | `GET`  | /payments/search                       | /v1/payments/search              |[visita](/reference/payments/endpoints/_payments_search/get.yaml)|
+| Búsqueda de pagos       | `GET`  | /collections/search                    | /v1/payments/search              |[visita](/reference/payments/endpoints/_payments_search/get.yaml)|
+
+### Ejemplos
+
+#### Devolución total
+'''json
+curl -X POST \
+        -H "content-type: application/json" \
+        "https://api.mercadopago.com/v1/payments/:id/refunds?access_token=ENV_ACCESS_TOKEN"
+'''
+
+#### Devolución parcial
+
+'''curl
+curl -X POST \
+        -H 'content-type: application/json' \
+        'https://api.mercadopago.com/v1/payments/12861583/refunds?access_token=ENV_ACCESS_TOKEN' \
+        -d '{
+                "amount": 5.0
+        }'
+'''
+
+Si usted necesita hacer adaptaciones, **es importante que usted recuerde hacer este cambio en tiempo hábil, porque de lo contrario, es muy probable que sus conexiones con el Mercado Pago empiecen a fallar.**
+
+Si tiene alguna duda o necesita ayuda para completar con éxito este cambio, por favor, póngase en contacto con nosotros a través del siguiente correo electrónico: developers@mercadopago.com.br.
+
+Equipo de Mercado Pago.

--- a/guides/localization/migrating-v0-v1.pt.md
+++ b/guides/localization/migrating-v0-v1.pt.md
@@ -1,0 +1,58 @@
+# Migração da versão V0 para V1 da API de Mercado Pago
+
+No Mercado Pago procuramos sempre otimizar nossa plataforma oferecendo a mais alta eficiência e segurança no processamento de pagamentos.
+
+No momento, estamos trabalhando na migração da nossa API v0 para a V1 com o objetivo de manter os mais altos padrões de qualidade.
+Consequentemente, o Mercado Pago exigirá a utilização da nova versão da API seja utilizada a partir de 30 de julho de 2018.
+
+Depois desse prazo, a versão v0 será desativada e qualquer tentativa de conexão utilizando-a falhará.
+
+### Pontos para serem levados em conta
+
+* A alteração terá impacto **a partir de 30 de julho de 2018.**
+* Se você usa apenas os botões de pagamento de Mercado Pago, essa alteração não afetará você.
+* Se você usa apenas Mercado Shops, essa alteração não afetará você.
+* Caso tenha seu **próprio e-commerce, consulte sua equipe de TI**.
+* Caso **opere com alguma plataforma de e-commerce**, como por exemplo: Magento, Shopify ou outros **Consulte seu respectivo suporte técnico**.
+
+## Recursos migrados
+
+A tabela abaixo traz uma relação dos recursos migrados.
+
+| Uso                     | Método | URI do Recurso deprecado               | URI do Recurso equivalente       | Referência                  |
+|-------------------------|--------|----------------------------------------|----------------------------------|-----------------------------|
+| Devoluções              | `POST` | /collections/$payment_id/refunds       | /v1/payments/$payment_id/refunds |-                            |
+| Devoluções              | `PUT`  | /collections/$payment_id               | /v1/payments/$payment_id/        |-                            |
+| Atualização de pagamento| `PUT`  | /payments/$payment_id                  | /v1/payments/$payment_id/        |[acesse](/reference/payments/endpoints/_payments_id/put.yaml)|
+| Atualização de pagamento| `PUT`  | /collections/$payment_id               | /v1/payments/$payment_id/        |[acesse](/reference/payments/endpoints/_payments_id/put.yaml)|
+| Pagamentos              | `GET`  | /payments/$payment_id                  | /v1/payments/$payment_id/        |[acesse](/reference/payments/endpoints/_payments_id/get.yaml)|
+| Pagamentos              | `GET`  | /collections/$payment_id               | /v1/payments/$payment_id/        |[acesse](/reference/payments/endpoints/_payments_id/get.yaml)|
+| Notificação de pagamentos| `GET`  | /collections/notifications/$payment_id | /v1/payments/$payment_id/       |[acesse](/reference/payments/endpoints/_payments_id/get.yaml)|
+| Busca de pagamentos     | `GET`  | /payments/search                       | /v1/payments/search              |[acesse](/reference/payments/endpoints/_payments_search/get.yaml)|
+| Busca de pagamentos     | `GET`  | /collections/search                    | /v1/payments/search              |[acesse](/reference/payments/endpoints/_payments_search/get.yaml)|
+
+### Exemplos
+
+#### Devolução Total
+'''json
+curl -X POST \
+        -H "content-type: application/json" \
+        "https://api.mercadopago.com/v1/payments/:id/refunds?access_token=ENV_ACCESS_TOKEN"
+'''
+
+#### Devolução Parcial
+
+'''curl
+curl -X POST \
+        -H 'content-type: application/json' \
+        'https://api.mercadopago.com/v1/payments/12861583/refunds?access_token=ENV_ACCESS_TOKEN' \
+        -d '{
+                "amount": 5.0
+        }'
+'''
+
+Caso você precise fazer adaptações, **é importante que você se lembre de fazer essa alteração em tempo hábil, porque caso contrário, é muito provável que suas conexões com o Mercado Pago comecem a falhar.**
+
+Se você tiver alguma dúvida ou precisar de ajuda para concluir com êxito essa mudança, entre em contato conosco através do seguinte e-mail: developers@mercadopago.com.br.
+
+Equipe do Mercado Pago.


### PR DESCRIPTION
Añadimos una página con detalles de la migración. Enviaremos un comunicado a los clientes que todavía utilizan la V0 y colocaremos un enlace a esa página como forma de ayuda.