### PR TITLE
Fix Ruby SDK integration guide

### DIFF
--- a/guides/payments/web-payment-checkout/latest/integration.en.md
+++ b/guides/payments/web-payment-checkout/latest/integration.en.md
@@ -194,8 +194,8 @@ preference_data = {
 }
 preference = $mp.create_preference(preference_data)
 
-# This value replaces the String "<%= @init_point %>" in your HTML
-@init_point = preference["response"]["init_point"]
+# This value replaces the String "<%= @preference_id %>" in your HTML
+@preference_id = preference["response"]["id"]
 ```
 ```csharp
 // Mercado Pago SDK
@@ -270,7 +270,7 @@ Finally, add the following code to show the payment button of your Smart Checkou
 <form action="/payment-process" method="POST">
   <script
    src="https://www.mercadopago.com.br/integrations/v1/web-payment-checkout.js"
-   data-preference-id="%= @init_point %>">
+   data-preference-id="<%= @preference_id %>">
   </script>
 </form>
 ```

--- a/guides/payments/web-payment-checkout/latest/integration.es.md
+++ b/guides/payments/web-payment-checkout/latest/integration.es.md
@@ -194,8 +194,8 @@ preference_data = {
 }
 preference = $mp.create_preference(preference_data)
 
-# Este valor reemplazará el string "<%= @init_point %>" en tu HTML
-@init_point = preference["response"]["init_point"]
+# Este valor reemplazará el string "<%= @preference_id %>" en tu HTML
+@preference_id = preference["response"]["id"]
 ```
 ```csharp
 // SDK de Mercado Pago
@@ -270,7 +270,7 @@ Por último, suma el siguiente código para mostrar el botón de pago de tu Smar
 <form action="/procesar-pago" method="POST">
   <script
    src="https://www.mercadopago.com.ar/integrations/v1/web-payment-checkout.js"
-   data-preference-id="%= @init_point %>">
+   data-preference-id="<%= @preference_id %>">
   </script>
 </form>
 ```

--- a/guides/payments/web-payment-checkout/latest/integration.pt.md
+++ b/guides/payments/web-payment-checkout/latest/integration.pt.md
@@ -194,8 +194,8 @@ preference_data = {
 }
 preference = $mp.create_preference(preference_data)
 
-# Este valor substituirá a string "<%= @init_point %>" no seu HTML
-@init_point = preference["response"]["init_point"]
+# Este valor substituirá a string "<%= @preference_id %>" no seu HTML
+@preference_id = preference["response"]["id"]
 ```
 ```csharp
 // SDK de Mercado Pago
@@ -270,7 +270,7 @@ Por último, adicione o seguinte código para mostrar o botão de pagamento do s
 <form action="/processar_pagamento" method="POST">
   <script
    src="https://www.mercadopago.com.br/integrations/v1/web-payment-checkout.js"
-   data-preference-id="%= @init_point %>">
+   data-preference-id="<%= @preference_id %>">
   </script>
 </form>
 ```


### PR DESCRIPTION
## Description
The integration using ruby SDK was not correct as it used `init_point` (which is an url) instead of preference_id for the attribute `data-preference-id`.

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [x] This request modifies code snippets. 
- [x] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
