### PR TITLE
Added taxes support to web-checkout documentation

### DIFF
--- a/guides/payments/web-checkout/personalization.es.md
+++ b/guides/payments/web-checkout/personalization.es.md
@@ -268,6 +268,29 @@ Si no quieres permitir que se ingrese a la preferencia de pago para efectuar el 
 	"expiration_date_to": "2017-02-28T12:00:00.000-04:00"
 ```
 
+----[mco]----
+### IVA diferenciado
+
+Puedes modificar el valor del impuesto para la Dirección de Impuestos y Aduanas Nacionales (DIAN) que aplique según el producto o servicio que ofrezcas. Si no diferencias este valor, se aplicará por defecto el 19%.
+
+Atributo | Descripción
+---------| -----------
+type | Identificador del impuesto. Solo se admiten los valores IVA e INC
+value | Monto del impuesto. Se admite un máximo de dos decimales. Para ítemes excentos de impuestos se debe informar cero
+
+```json
+===
+Usa el atributo taxes para definir el valor que corresponda
+===
+"taxes": [
+	{
+		"type": "IVA",
+		"value": 16
+	}
+]
+```
+
+------------
 
 Para conocer más sobre los atributos de la preferencia, [consultá la documentación de la API](https://www.mercadopago.com.ar/developers/es/reference/preferences/resource/)
 
@@ -275,6 +298,9 @@ Para conocer más sobre los atributos de la preferencia, [consultá la documenta
 
 ### Aquí tienes una preferencia completa
 Para resumir todo lo anterior, a continuación se muestran todos los datos que se pueden configurar en una preferencia:
+
+----[mlm, mlc, mpe, mlu]----
+
 
 ```json
 {
@@ -347,3 +373,86 @@ Para resumir todo lo anterior, a continuación se muestran todos los datos que s
 }
 
 ```
+------------
+
+----[mco]----
+
+
+```json
+{
+	"items": [
+		{
+			"id": "item-ID-1234",
+			"title": "Title of what you are paying for. It will be displayed in the payment process.",
+			"currency_id": "CLP",
+			"picture_url": "https://www.mercadopago.com/org-img/MP3/home/logomp3.gif",
+			"description": "Item description",
+			"category_id": "art", // Available categories at https://api.mercadopago.com/item_categories
+			"quantity": 1,
+			"unit_price": 100
+		}
+	],
+	"payer": {
+		"name": "user-name",
+		"surname": "user-surname",
+		"email": "user@email.com",
+		"date_created": "2015-06-02T12:58:41.425-04:00",
+		"phone": {
+			"area_code": "11",
+			"number": "4444-4444"
+		},
+		"identification": {
+			"type": "RUT", // Available ID types at https://api.mercadopago.com/v1/identification_types
+			"number": "12345678"
+		},
+		"address": {
+			"street_name": "Street",
+			"street_number": 123,
+			"zip_code": "5700"
+		}
+	},
+	"back_urls": {
+		"success": "https://www.success.com",
+		"failure": "http://www.failure.com",
+		"pending": "http://www.pending.com"
+	},
+	"auto_return": "approved",
+	"payment_methods": {
+		"excluded_payment_methods": [
+			{
+				"id": "master"
+			}
+		],
+		"excluded_payment_types": [
+			{
+				"id": "ticket"
+			}
+		],
+		"installments": 12,
+		"default_payment_method_id": null,
+		"default_installments": null
+	},
+	"shipments": {
+		"receiver_address": {
+			"zip_code": "5700",
+			"street_number": 123,
+			"street_name": "Street",
+			"floor": 4,
+			"apartment": "C"
+		}
+	},
+	"notification_url": "https://www.your-site.com/ipn",
+	"external_reference": "Reference_1234",
+	"expires": true,
+	"expiration_date_from": "2016-02-01T12:00:00.000-04:00",
+	"expiration_date_to": "2016-02-28T12:00:00.000-04:00",
+	"taxes": [
+		{
+			"type": "IVA",
+			"value": 16
+		}
+	]
+}
+
+```
+------------

--- a/guides/payments/web-checkout/personalization.es.md
+++ b/guides/payments/web-checkout/personalization.es.md
@@ -299,7 +299,7 @@ Para conocer más sobre los atributos de la preferencia, [consultá la documenta
 ### Aquí tienes una preferencia completa
 Para resumir todo lo anterior, a continuación se muestran todos los datos que se pueden configurar en una preferencia:
 
-----[mlm, mlc, mpe, mlu]----
+----[mlm, mlc, mpe, mla, mlb, mlu]----
 
 
 ```json

--- a/reference/preferences/resource.yaml
+++ b/reference/preferences/resource.yaml
@@ -472,5 +472,24 @@ properties:
     description:
           en: When set to true, the payment can only be approved or rejected. Otherwise in_process status is added.
           es: Cuando se configura como true los pagos sólo pueden resultar aprobados o rechazados. Caso contrario también pueden resultar in_process.
-          pt: Quando definido como true, o pagamento só pode ter os status approved ou rejected. Caso contrário, o status in_process é adicionado..
+          pt: Quando definido como true, o pagamento só pode ter os status approved ou rejected. Caso contrário, o status in_process é adicionado.
+- taxes:
+    type: Array(Object)
+    description:
+      en: 'Differentiated taxes definition. Only available for Mercado Libre Colombia.'
+      es: 'Definición de impuestos diferenciados. Unicamente disponible para Mercado Libre Colombia.'
+      pt: 'Definição de impostos diferenciados. Disponível apenas para o Mercado Livre Colombia.'
+    properties:
+    - type:
+        type: String(3)
+        description:
+          en: 'Tax identifier. Only IVA and INC'
+          es: 'Identificador de impuesto. Solo se admiten los valores IVA e INC.'
+          pt: 'Identificador de imposto. Somente IVA e INC.'
+    - value:
+        type: Float
+        description:
+          en: 'Tax amount. A maximum of two decimal places is supported. For tax exempt items, zero must be reported.'
+          es: 'Monto del impuesto. Se admite un máximo de dos decimales. Para ítems exentos de impuestos se debe informar cero.'
+          pt: 'Valor do imposto. É suportado no máximo duas casas decimais. Para itens isentos de imposto, zero deve ser relatado.'
 


### PR DESCRIPTION
Se agrega la documentación para el nuevo campo taxes soportado por la preferencia de Web Checkout.

Secciones modificadas: Personalización y Referencia a la API.

Este campo solo está disponible para el sitio MCO y por esto se tuvo que hacer la diferenciación en el contenido.