### PR TITLE
composer require mercadopago/dx-php:dev-master

### DIFF
--- a/plugins_sdks/sdks/official/php.es.md
+++ b/plugins_sdks/sdks/official/php.es.md
@@ -11,7 +11,7 @@ Nuesto SDK es compatible con las versiones de PHP 5.6 o superior.
 #### Usando Composer
 
 1. Descargar [Composer](https://getcomposer.org/download/) (Si este no se encuentra instalado previamente)
-2. Dirigirse al directorio del proyecto y ejecutar `composer require "mercadopago/dx-php:dev-master"` en la linea de comandos.
+2. Dirigirse al directorio del proyecto y ejecutar `composer require "mercadopago/dx-php"` en la linea de comandos.
 3. Ahora el directorio deberia verse asi.
 
 ![Structure of the Mercado Pago SDK for PHP](https://user-images.githubusercontent.com/864790/34394635-44f7745a-eb39-11e7-981d-77cf759cf05f.png)


### PR DESCRIPTION
**Error al querer requerir el sdk de la forma  composer require mercadopago/dx-php:dev-master**
 
>  [InvalidArgumentException]
>  Could not find package mercadopago/dx-php in a version matching dev-master

**Para que me descargue correctamente el sdk utilice el siguiente comando**
> composer require mercadopago/dx-php
