### PR TITLE
Modificación de la cantidad de días disponibles para hacer un refund de un pago según site id

### DIFF
--- a/guides/manage-account/cancellations-and-refunds.en.md
+++ b/guides/manage-account/cancellations-and-refunds.en.md
@@ -67,7 +67,7 @@ You can refund a payment within **360 days** after it was approved.
 ----[mlb]----
 You can refund a payment within **120 days** after it was approved.
 ------------
-----[mlm,mlc,mlu,mpe,mco]----
+----[mlm, mlc, mlu, mpe, mco]----
 You can refund a payment within **180 days** after it was approved.
 ------------
 

--- a/guides/manage-account/cancellations-and-refunds.en.md
+++ b/guides/manage-account/cancellations-and-refunds.en.md
@@ -61,7 +61,15 @@ curl -X PUT \
 **Response status code: 200 OK**
 
 ## Refunds
-You can refund a payment within **90 days** after it was approved.
+----[mla]----
+You can refund a payment within **360 days** after it was approved.
+------------
+----[mlb]----
+You can refund a payment within **120 days** after it was approved.
+------------
+----[mlm,mlc,mlu,mpe,mco]----
+You can refund a payment within **180 days** after it was approved.
+------------
 
 You must have sufficient funds in your account in order to successfully refund the payment amount. Otherwise, you will get a `400 Bad Request error`.
 

--- a/guides/manage-account/cancellations-and-refunds.es.md
+++ b/guides/manage-account/cancellations-and-refunds.es.md
@@ -67,7 +67,7 @@ Puedes devolver un pago dentro de los **360 días** desde su acreditación.
 ----[mlb]----
 Puedes devolver un pago dentro de los **120 días** desde su acreditación.
 ------------
-----[mlm,mlc,mlu,mpe,mco]----
+----[mlm, mlc, mlu, mpe, mco]----
 Puedes devolver un pago dentro de los **180 días** desde su acreditación.
 ------------
 

--- a/guides/manage-account/cancellations-and-refunds.es.md
+++ b/guides/manage-account/cancellations-and-refunds.es.md
@@ -61,8 +61,15 @@ curl -X PUT \
 **Response status code: 200 OK**
 
 ## Devoluciones
-
-Puedes devolver un pago dentro de los **90 días** desde su acreditación.
+----[mla]----
+Puedes devolver un pago dentro de los **360 días** desde su acreditación.
+------------
+----[mlb]----
+Puedes devolver un pago dentro de los **120 días** desde su acreditación.
+------------
+----[mlm,mlc,mlu,mpe,mco]----
+Puedes devolver un pago dentro de los **180 días** desde su acreditación.
+------------
 
 Debes poseer suficiente dinero disponible en tu cuenta para devolver el monto del pago satisfactoriamente. De lo contrario obtendrás un error `400 Bad Request`.
 

--- a/guides/manage-account/cancellations-and-refunds.pt.md
+++ b/guides/manage-account/cancellations-and-refunds.pt.md
@@ -62,7 +62,15 @@ curl -X PUT \
 **Response status code: 200 OK**
 
 ## Devoluções
-É possível devolver um pagamento dentro de **90 dias** a partir de sua data de aprovação.
+----[mla]----
+É possível devolver um pagamento dentro de **360 dias** a partir de sua data de aprovação.
+------------
+----[mlb]----
+É possível devolver um pagamento dentro de **120 dias** a partir de sua data de aprovação.
+------------
+----[mlm,mlc,mlu,mpe,mco]----
+É possível devolver um pagamento dentro de **180 dias** a partir de sua data de aprovação.
+------------
 
 Deve haver saldo suficiente disponível em sua conta para efetuar a devolução do valor do pagamento com sucesso. Caso contrário, obterá um erro `400 Bad Request`.
 

--- a/guides/manage-account/cancellations-and-refunds.pt.md
+++ b/guides/manage-account/cancellations-and-refunds.pt.md
@@ -68,7 +68,7 @@ curl -X PUT \
 ----[mlb]----
 É possível devolver um pagamento dentro de **120 dias** a partir de sua data de aprovação.
 ------------
-----[mlm,mlc,mlu,mpe,mco]----
+----[mlm, mlc, mlu, mpe, mco]----
 É possível devolver um pagamento dentro de **180 dias** a partir de sua data de aprovação.
 ------------
 


### PR DESCRIPTION
La cantidad de días para hacer un refund( devolución) de un pago desde su acreditación se modificó de 90 días a otra cantidad según la siguiente config:

-MLA: 360 días
-MLB: 120 días
-MLM: 180 días
-MLC: 180 días
-MCO: 180 días
-MPE: 180 días
-MLU: 180 días

Para ello se modificó el archivo https://github.com/mercadopago/devsite-docs/blob/master/guides/manage-account/cancellations-and-refunds.es.md en sus 3 idiomas (es-en-pt).