### PR TITLE
[COW] Added docs for Merchant Tracks feature

### DIFF
--- a/guides/payments/web-payment-checkout/latest/configurations.en.md
+++ b/guides/payments/web-payment-checkout/latest/configurations.en.md
@@ -352,6 +352,238 @@ To activate the payment option, go to your <a href="https://www.mercadopago.com.
 
 ------------
 
+## Integrations
+
+### Facebook Pixel
+
+When creating a preference, you can associate an identifier corresponding to a Facebook Pixel as follows:
+
+
+[[[
+```php
+<?php
+  # Create a preference object
+  $preference = new MercadoPago\Preference();
+  ...
+  $preference->tracks = array(
+    array(
+      'type' => 'facebook_ad',
+      'values'=> array(
+        'pixel_id' => 'PIXEL_ID'
+      )
+    )
+  );
+
+  ...
+  # Save and post the preference 
+  $preference->save();
+?>
+```
+```node 
+var preference = {
+  ...
+  tracks: [
+        {
+          type: "facebook_ad",
+          values: {
+            "pixel_id": 'PIXEL_ID'
+          }
+        }
+      ]
+  ...
+};
+```
+```java
+// Create a preference object
+Preference preference = new Preference();
+
+Track trackFacebook = new Track()
+                .setType("facebook_ad")
+                .setValues(new TrackValues()
+                        .setPixelId("PIXEL_ID")
+                );
+
+Preference preference = new Preference()
+        .appendTrack(trackFacebook);
+
+// Save and post the preference
+preference.save();
+```
+```csharp
+List<Track> tracks = new List<Track>();
+tracks.Add(
+    new Track
+    {
+        Type = "facebook_ad",
+        Values = new JObject
+        {
+            { "pixel_id", "PIXEL_ID" }
+        }
+    });
+
+MercadoPago.Resources.Preference preference = new MercadoPago.Resources.Preference
+{
+    ...
+    Tracks = tracks
+};
+
+preference.Save();
+```
+```curl
+curl -X POST \
+  'https://api.mercadolibre.com/checkout/preferences?access_token="PROD_ACCESS_TOKEN"' \
+  -H 'Content-Type: application/json' \
+  -H 'cache-control: no-cache' \
+  -d '{
+	"items": [
+        {
+            "id_product":1,
+            "quantity":1,
+            "unit_price": 234.33,
+            "titulo":"Mi producto"
+        }
+    ],
+    "tracks": [
+        {
+            "type": "facebook_ad",
+            "values": {
+                "pixel_id": "PIXEL_ID"
+            }
+        }
+    ]
+}'
+```
+]]]
+
+With this configuration, when payments are *approved* through Checkout Mercado Pago, you will see a `Purchase` event associated with the specified pixel.
+
+> WARNING
+>
+> Important
+>
+> Payments that are not approved instantly (pending) will not be associated to the pixel. <br/>At the moment, only one pixel can be set.<br/>
+
+> NOTE
+>
+> Note
+>
+> You can test how your integration works using the Chrome extension _Facebook Pixel Helper_. 
+
+
+### Google Ads Conversions
+
+When creating a preference, you can associate a Google Ads Conversion Tracking tag as follows:
+
+
+[[[
+```php
+<?php
+  # Create a preference object
+  $preference = new MercadoPago\Preference();
+  ...
+  $preference->tracks = array(
+    array(
+        'type' => 'google_ad',
+        'values' => array(
+          'conversion_id' => 'CONVERSION_ID',
+          'conversion_label' => 'CONVERSION_LABEL'
+        )
+    )
+  );
+
+  ...
+  # Save and post the preference
+  $preference->save();
+?>
+```
+```node
+var preference = {
+  ...
+  tracks: [
+        {
+            type: "google_ad",
+            values: {
+              conversion_id: "CONVERSION_ID",
+              conversion_label: "CONVERSION_LABEL"
+            } 
+        }
+      ]
+  ...
+};
+```
+```java
+// Create a preference object
+Preference preference = new Preference();
+
+Track trackGoogle = new Track()
+                .setType("google_ad")
+                .setValues(new TrackValues()
+                        .setConversionId("CONVERSION_ID")
+                        .setConversionLabel("CONVERSION_LABEL")
+                );
+
+
+Preference preference = new Preference()
+        .appendTrack(Google);
+
+// Save and post the preference
+preference.save();
+```
+```csharp
+List<Track> tracks = new List<Track>();
+tracks.Add(
+    new Track
+    {
+        Type = "google_ad",
+        Values = new JObject
+        {
+            { "conversion_id", "CONVERSION_ID" },
+            { "conversion_label", "CONVERSION_LABEL" }
+        }
+    });
+
+MercadoPago.Resources.Preference preference = new MercadoPago.Resources.Preference
+{
+    ...
+    Tracks = tracks
+};
+
+preference.Save();
+```
+```curl
+curl -X POST \
+  'https://api.mercadolibre.com/checkout/preferences?access_token="PROD_ACCESS_TOKEN"' \
+  -H 'Content-Type: application/json' \
+  -H 'cache-control: no-cache' \
+  -d '{
+	"items": [
+        {
+            "id_product":1,
+            "quantity":1,
+            "unit_price": 234.33,
+            "titulo":"Mi producto"
+        }
+    ],
+    "tracks": [
+        {
+            "type": "google_ad",
+            "values": {
+                "conversion_id", "CONVERSION_ID",
+                "conversion_label", "CONVERSION_LABEL"
+            }
+        }
+    ]
+}'
+```
+]]]
+
+
+> WARNING
+>
+> Important
+>
+> Payments that are not approved instantly (pending) will not be associated. <br/>At the moment, only one tag can be set.<br/>
+
 ---
 
 ### Next steps

