### PR TITLE
Quitar info de liberación flexible para pagos de Advanced Payments

### DIFF
--- a/guides/marketplace/advanced-payments/introduction.en.md
+++ b/guides/marketplace/advanced-payments/introduction.en.md
@@ -35,7 +35,8 @@ The Split Payment functionality provides a solution for Marketplace payments whe
 * The commission charged by the Marketplace applies to each payment.
 * This allows having different commissions for different Sellers and in turn different commissions according to the type or category of the product offered by a Seller.
 
-#### Release of your Sellers money
+#### Sellers Money Release
+
 
 * The money of your Sellers will be released in 30 days by default.
 

--- a/guides/marketplace/advanced-payments/introduction.en.md
+++ b/guides/marketplace/advanced-payments/introduction.en.md
@@ -35,8 +35,8 @@ The Split Payment functionality provides a solution for Marketplace payments whe
 * The commission charged by the Marketplace applies to each payment.
 * This allows having different commissions for different Sellers and in turn different commissions according to the type or category of the product offered by a Seller.
 
-#### Release of money from your Sellers
+#### Release of your Sellers money
 
-* The release of money from your Sellers will be 30 days by default.
+* The money of your Sellers will be released in 30 days by default.
 
 [Start using split payments in Marketplace](https://www.mercadopago.com.br/developers/en/guides/marketplace/advanced-payments/receive-split-payments/).

--- a/guides/marketplace/advanced-payments/introduction.en.md
+++ b/guides/marketplace/advanced-payments/introduction.en.md
@@ -8,13 +8,6 @@ sites_supported:
 ---
 
 # Advanced Payments
-
-> WARNING
->
-> Important
->
-> Before using this API, it is important that you contact your Mercado Pago account executive.
-
 ## Introduction
 
 Advanced Payments is an API that allows processing payments with additional functionalities to the regular [API of Payments](https://www.mercadopago.com.br/developers/en/guides/payments/api/introduction/). It currently allows to make Marketplace split payments.
@@ -42,7 +35,8 @@ The Split Payment functionality provides a solution for Marketplace payments whe
 * The commission charged by the Marketplace applies to each payment.
 * This allows having different commissions for different Sellers and in turn different commissions according to the type or category of the product offered by a Seller.
 
-#### Flexible release of Sellers money
+#### Release of money from your Sellers
 
-* At the time of integration, a range of days is set in which the money of the Sellers can be released.
-* The release is set in each payment and can be modified later.
+* The release of money from your Sellers will be 30 days by default.
+
+[Start using split payments in Marketplace](https://www.mercadopago.com.br/developers/en/guides/marketplace/advanced-payments/receive-split-payments/).

--- a/guides/marketplace/advanced-payments/introduction.es.md
+++ b/guides/marketplace/advanced-payments/introduction.es.md
@@ -37,6 +37,6 @@ La **funcionalidad de Split de Pagos** brinda una solución para los pagos de Ma
 
 #### Liberación de dinero de tus Vendedores 
 
-* La liberación del dinero de tus Vendedores será de 30 días por defecto.
+* El dinero de tus Vendedores se liberará en 30 días por defecto.
 
 [Comenzar a usar split de pagos en Marketplace](https://www.mercadopago.com.ar/developers/es/guides/marketplace/advanced-payments/receive-split-payments/).

--- a/guides/marketplace/advanced-payments/introduction.es.md
+++ b/guides/marketplace/advanced-payments/introduction.es.md
@@ -37,6 +37,6 @@ La **funcionalidad de Split de Pagos** brinda una solución para los pagos de Ma
 
 #### Liberación de dinero de tus vendedores 
 
-* El dinero de tus Vendedores se liberará en 30 días por defecto.
+* El dinero de tus vendedores se liberará en 30 días por defecto.
 
 [Comenzar a usar split de pagos en Marketplace](https://www.mercadopago.com.ar/developers/es/guides/marketplace/advanced-payments/receive-split-payments/).

--- a/guides/marketplace/advanced-payments/introduction.es.md
+++ b/guides/marketplace/advanced-payments/introduction.es.md
@@ -8,13 +8,6 @@ sites_supported:
 ---
 
 # Advanced Payments
-
-> WARNING
->
-> Importante
->
-> Antes de utilizar esta API, es importante contactar a tu ejecutivo de cuenta de Mercado Pago.
-
 ## Introducción
 
 Advanced Payments es una API que permite procesar pagos con funcionalidades adicionales a la [API de Payments](https://www.mercadopago.com.ar/developers/es/guides/payments/api/introduction/) regular.
@@ -42,9 +35,8 @@ La **funcionalidad de Split de Pagos** brinda una solución para los pagos de Ma
 * La comisión que cobra el Marketplace se aplica pago a pago.
 * Esto permite tener distintas comisiones para distintos vendedores y a su vez distintas comisiones según el tipo o categoría del producto que ofrezca un vendedor.
 
-#### Liberación flexible de dinero de Vendedores
+#### Liberación de dinero de tus Vendedores 
 
-* Al momento de la integración se configura un rango de días en el cual se podrá liberar el dinero de los vendedores.
-* La liberación se setea en cada pago y puede modificarse posteriormente.
+* La liberación del dinero de tus Vendedores será de 30 días por defecto.
 
 [Comenzar a usar split de pagos en Marketplace](https://www.mercadopago.com.ar/developers/es/guides/marketplace/advanced-payments/receive-split-payments/).

--- a/guides/marketplace/advanced-payments/introduction.es.md
+++ b/guides/marketplace/advanced-payments/introduction.es.md
@@ -35,7 +35,7 @@ La **funcionalidad de Split de Pagos** brinda una solución para los pagos de Ma
 * La comisión que cobra el Marketplace se aplica pago a pago.
 * Esto permite tener distintas comisiones para distintos vendedores y a su vez distintas comisiones según el tipo o categoría del producto que ofrezca un vendedor.
 
-#### Liberación de dinero de tus Vendedores 
+#### Liberación de dinero de tus vendedores 
 
 * El dinero de tus Vendedores se liberará en 30 días por defecto.
 

--- a/guides/marketplace/advanced-payments/introduction.pt.md
+++ b/guides/marketplace/advanced-payments/introduction.pt.md
@@ -35,8 +35,8 @@ A funcionalidade de Split de Pagamentos fornece uma solução para os pagamentos
 * A comissão que o Marketplace cobra se aplica a cada pagamento.
 * Isso permite ter diferentes comissões para diferentes vendedores e em sua vez diferentes comissões segundo o tipo ou categoria do produto que um vendedor ofereça.
 
-#### Liberação de dinheiro de seus Vendedores
+#### Liberação do dinheiro dos Vendedores
 
-* A liberação de dinheiro de seus Vendedores será de 30 dias por padrão.
+* O dinheiro dos seus Vendedores será liberado em 30 dias por padrão.
 
 [Comece a usar pagamentos divididos no Marketplace](https://www.mercadopago.com.br/developers/pt/guides/marketplace/advanced-payments/receive-split-payments/).

--- a/guides/marketplace/advanced-payments/introduction.pt.md
+++ b/guides/marketplace/advanced-payments/introduction.pt.md
@@ -35,7 +35,8 @@ A funcionalidade de Split de Pagamentos fornece uma solução para os pagamentos
 * A comissão que o Marketplace cobra se aplica a cada pagamento.
 * Isso permite ter diferentes comissões para diferentes vendedores e em sua vez diferentes comissões segundo o tipo ou categoria do produto que um vendedor ofereça.
 
-#### Liberação do dinheiro dos Vendedores
+#### Liberação do dinheiro dos vendedores
+
 
 * O dinheiro dos seus Vendedores será liberado em 30 dias por padrão.
 

--- a/guides/marketplace/advanced-payments/introduction.pt.md
+++ b/guides/marketplace/advanced-payments/introduction.pt.md
@@ -8,13 +8,6 @@ sites_supported:
 ---
 
 # Advanced Payments
-
-> WARNING
->
-> Importante
->
-> Antes de utilizar essa API, é importante entrar em contato com seu executivo de conta do Mercado Pago.
-
 ## Introdução
 
 Advanced Payments é uma API que permite processar pagamentos com funcionalidades adicionais à [API de Payments](https://www.mercadopago.com.br/developers/pt/guides/payments/api/introduction/) regular.
@@ -42,7 +35,8 @@ A funcionalidade de Split de Pagamentos fornece uma solução para os pagamentos
 * A comissão que o Marketplace cobra se aplica a cada pagamento.
 * Isso permite ter diferentes comissões para diferentes vendedores e em sua vez diferentes comissões segundo o tipo ou categoria do produto que um vendedor ofereça.
 
-#### Liberação flexível de dinheiro de Vendedores
+#### Liberação de dinheiro de seus Vendedores
 
-* No momento da integração configura-se um intervalo de dias no qual o dinheiro dos vendedores pode ser liberado.
-* A liberação é atribuída em cada pagamento e pode ser modificada posteriormente.
+* A liberação de dinheiro de seus Vendedores será de 30 dias por padrão.
+
+[Comece a usar pagamentos divididos no Marketplace](https://www.mercadopago.com.br/developers/pt/guides/marketplace/advanced-payments/receive-split-payments/).

--- a/guides/marketplace/advanced-payments/introduction.pt.md
+++ b/guides/marketplace/advanced-payments/introduction.pt.md
@@ -38,6 +38,7 @@ A funcionalidade de Split de Pagamentos fornece uma solução para os pagamentos
 #### Liberação do dinheiro dos vendedores
 
 
-* O dinheiro dos seus Vendedores será liberado em 30 dias por padrão.
+* O dinheiro dos seus vendedores será liberado em 30 dias por padrão.
+
 
 [Comece a usar pagamentos divididos no Marketplace](https://www.mercadopago.com.br/developers/pt/guides/marketplace/advanced-payments/receive-split-payments/).


### PR DESCRIPTION
## Description
Sacamos la información de "liberación flexible" ya que los usuarios comunes no tendrán acceso a este feature, solo los Integradores cartera asesorada podrán contar con ella.

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [x] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
