### PR TITLE
Corregido link a la página de detalles de la migración v0 v1

### DIFF
--- a/guides/changelog/2018.en.md
+++ b/guides/changelog/2018.en.md
@@ -34,7 +34,7 @@ Migración de los siguientes recursos:
 | Payments search       | `GET`  | /payments/search                       | /v1/payments/search              |
 | Payments search       | `GET`  | /collections/search                    | /v1/payments/search              |
 
-More information [in this article](/ guides / migration-v0-v1 / migrating-v0-v1.pt.md).
+More information [in this article](/guides/localization/migrating-v0-v1.en.md).
 
 ## June 14 2018
 

--- a/guides/changelog/2018.es.md
+++ b/guides/changelog/2018.es.md
@@ -35,7 +35,7 @@ Migración de los siguientes recursos:
 | Búsqueda de pagos       | `GET`  | /payments/search                         | /v1/payments/search                |
 | Búsqueda de pagos       | `GET`  | /collections/search                      | /v1/payments/search                |
 
-Más información [en este artículo](/ guides / migration-v0-v1 / migrating-v0-v1.es.md).
+Más información [en este artículo](/guides/localization/migrating-v0-v1.es.md).
 
 ## 14 de Junio de 2018
 

--- a/guides/changelog/2018.pt.md
+++ b/guides/changelog/2018.pt.md
@@ -33,7 +33,7 @@ Migração dos seguintes recursos:
 | Busca de pagamentos     | `GET`  | /payments/search                       | /v1/payments/search              |
 | Busca de pagamentos     | `GET`  | /collections/search                    | /v1/payments/search              |
 
-Mais informações [neste artigo](/guides/migration-v0-v1/migrating-v0-v1.pt.md).
+Mais informações [neste artigo](/guides/localization/migrating-v0-v1.pt.md).
 
 ## 14 de junho 2018
 Devido a um problema de Divulgação de Informações, ocultaremos algumas informações de contato do pagador para **pagamentos não aprovados**.


### PR DESCRIPTION
El link a la página de detalles era incorrecto.
Hice el ajuste.