--- a/guides/payments/web-payment-checkout/latest/configurations.es.md
+++ b/guides/payments/web-payment-checkout/latest/configurations.es.md
@@ -481,6 +481,241 @@ Para activar la opción de pago, ve a tus <a href="https://www.mercadopago.com.a
 
 ------------
 
+## Integraciones
+
+### Píxel de Facebook
+
+Al momento de crear una preferencia, puedes asociarle un identificador correspondiente a un Píxel de Facebook de la siguiente manera:
+
+
+[[[
+```php
+<?php
+  # Crear un objeto preferencia
+  $preference = new MercadoPago\Preference();
+  ...
+  $preference->tracks = array(
+    array(
+      'type' => 'facebook_ad',
+      'values'=> array(
+        'pixel_id' => 'PIXEL_ID'
+      )
+    )
+  );
+
+  ...
+  # Guardar y postear la preferencia
+  $preference->save();
+?>
+```
+```node
+// Configura tu preferencia
+var preference = {
+  ...
+  tracks: [
+        {
+          type: "facebook_ad",
+          values: {
+            "pixel_id": 'PIXEL_ID'
+          }
+        }
+      ]
+  ...
+};
+```
+```java
+// Crea un objeto preferencia
+Preference preference = new Preference();
+
+Track trackFacebook = new Track()
+                .setType("facebook_ad")
+                .setValues(new TrackValues()
+                        .setPixelId("PIXEL_ID")
+                );
+
+Preference preference = new Preference()
+        .appendTrack(trackFacebook);
+
+// Guardar y postear la preferencia
+preference.save();
+```
+```csharp
+List<Track> tracks = new List<Track>();
+tracks.Add(
+    new Track
+    {
+        Type = "facebook_ad",
+        Values = new JObject
+        {
+            { "pixel_id", "PIXEL_ID" }
+        }
+    });
+
+MercadoPago.Resources.Preference preference = new MercadoPago.Resources.Preference
+{
+    ...
+    Tracks = tracks
+};
+
+preference.Save();
+```
+```curl
+curl -X POST \
+  'https://api.mercadolibre.com/checkout/preferences?access_token="PROD_ACCESS_TOKEN"' \
+  -H 'Content-Type: application/json' \
+  -H 'cache-control: no-cache' \
+  -d '{
+	"items": [
+        {
+            "id_product":1,
+            "quantity":1,
+            "unit_price": 234.33,
+            "titulo":"Mi producto"
+        }
+    ],
+    "tracks": [
+        {
+            "type": "facebook_ad",
+            "values": {
+                "pixel_id": "PIXEL_ID"
+            }
+        }
+    ]
+}'
+```
+]]]
+
+Con esta configuración, cuando se *aprueben* pagos a través de Checkout Mercado Pago, verás un evento `Purchase` asociado al píxel especificado.
+
+> WARNING
+>
+> Importante
+>
+> Los pagos que no sean aprobados en el momento (pendientes) no serán asociados al píxel. <br/>Por el momento, sólo se puede configurar un píxel.<br/>
+
+> NOTE
+>
+> Nota
+>
+> Puedes probar el funcionamiento de tu integración utilizando la extensión de Chrome _Facebook Pixel Helper_. 
+
+
+### Conversiones de Google Ads
+
+Al momento de crear una preferencia, puedes asociarle una etiqueta para seguimiento de conversiones de Google Ads de la siguiente manera:
+
+
+[[[
+```php
+<?php
+  # Crear un objeto preferencia
+  $preference = new MercadoPago\Preference();
+  ...
+  $preference->tracks = array(
+    array(
+        'type' => 'google_ad',
+        'values' => array(
+          'conversion_id' => 'CONVERSION_ID',
+          'conversion_label' => 'CONVERSION_LABEL'
+        )
+    )
+  );
+
+  ...
+  # Guardar y postear la preferencia
+  $preference->save();
+?>
+```
+```node
+// Configura tu preferencia
+var preference = {
+  ...
+  tracks: [
+        {
+            type: "google_ad",
+            values: {
+              conversion_id: "CONVERSION_ID",
+              conversion_label: "CONVERSION_LABEL"
+            } 
+        }
+      ]
+  ...
+};
+```
+```java
+// Crea un objeto preferencia
+Preference preference = new Preference();
+
+Track trackGoogle = new Track()
+                .setType("google_ad")
+                .setValues(new TrackValues()
+                        .setConversionId("CONVERSION_ID")
+                        .setConversionLabel("CONVERSION_LABEL")
+                );
+
+
+Preference preference = new Preference()
+        .appendTrack(Google);
+
+// Guardar y postear la preferencia
+preference.save();
+```
+```csharp
+List<Track> tracks = new List<Track>();
+tracks.Add(
+    new Track
+    {
+        Type = "google_ad",
+        Values = new JObject
+        {
+            { "conversion_id", "CONVERSION_ID" },
+            { "conversion_label", "CONVERSION_LABEL" }
+        }
+    });
+
+MercadoPago.Resources.Preference preference = new MercadoPago.Resources.Preference
+{
+    ...
+    Tracks = tracks
+};
+
+preference.Save();
+```
+```curl
+curl -X POST \
+  'https://api.mercadolibre.com/checkout/preferences?access_token="PROD_ACCESS_TOKEN"' \
+  -H 'Content-Type: application/json' \
+  -H 'cache-control: no-cache' \
+  -d '{
+	"items": [
+        {
+            "id_product":1,
+            "quantity":1,
+            "unit_price": 234.33,
+            "titulo":"Mi producto"
+        }
+    ],
+    "tracks": [
+        {
+            "type": "google_ad",
+            "values": {
+                "conversion_id", "CONVERSION_ID",
+                "conversion_label", "CONVERSION_LABEL"
+            }
+        }
+    ]
+}'
+```
+]]]
+
+
+> WARNING
+>
+> Importante
+>
+> Los pagos que no sean aprobados en el momento (pendientes) no serán asociados. <br/>Por el momento, sólo se puede configurar un tag.<br/>
+
+
 ### Próximos pasos
 
 > LEFT_BUTTON_REQUIRED_ES

