### PR TITLE
Fixed tables in Chargebacks Documentation

### DIFF
--- a/guides/manage-account/chargebacks.en.md
+++ b/guides/manage-account/chargebacks.en.md
@@ -62,14 +62,14 @@ With this `ID` you can make a ** GET** to` https://api.mercadopago.com/v1/charge
 According to the vendor's operation, your commercial agreement - or both - may vary the coverage policy of each chargeback by Mercado Pago. The field `coverage_elegible` defines if the chargeback is possible to be disputed or not.
 
 | Field         | Value           | Description
-| ----      | ----                |
+| ----          | ----            | ----
 | `coverage_elegible` | **false** | Indicates that the chargeback can not be disputed
 | `coverage_elegible` | **true**  | Indicates that the chargeback can be disputed
 
 In addition, there is a `documentation_required` field that indicates whether the documentation is required to be uploaded to be covered.
 
 | Field         | Value           | Description
-| ----      | ----                |
+| ----          | ----            | ----
 | `documentation_required` | **false** | Indicates that no documentation is required for the chargeback
 | `documentation_required` | **true**  | Indicates that documentation is required for the chargeback
 
@@ -113,7 +113,7 @@ Once the documentation is sent, a Mercado Pago representative will review it.
 Eventually the chargeback may have two types of possible resolutions:
 
 | Field         | Value           | Description
-| ----      | ----                |
+| ----          | ----            | ----
 | `coverage_applied` | **false** | Indicates that Mercado Pago failed _ against_ the seller (the money is returned to the buyer)
 | `coverage_applied` | **true**  | Indicates that Mercado Pago failed _ against_ the seller (the money is returned to the seller)
 

--- a/guides/manage-account/chargebacks.es.md
+++ b/guides/manage-account/chargebacks.es.md
@@ -60,14 +60,14 @@ Con dicho `ID` podrás hacer un **GET** a `https://api.mercadopago.com/v1/charge
 Según la operatoria del vendedor, su acuerdo comercial - o ambos - puede variar la política de cobertura de cada contracargo por parte de Mercado Pago. El campo `coverage_elegible` define si el contracargo es posible de ser disputado o no.
 
 | Campo         | Valor           | Descripción
-| ----      | ----                |
+| ----          | ----            | ----
 | `coverage_elegible` | **false** | Indica que el contracargo no puede ser disputado
 | `coverage_elegible` | **true**  |Indica que el contracargo sí puede ser disputado
 
 Además se cuenta con el campo `documentation_required` que indica si se requiere que se suba la documentación para ser cubierto. 
 
 | Campo         | Valor           | Descripción
-| ----      | ----                |
+| ----          | ----            | ----
 | `documentation_required` | **false** | Indica que no se requiere documentación para el contracargo
 | `documentation_required` | **true**  |Indica que se requiere documentación para el contracargo
 
@@ -111,7 +111,7 @@ Una vez enviada la documentación, un representante de Mercado Pago la revisará
 Eventualmente el contracargo podrá tener dos tipos de resoluciones posibles:
 
 | Campo         | Valor           | Descripción
-| ----      | ----                |
+| ----          | ----            | ----
 | `coverage_applied` | **false** | Indica que Mercado Pago falló _en contra_ del vendedor (se le devuelve el dinero al comprador)
 | `coverage_applied` | **true**  | Indica que Mercado Pago falló _a favor_ del vendedor (se le devuelve el dinero al vendedor)
 


### PR DESCRIPTION
Se arregla un error de visualización en las tablas de la doc de contracargos. Solo sucedía en inglés y español.