### PR TITLE
fixed typo in samples directory

### DIFF
--- a/reference/merchant_orders/endpoints/_merchant_orders_search/get.yaml
+++ b/reference/merchant_orders/endpoints/_merchant_orders_search/get.yaml
@@ -1,6 +1,6 @@
 ---
 resource: merchant_orders.raml
-sample:
+samples:
 - search_curl.sh
 - search_curl_response.json
 use:


### PR DESCRIPTION
Se corrije un error que hacía que no se mostraran los archivos del directorio samples.