### PR TITLE
fix links andorid/ios deviceML in PCI

### DIFF
--- a/guides/pci-compliant-merchants/receiving-payment-by-card.en.md
+++ b/guides/pci-compliant-merchants/receiving-payment-by-card.en.md
@@ -250,13 +250,13 @@ Our SDKs have features you can use to capture this information.
 
 ```android
 ===
-The [Device](https://github.com/mercadopago/px-ios/blob/master/MercadoPagoSDK/MercadoPagoSDK/Device.swift) class will collect both device and fingerprint information.
+The [Device](https://github.com/mercadopago/px-android/blob/master/px-services/src/main/java/com/mercadopago/android/px/model/Device.java) class will collect both device and fingerprint information.
 ===
 new Device(context);
 ```
 ```swift
 ===
-The [Device](https://github.com/mercadopago/px-android/blob/master/sdk/src/main/java/com/mercadopago/model/Device.java) class will collect both device and fingerprint information.
+The [Device](https://github.com/mercadopago/px-ios/blob/master/MercadoPagoSDK/MercadoPagoSDK/Device.swift) class will collect both device and fingerprint information.
 ===
 Device()
 ```

--- a/guides/pci-compliant-merchants/receiving-payment-by-card.es.md
+++ b/guides/pci-compliant-merchants/receiving-payment-by-card.es.md
@@ -250,13 +250,13 @@ Nuestros SDKs cuentan con funciones que puedes utilizar para capturar esta infor
 
 ```android
 ===
-La clase[Device](https://github.com/mercadopago/px-ios/blob/master/MercadoPagoSDK/MercadoPagoSDK/Device.swift) recolectará tanto la información del dispositivo como su fingerprint.
+La clase [Device](https://github.com/mercadopago/px-android/blob/master/px-services/src/main/java/com/mercadopago/android/px/model/Device.java) recolectará tanto la información del dispositivo como su fingerprint.
 ===
 new Device(context);
 ```
 ```swift
 ===
-La clase[Device](https://github.com/mercadopago/px-android/blob/master/sdk/src/main/java/com/mercadopago/model/Device.java) recolectará tanto la información del dispositivo como su fingerprint.
+La clase [Device](https://github.com/mercadopago/px-ios/blob/master/MercadoPagoSDK/MercadoPagoSDK/Device.swift) recolectará tanto la información del dispositivo como su fingerprint.
 ===
 Device()
 ```

--- a/guides/pci-compliant-merchants/receiving-payment-by-card.pt.md
+++ b/guides/pci-compliant-merchants/receiving-payment-by-card.pt.md
@@ -251,13 +251,13 @@ Nossos SDKs possuem funções que podem ser utilizadas para capturar essas infor
 
 ```android
 ===
-A classe [Device](https://github.com/mercadopago/px-ios/blob/master/MercadoPagoSDK/MercadoPagoSDK/Device.swift) coletará tanto as informações do dispositivo quanto sua impressão digital (fingerprint).
+A classe [Device](https://github.com/mercadopago/px-android/blob/master/px-services/src/main/java/com/mercadopago/android/px/model/Device.java) coletará tanto as informações do dispositivo quanto sua impressão digital (fingerprint).
 ===
 new Device(context);
 ```
 ```swift
 ===
-A classe [Device](https://github.com/mercadopago/px-android/blob/master/sdk/src/main/java/com/mercadopago/model/Device.java) coletará tanto as informações do dispositivo quanto sua impressão digital (fingerprint).
+A classe [Device](https://github.com/mercadopago/px-ios/blob/master/MercadoPagoSDK/MercadoPagoSDK/Device.swift) coletará tanto as informações do dispositivo quanto sua impressão digital (fingerprint).
 ===
 Device()
 ```


### PR DESCRIPTION
## Description
En la sección PCI Compliant para integrar Device los links a Android y a iOS están cambiados (y el de Android estaba roto)

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