--- a/guides/payments/web-payment-checkout/latest/configurations.pt.md
+++ b/guides/payments/web-payment-checkout/latest/configurations.pt.md
@@ -467,6 +467,239 @@ Você pode ativar a opção de oferecer pagamento com dois cartões de crédito 
 
 ------------
 
+## Integraciones
+
+### Pixel do Facebook
+
+Ao criar uma preferência, você pode associar um identificador correspondente a um Pixel do Facebook da seguinte maneira:
+
+
+[[[
+```php
+<?php
+  # Cria um objeto preferência
+  $preference = new MercadoPago\Preference();
+  ...
+  $preference->tracks = array(
+    array(
+      'type' => 'facebook_ad',
+      'values'=> array(
+        'pixel_id' => 'PIXEL_ID'
+      )
+    )
+  );
+
+  ...
+  # Salvar e postar a preferência
+  $preference->save();
+?>
+```
+```node
+var preference = {
+  ...
+  tracks: [
+        {
+          type: "facebook_ad",
+          values: {
+            "pixel_id": 'PIXEL_ID'
+          }
+        }
+      ]
+  ...
+};
+```
+```java
+// Cria um objeto preferência
+Preference preference = new Preference();
+
+Track trackFacebook = new Track()
+                .setType("facebook_ad")
+                .setValues(new TrackValues()
+                        .setPixelId("PIXEL_ID")
+                );
+
+Preference preference = new Preference()
+        .appendTrack(trackFacebook);
+
+// Salvar e postar a preferência
+preference.save();
+```
+```csharp
+List<Track> tracks = new List<Track>();
+tracks.Add(
+    new Track
+    {
+        Type = "facebook_ad",
+        Values = new JObject
+        {
+            { "pixel_id", "PIXEL_ID" }
+        }
+    });
+
+MercadoPago.Resources.Preference preference = new MercadoPago.Resources.Preference
+{
+    ...
+    Tracks = tracks
+};
+
+preference.Save();
+```
+```curl
+curl -X POST \
+  'https://api.mercadolibre.com/checkout/preferences?access_token="PROD_ACCESS_TOKEN"' \
+  -H 'Content-Type: application/json' \
+  -H 'cache-control: no-cache' \
+  -d '{
+	"items": [
+        {
+            "id_product":1,
+            "quantity":1,
+            "unit_price": 234.33,
+            "titulo":"Mi producto"
+        }
+    ],
+    "tracks": [
+        {
+            "type": "facebook_ad",
+            "values": {
+                "pixel_id": "PIXEL_ID"
+            }
+        }
+    ]
+}'
+```
+]]]
+
+Com essa configuração, quando os pagamentos são *aprovados* pelo Checkout Mercado Pago, você verá um evento `Purchase` associado ao pixel especificado.
+
+> WARNING
+>
+> Importante
+>
+> Os pagamentos que não são aprovados no momento (pendentes) não serão associados ao pixel. <br/> No momento, apenas um pixel pode ser definido. <br/>
+
+> NOTE
+>
+> Nota
+>
+> Você pode testar como sua integração funciona usando a extensão do Chrome _Facebook Pixel Helper_. 
+
+
+### Conversões do Google Ads
+
+Ao criar uma preferência, você pode associar uma tag ao Google Ads Conversion Tracking da seguinte maneira:
+
+
+[[[
+```php
+<?php
+  # Cria um objeto preferência
+  $preference = new MercadoPago\Preference();
+  ...
+  $preference->tracks = array(
+    array(
+        'type' => 'google_ad',
+        'values' => array(
+          'conversion_id' => 'CONVERSION_ID',
+          'conversion_label' => 'CONVERSION_LABEL'
+        )
+    )
+  );
+
+  ...
+  # Salvar e postar a preferência
+  $preference->save();
+?>
+```
+```node
+var preference = {
+  ...
+  tracks: [
+        {
+            type: "google_ad",
+            values: {
+              conversion_id: "CONVERSION_ID",
+              conversion_label: "CONVERSION_LABEL"
+            } 
+        }
+      ]
+  ...
+};
+```
+```java
+// Cria um objeto preferência
+Preference preference = new Preference();
+
+Track trackGoogle = new Track()
+                .setType("google_ad")
+                .setValues(new TrackValues()
+                        .setConversionId("CONVERSION_ID")
+                        .setConversionLabel("CONVERSION_LABEL")
+                );
+
+
+Preference preference = new Preference()
+        .appendTrack(Google);
+
+// Salvar e postar a preferência
+preference.save();
+```
+```csharp
+List<Track> tracks = new List<Track>();
+tracks.Add(
+    new Track
+    {
+        Type = "google_ad",
+        Values = new JObject
+        {
+            { "conversion_id", "CONVERSION_ID" },
+            { "conversion_label", "CONVERSION_LABEL" }
+        }
+    });
+
+MercadoPago.Resources.Preference preference = new MercadoPago.Resources.Preference
+{
+    ...
+    Tracks = tracks
+};
+
+preference.Save();
+```
+```curl
+curl -X POST \
+  'https://api.mercadolibre.com/checkout/preferences?access_token="PROD_ACCESS_TOKEN"' \
+  -H 'Content-Type: application/json' \
+  -H 'cache-control: no-cache' \
+  -d '{
+	"items": [
+        {
+            "id_product":1,
+            "quantity":1,
+            "unit_price": 234.33,
+            "titulo":"Mi producto"
+        }
+    ],
+    "tracks": [
+        {
+            "type": "google_ad",
+            "values": {
+                "conversion_id", "CONVERSION_ID",
+                "conversion_label", "CONVERSION_LABEL"
+            }
+        }
+    ]
+}'
+```
+]]]
+
+
+> WARNING
+>
+> Importante
+>
+> Os pagamentos que não forem aprovados no momento (pendentes) não serão associados. <br/> No momento, apenas uma tag pode ser definida. <br/>
+
+
 ---
 
 ### Próximos passos

--- a/reference/preferences/endpoints/_checkout_preferences/post.yaml
+++ b/reference/preferences/endpoints/_checkout_preferences/post.yaml
@@ -26,6 +26,7 @@ use:
 - marketplace
 - marketplace_fee
 - differential_pricing
+- tracks
 errors:
 - 400 bad_request:
   - invalid_collector_id:

--- a/reference/preferences/resource.yaml
+++ b/reference/preferences/resource.yaml
@@ -492,4 +492,32 @@ properties:
           en: 'Tax amount. A maximum of two decimal places is supported. For tax exempt items, zero must be reported.'
           es: 'Monto del impuesto. Se admite un máximo de dos decimales. Para ítems exentos de impuestos se debe informar cero.'
           pt: 'Valor do imposto. É suportado no máximo duas casas decimais. Para itens isentos de imposto, zero deve ser relatado.'
+- tracks:
+    type: Array (Object)
+    description:
+      en: Tracks to be executed during the users's interaction in the Checkout flow.
+      es: Tracks que se ejecutarán durante la interacción de los usuarios en el flujo de Pago.
+      pt: Tracks que serão executados durante a interação do usuário no fluxo de Pagamento.
+    properties:
+    - type:
+        type: String
+        description:
+          en: Track type. Specifies which tool the values belong to.
+          es: Tipo del track. Especifica a qué herramienta pertenecen los valores.
+          pt: Tipo da track. Especifique a herramienta pertenecen los valores.
+        enum:
+        - google_ad:
+            en: Allows configurations for GTM's Google Ads Conversion Tracking tag. Necessary values: conversion_id and conversion_label.
+            es: Permite configurar una etiqueta de seguimiento de conversiones de Google Ads de GTM. Valores necesarios: conversion_id y conversion_label.
+            pt: Configure uma tag de acompanhamento de conversões do Google Ads no GTM. Valores necessários: conversion_id e conversion_label.
+        - facebook_ad:
+            en: Allows configurations for Facebook Pixel. Necessary values: pixel_id.
+            es: Permite configurar un Pixel de Facebook. Valores necesarios: pixel_id.
+            pt: Permite configurar um pixel do Facebook. Valores necessários: pixel_id.
+    - values:
+        type: Map
+        description:
+          en: Configuration values according the track type.
+          es: Valores de configuración de acuerdo al tipo de track.
+          pt: Valores de configuração de acordo com o tipo de track.
 


### PR DESCRIPTION
## Description
Se agrega documentación para el nuevo feature del Checkout Off Web "Merchant Tracks". 
Permite configurar Píxeles de Facebook o Tags de Seguimiento de Conversión de Google Ads, a los cuales se notifica cuando el usuario genera un pago aprobado.

@Juanii95 no actualicé el changelog porque esto se sube ya iniciado el próximo año. Dejo el contenido que debería ir acá:

## 3 de Enero de 2019
Para facilitar el seguimiento de los pagos aprobados en el Checkout Mercado Pago, ahora puedes configurar un Píxel de Facebook y/o un tag de Seguimiento de Conversiones de Google Ads de GTM, a los cuales se asociarán los pagos realizados por tus usuarios.

Para más detalle, ver [cómo integrar Facebook Pixel y Conversiones de Google Ads](https://www.mercadopago.com.ar/developers/es/guides/payments/web-payment-checkout/configurations/).

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [x] This request modifies code snippets. 
- [x] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [x] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [x] Requires translations.
