### PR TITLE
Fix transactionAmount examples on Java snippets

### DIFF
--- a/guides/marketplace/api/create-marketplace.en.md
+++ b/guides/marketplace/api/create-marketplace.en.md
@@ -157,7 +157,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setToken('ff8080814c11e237014c1ff593b57b4d')
       .setDescription('Title of what you are paying for')
       .setInstallments(1)
@@ -216,14 +216,14 @@ The seller will receive the difference between the total amount and the fees, bo
 
 You need to send your `notification_url`, where you will receive a notification of all new payments and status updates generated.
 
-In order to receive notifications when your clients authorize your application, you can [configure the url](https://www.mercadopago.com/mla/account/webhooks) in your account. 
+In order to receive notifications when your clients authorize your application, you can [configure the url](https://www.mercadopago.com/mla/account/webhooks) in your account.
 
 For more information, go to the [notifications section](https://www.mercadopago.com.ar/developers/en/guides/notifications/webhooks).
 
 ### Refunds and cancellations
 
 The cancellations and refunds can be made either by the marketplace or by the seller, via API or through the Mercado Pago account.
-In case the Marketplace is the one that does the refund/cancellation, you´ll have to use the credentials obtained for that user in the Oauth process. 
+In case the Marketplace is the one that does the refund/cancellation, you´ll have to use the credentials obtained for that user in the Oauth process.
 
 Cancellations can only be made using the cancellation API.
 
@@ -232,4 +232,4 @@ For more information, go to [refunds and cancellations.](https://www.mercadopago
 ### Test your integration
 
 You can try your Marketplace using your Sandbox credentials to associate the sellers and to make the payments/refunds/cancellations.  
-[Test your integration](https://www.mercadopago.com.ar/developers/en/guides/payments/api/testing/) 
+[Test your integration](https://www.mercadopago.com.ar/developers/en/guides/payments/api/testing/)

--- a/guides/marketplace/api/create-marketplace.es.md
+++ b/guides/marketplace/api/create-marketplace.es.md
@@ -90,8 +90,8 @@ En la respuesta, además del `access_token` y `public_key` del vendedor que se h
 > Nota
 >
 > Las credenciales tienen un **tiempo de validez de 6 meses**.
-> Si no se renuevan las credenciales de los vendedores antes de los 6 meses, **las mismas perderán vigencia y se deberá volver a autorizar al vendedor**. 
-> Recomendación: Renovar las credenciales a los 5 meses de obtenerlas. 
+> Si no se renuevan las credenciales de los vendedores antes de los 6 meses, **las mismas perderán vigencia y se deberá volver a autorizar al vendedor**.
+> Recomendación: Renovar las credenciales a los 5 meses de obtenerlas.
 
 ### Renueva las credenciales de tus vendedores
 
@@ -178,7 +178,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setToken('ff8080814c11e237014c1ff593b57b4d')
       .setDescription('Title of what you are paying for')
       .setInstallments(1)
@@ -245,7 +245,7 @@ En el artículo de [notificaciones](https://www.mercadopago.com.ar/developers/es
 ### Devoluciones y cancelaciones
 
 Las devoluciones y cancelaciones podrán ser realizadas tanto por el _marketplace_ como por el vendedor, vía API o desde la cuenta de Mercado Pago.
-En caso de que las cancelaciones las haga el Marketplace, se deben utilizar las obtenidas para el vendedor. 
+En caso de que las cancelaciones las haga el Marketplace, se deben utilizar las obtenidas para el vendedor.
 
 En el caso de las cancelaciones, solo podrán ser realizadas  utilizando la API de cancelaciones.
 
@@ -253,6 +253,6 @@ Puedes encontrar más información en el artículo sobre [devoluciones y cancela
 
 ### Probá tu Marketplace
 
-Puedes probar tu Marketplace utilizando las credenciales de Sandbox de tu cuenta tanto para asociar a los vendedores como para realizar los cobros/cancelaciones y demás. 
-Se podrá utilizar las tarjetas de test proporcionadas por Mercado Pago, y los distintos prefijos para manejar los mensajes de respuesta. 
-[Probá tu integración](https://www.mercadopago.com.ar/developers/es/guides/payments/api/testing/) 
+Puedes probar tu Marketplace utilizando las credenciales de Sandbox de tu cuenta tanto para asociar a los vendedores como para realizar los cobros/cancelaciones y demás.
+Se podrá utilizar las tarjetas de test proporcionadas por Mercado Pago, y los distintos prefijos para manejar los mensajes de respuesta.
+[Probá tu integración](https://www.mercadopago.com.ar/developers/es/guides/payments/api/testing/)

--- a/guides/marketplace/api/create-marketplace.pt.md
+++ b/guides/marketplace/api/create-marketplace.pt.md
@@ -89,8 +89,8 @@ Na resposta, além do `access_token` e da `public_key`do vendedor que foi vincul
 > Nota
 >
 > As credenciais têm um **prazo de validade de 6 meses**.
-> Se não se renovarem as credenciais dos vendedores antes dos 6 meses, **as mesmas perderão vigência e se deverá autorizar o vendedor novamente**. 
-> Recomendação: Renovar as credenciais a cada 5 meses. 
+> Se não se renovarem as credenciais dos vendedores antes dos 6 meses, **as mesmas perderão vigência e se deverá autorizar o vendedor novamente**.
+> Recomendação: Renovar as credenciais a cada 5 meses.
 
 
 ### Renove as credenciais de seus vendedores
@@ -177,7 +177,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setToken('ff8080814c11e237014c1ff593b57b4d')
       .setDescription('Title of what you are paying for')
       .setInstallments(1)
@@ -264,4 +264,4 @@ Para mais informações, consulte a seção de [devoluções e cancelamentos](ht
 
 Você pode usar os cartões de teste fornecidos pelo Mercado Pago e os diferentes prefixos para manipular as mensagens de resposta.
 
-[Teste sua integração](https://www.mercadopago.com.br/developers/pt/guides/payments/api/testing) 
+[Teste sua integração](https://www.mercadopago.com.br/developers/pt/guides/payments/api/testing)

--- a/guides/payments/api/advanced-integration.es.md
+++ b/guides/payments/api/advanced-integration.es.md
@@ -114,7 +114,7 @@ curl -X POST \
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Respuesta
 
-```json 
+```json
 {
     "id": "123456789-jxOV430go9fx2e",
     "email": "test@test.com",
@@ -460,7 +460,7 @@ payer.type = "customer";
 payer.id = "123456789-jxOV430go9fx2e";
 
 Payment payment = new Payment();
-payment.setTransactionAmount(100);
+payment.setTransactionAmount(100f);
 payment.setInstallments(1);
 payment.setToken('ff8080814c11e237014c1ff593b57b4d');
 payment.setPayer(payer);

--- a/guides/payments/api/advanced-integration.pt.md
+++ b/guides/payments/api/advanced-integration.pt.md
@@ -7,7 +7,7 @@ Use nossas APIs para guardar a referência dos cartões dos seus clientes e pode
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Crie um cliente e um cartão
 
 Para criar um cliente e associá-lo ao seu cartão, é preciso enviar o campo do e-mail e o token gerado.
-Cada cliente será guardado com o valor `customer` e cada cartão com o valor `card`. 
+Cada cliente será guardado com o valor `customer` e cada cartão com o valor `card`.
 
 [[[
 
@@ -114,7 +114,7 @@ curl -X POST \
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Resposta
 
-```json 
+```json
 {
     "id": "123456789-jxOV430go9fx2e",
     "email": "test@test.com",
@@ -137,7 +137,7 @@ curl -X POST \
 > NOTE
 >
 > Nota
-> 
+>
 > Te recomendamos armazenas os dados do cartão assim que realizar um pagamento de forma exitosa para guardar os dados corretos.
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Adicione novos cartões a um cliente
@@ -340,7 +340,7 @@ Primeiro, obtenha a lista de cartões guardados para que seu cliente possa escol
 ```csharp
 
 customer = Customer.FindById("customer.Id");
-List<Card> cards = customer.Cards; 
+List<Card> cards = customer.Cards;
 
 ```
 ```curl
@@ -351,9 +351,9 @@ curl -X GET \
 
 ]]]
 
-Resposta dos dados de um cartão guardado: 
+Resposta dos dados de um cartão guardado:
 
-```json 
+```json
 [{
     "id": "1490022319978",
     "expiration_month": 12,
@@ -461,7 +461,7 @@ payer.type = "customer";
 payer.id = "123456789-jxOV430go9fx2e";
 
 Payment payment = new Payment();
-payment.setTransactionAmount(100);
+payment.setTransactionAmount(100f);
 payment.setInstallments(1);
 payment.setToken('ff8080814c11e237014c1ff593b57b4d');
 payment.setPayer(payer);

--- a/guides/payments/api/other-features.es.md
+++ b/guides/payments/api/other-features.es.md
@@ -41,7 +41,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setToken('ff8080814c11e237014c1ff593b57b4d')
       .setDescription('Title of what you are paying for')
       .setInstallments(1)
@@ -70,9 +70,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -196,9 +196,9 @@ La respuesta va a devolver que el pago se encuentra aprobado y acreditado.
 ```
 
 > NOTE
-> 
+>
 > Nota
-> 
+>
 > Si no agregas un monto, se capturará el total reservado.
 
 ## Captura un pago por un monto menor al reservado

--- a/guides/payments/api/other-features.pt.md
+++ b/guides/payments/api/other-features.pt.md
@@ -40,7 +40,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setToken('ff8080814c11e237014c1ff593b57b4d')
       .setDescription('Title of what you are paying for')
       .setInstallments(1)
@@ -69,9 +69,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -125,7 +125,7 @@ A resposta indica que o pagamento se encontra autorizado e pendente de captura.
 }
 ```
 
-Também pode resultar rejeitado ou ficar pendente. Tenha em conta que os valores autorizados não poderão ser utilizados pelo seu cliente até que não sejam capturados. Recomendamos realizar a captura o quanto antes. 
+Também pode resultar rejeitado ou ficar pendente. Tenha em conta que os valores autorizados não poderão ser utilizados pelo seu cliente até que não sejam capturados. Recomendamos realizar a captura o quanto antes.
 
 
 > WARNING
@@ -196,9 +196,9 @@ A resposta devolverá que o pagamento se encontra aprovado e creditado.
 ```
 
 > NOTE
-> 
+>
 > Nota
-> 
+>
 > Se não adicionar o valor, será capturado o total reservado.
 
 ## Capturar um pagamento por um valor inferior ao reservado

--- a/guides/payments/api/other-payment-ways.es.md
+++ b/guides/payments/api/other-payment-ways.es.md
@@ -55,7 +55,7 @@ payment_methods = MercadoPago::SDK.get("/v1/payment_methods")
 using MercadoPago;
 MercadoPago.SDK.SetAccessToken = "ENV_ACCESS_TOKEN";
 
-payment_methods = MercadoPago.SDK.get("/v1/payment_methods"); 
+payment_methods = MercadoPago.SDK.get("/v1/payment_methods");
 
 ```
 ```curl
@@ -139,9 +139,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -151,7 +151,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("rapipago")
       .setPayer(new Payer("test_user_19653727@testuser.com"));
@@ -475,9 +475,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -487,7 +487,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("oxxo")
       .setPayer(new Payer("test_user_82045343@testuser.com"));
@@ -660,7 +660,7 @@ payment_methods = MercadoPago::SDK.get("/v1/payment_methods")
 using MercadoPago;
 MercadoPago.SDK.SetAccessToken = "ENV_ACCESS_TOKEN";
 
-payment_methods = MercadoPago.SDK.get("/v1/payment_methods"); 
+payment_methods = MercadoPago.SDK.get("/v1/payment_methods");
 
 ```
 ```curl
@@ -759,9 +759,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -771,7 +771,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("abitab")
       .setPayer(new Payer("test_user_84162205@testuser.com"));
@@ -929,7 +929,7 @@ payment_methods = MercadoPago::SDK.get("/v1/payment_methods")
 using MercadoPago;
 MercadoPago.SDK.SetAccessToken = "ENV_ACCESS_TOKEN";
 
-payment_methods = MercadoPago.SDK.get("/v1/payment_methods"); 
+payment_methods = MercadoPago.SDK.get("/v1/payment_methods");
 
 ```
 ```curl
@@ -1063,9 +1063,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -1075,7 +1075,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(5000)
+payment.setTransactionAmount(5000f)
       .setDescription('Título del producto')
       .setPaymentMethodId("efecty")
       .setPayer(new Payer("test_user_19549678@testuser.com"));
@@ -1332,9 +1332,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -1344,7 +1344,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("servipag")
       .setPayer(new Payer("test_user_15748052@testuser.com"));
@@ -1582,9 +1582,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -1594,7 +1594,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("pagoefectivo_atm")
       .setPayer(new Payer("test_user_42972582@testuser.com"));
@@ -1824,7 +1824,7 @@ Para recibir pagos con boleto o pagos en lotérica solo tienes que enviar el det
      "email" => "test@test.com",
      "first_name" => "Test",
      "last_name" => "User",
-     "identification" => array( 
+     "identification" => array(
          "type" => "CPF",
          "number" => "19119119100"
       ),
@@ -1855,7 +1855,7 @@ var payment_data = {
     email: 'test@test.com',
     first_name: 'Test',
     last_name: 'User',
-    identification: { 
+    identification: {
         type: 'CPF',
         number: '19119119100'
     },
@@ -1871,9 +1871,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -1900,7 +1900,7 @@ payment.setTransactionAmount(100f)
                .setStreetNumber(3003)
                .setNeighborhood("Bonfim")
                .setCity("Osasco")
-               .setFederalUnit("SP")) 
+               .setFederalUnit("SP"))
 );
 
 payment.save();
@@ -2067,4 +2067,3 @@ Revisa los [tiempos de acreditación por medio de pago](https://www.mercadopago.
 > Optimiza tu integración y mejora la gestión de tus ventas.
 >
 > [Integración avanzada](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/payments/api/advanced-integration)
-

--- a/guides/payments/api/other-payment-ways.pt.md
+++ b/guides/payments/api/other-payment-ways.pt.md
@@ -55,7 +55,7 @@ payment_methods = MercadoPago::SDK.get("/v1/payment_methods")
 using MercadoPago;
 MercadoPago.SDK.SetAccessToken = "ENV_ACCESS_TOKEN";
 
-payment_methods = MercadoPago.SDK.get("/v1/payment_methods"); 
+payment_methods = MercadoPago.SDK.get("/v1/payment_methods");
 
 ```
 ```curl
@@ -139,9 +139,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -151,7 +151,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("rapipago")
       .setPayer(new Payer("test_user_19653727@testuser.com"));
@@ -475,9 +475,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -487,7 +487,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("oxxo")
       .setPayer(new Payer("test_user_82045343@testuser.com"));
@@ -660,7 +660,7 @@ payment_methods = MercadoPago::SDK.get("/v1/payment_methods")
 using MercadoPago;
 MercadoPago.SDK.SetAccessToken = "ENV_ACCESS_TOKEN";
 
-payment_methods = MercadoPago.SDK.get("/v1/payment_methods"); 
+payment_methods = MercadoPago.SDK.get("/v1/payment_methods");
 
 ```
 ```curl
@@ -759,9 +759,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -771,7 +771,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("abitab")
       .setPayer(new Payer("test_user_84162205@testuser.com"));
@@ -929,7 +929,7 @@ payment_methods = MercadoPago::SDK.get("/v1/payment_methods")
 using MercadoPago;
 MercadoPago.SDK.SetAccessToken = "ENV_ACCESS_TOKEN";
 
-payment_methods = MercadoPago.SDK.get("/v1/payment_methods"); 
+payment_methods = MercadoPago.SDK.get("/v1/payment_methods");
 
 ```
 ```curl
@@ -1063,9 +1063,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -1075,7 +1075,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(5000)
+payment.setTransactionAmount(5000f)
       .setDescription('Título del producto')
       .setPaymentMethodId("efecty")
       .setPayer(new Payer("test_user_19549678@testuser.com"));
@@ -1332,9 +1332,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -1344,7 +1344,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("servipag")
       .setPayer(new Payer("test_user_15748052@testuser.com"));
@@ -1582,9 +1582,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -1594,7 +1594,7 @@ MercadoPago.SDK.configure("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
 
-payment.setTransactionAmount(100)
+payment.setTransactionAmount(100f)
       .setDescription('Título del producto')
       .setPaymentMethodId("pagoefectivo_atm")
       .setPayer(new Payer("test_user_42972582@testuser.com"));
@@ -1757,7 +1757,7 @@ payment_methods = MercadoPago::SDK.get("/v1/payment_methods")
 using MercadoPago;
 MercadoPago.SDK.SetAccessToken = "ENV_ACCESS_TOKEN";
 
-payment_methods = MercadoPago.SDK.get("/v1/payment_methods"); 
+payment_methods = MercadoPago.SDK.get("/v1/payment_methods");
 
 ```
 ```curl
@@ -1824,7 +1824,7 @@ Para receber pagamentos em boleto ou pagamento em lotérica envie os detalhes de
      "email" => "test@test.com",
      "first_name" => "Test",
      "last_name" => "User",
-     "identification" => array( 
+     "identification" => array(
          "type" => "CPF",
          "number" => "19119119100"
       ),
@@ -1855,7 +1855,7 @@ var payment_data = {
     email: 'test@test.com',
     first_name: 'Test',
     last_name: 'User',
-    identification: { 
+    identification: {
         type: 'CPF',
         number: '19119119100'
     },
@@ -1871,9 +1871,9 @@ var payment_data = {
 };
 
 mercadopago.payment.create(payment_data).then(function (data) {
-  
+
 }).catch(function (error) {
-  
+
 });
 
 ```
@@ -1900,7 +1900,7 @@ payment.setTransactionAmount(100f)
                .setStreetNumber(3003)
                .setNeighborhood("Bonfim")
                .setCity("Osasco")
-               .setFederalUnit("SP")) 
+               .setFederalUnit("SP"))
 );
 
 payment.save();
@@ -2067,4 +2067,3 @@ Revise os [tempos de aprovação por meio de pagamento](https://www.mercadopago.
 > Otimize sua integração e melhore a gestão das suas vendas.
 >
 > [Integração avançada](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/payments/api/advanced-integration)
-

--- a/guides/payments/api/receiving-payment-by-card.es.md
+++ b/guides/payments/api/receiving-payment-by-card.es.md
@@ -199,7 +199,7 @@ function getInstallments(){
 
 Antes de enviar el pago, debes crear el token que contendrá de manera segura toda la información de la tarjeta. Lo debes generar de la siguiente manera:
 
-```javascript 
+```javascript
 doSubmit = false;
 document.querySelector('#pay').addEventListener('submit', doPay);
 
@@ -272,7 +272,7 @@ Ten en cuenta que para que este paso funcione es necesario que configures tu [cl
     require_once 'vendor/autoload.php';
 
     MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
-    
+
     $payment = new MercadoPago\Payment();
     $payment->transaction_amount = [FAKER][NUMBER][BETWEEN][100, 200];
     $payment->token = "ff8080814c11e237014c1ff593b57b4d";
@@ -284,10 +284,10 @@ Ten en cuenta que para que este paso funcione es necesario que configures tu [cl
     );
 
     $payment->save();
-    
+
 
     echo $payment->status;
-    
+
 ?>
 ```
 ```node
@@ -323,7 +323,7 @@ Puedes encontrar el estado del pago en el valor _status_.
 MercadoPago.SDK.setAccessToken("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
-payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200])
+payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200]f)
        .setToken("ff8080814c11e237014c1ff593b57b4d")
        .setDescription("[FAKER][COMMERCE][PRODUCT_NAME]")
        .setInstallments(1)

--- a/guides/payments/api/receiving-payment-by-card.pt.md
+++ b/guides/payments/api/receiving-payment-by-card.pt.md
@@ -30,7 +30,7 @@ Para criar um pagamento é necessário fazer a captura dos dados do cartão atra
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1. Inclua a biblioteca MercadoPago.js
 
 **Use nossa biblioteca oficial para acessar a API de Mercado Pago** no seu frontend e coletar os dados de forma segura.
- 
+
 ```html
 <script src="https://secure.mlstatic.com/sdk/javascript/v1/mercadopago.js"></script>
 ```
@@ -63,7 +63,7 @@ No seguinte exemplo se assume que os dados `transaction_amount` e `description` 
         <p>
             <label for="cardholderName">Nome e sobrenome</label>
             <input type="text" id="cardholderName" data-checkout="cardholderName" />
-        </p> 
+        </p>
         <p>
             <label for="cardExpirationMonth">Mês de vencimento</label>
             <input type="text" id="cardExpirationMonth" data-checkout="cardExpirationMonth" onselectstart="return false" onpaste="return false" onCopy="return false" onCut="return false" onDrag="return false" onDrop="return false" autocomplete=off />
@@ -103,11 +103,11 @@ No seguinte exemplo se assume que os dados `transaction_amount` e `description` 
 
 Configure sua [chave pública]([FAKER][CREDENTIALS][URL]) da seguinte forma:
 
-```javascript 
+```javascript
 window.Mercadopago.setPublishableKey("ENV_PUBLIC_KEY");
 ```
 
-> Se ainda não possui conta para ver suas credenciais, [regístre-se](https://www.mercadopago[FAKER][URL][DOMAIN]/registration-mp). 
+> Se ainda não possui conta para ver suas credenciais, [regístre-se](https://www.mercadopago[FAKER][URL][DOMAIN]/registration-mp).
 
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4. Obtenha os dados para seu formulário
@@ -120,7 +120,7 @@ Um dos campos obrigatórios é o tipo de documento. Utilize a lista de documento
 
 Incluindo o elemento de tipo select com `id = docType` que se encontra no formulário, MercadoPago.js completará automaticamente as opções disponíveis quando a seguinte função for chamada:
 
-```javascript 
+```javascript
 window.Mercadopago.getIdentificationTypes();
 ```
 
@@ -133,7 +133,7 @@ window.Mercadopago.getIdentificationTypes();
 
 Valide os dados dos seus clientes enquanto são preenchidos para evitar erros e oferecer corretamente as parcelas disponíveis. Use o seguinte código de exemplo para identificar o meio de pagamento com os primeiros 6 dígitos do cartão.
 
-```javascript 
+```javascript
 document.getElementById('cardNumber').addEventListener('keyup', guessPaymentMethod);
 document.getElementById('cardNumber').addEventListener('change', guessPaymentMethod);
 
@@ -171,7 +171,7 @@ function getInstallments(){
     window.Mercadopago.getInstallments({
         "payment_method_id": document.getElementById('payment_method_id').value,
         "amount": parseFloat(document.getElementById('transaction_amount').value)
-        
+
     }, function (status, response) {
         if (status == 200) {
             document.getElementById('installments').options.length = 0;
@@ -266,7 +266,7 @@ Tenha em conta que para que esse passo funcione é necessário que configure sua
     require_once 'vendor/autoload.php';
 
     MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
-    
+
     $payment = new MercadoPago\Payment();
     $payment->transaction_amount = [FAKER][NUMBER][BETWEEN][100, 200];
     $payment->token = "ff8080814c11e237014c1ff593b57b4d";
@@ -278,10 +278,10 @@ Tenha em conta que para que esse passo funcione é necessário que configure sua
     );
 
 $payment->save();
-    
+
 
 echo $payment->status;
-    
+
 ?>
 ```
 ```node
@@ -318,7 +318,7 @@ Encontre o estado do pagamento no campo _status_.
 MercadoPago.SDK.setAccessToken("ENV_ACCESS_TOKEN");
 
 Payment payment = new Payment();
-payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200])
+payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200]f)
        .setToken("ff8080814c11e237014c1ff593b57b4d")
        .setDescription("[FAKER][COMMERCE][PRODUCT_NAME]")
        .setInstallments(1)
@@ -407,7 +407,7 @@ curl -X POST \
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Resposta
 
-```json 
+```json
 {
     "status": "approved",
     "status_detail": "accredited",
@@ -442,9 +442,9 @@ Isso ajudará a evitar casos de rejeição e estornos nos casos de transações 
 Te recomendamos usar a [manipulação de respostas de erro](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/payments/api/handling-responses/) e utilizar a comunicação sugerida em cada um dos casos.
 
 > NOTE
-> 
+>
 > Nota
-> 
+>
 > Evite pagamentos rejeitados com nossas [recomendações para melhorar a aprovação dos seus pagamentos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/manage-account/payment-rejections/).
 
 ## Receba notificações de pagamento

--- a/guides/payments/web-tokenize-checkout/receiving-payment-by-card.en.md
+++ b/guides/payments/web-tokenize-checkout/receiving-payment-by-card.en.md
@@ -112,7 +112,7 @@ You should only make an *API call* including the data you received from the chec
 MercadoPago.SDK.setAccessToken("ENV_ACCESS_TOKEN");
 //...
 Payment payment = new Payment();
-payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200])
+payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200]f)
        .setToken(token)
        .setDescription("[FAKER][COMMERCE][PRODUCT_NAME]")
        .setInstallments(installments)

--- a/guides/payments/web-tokenize-checkout/receiving-payment-by-card.es.md
+++ b/guides/payments/web-tokenize-checkout/receiving-payment-by-card.es.md
@@ -88,7 +88,7 @@ Solamente debes realizar un *API call* incluyendo los datos que recibiste del ch
 
 [[[
 ```php
-<?php 
+<?php
     require_once 'vendor/autoload.php';
 
     MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
@@ -115,7 +115,7 @@ Solamente debes realizar un *API call* incluyendo los datos que recibiste del ch
 MercadoPago.SDK.setAccessToken("ENV_ACCESS_TOKEN");
 //...
 Payment payment = new Payment();
-payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200])
+payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200]f)
        .setToken(token)
        .setDescription("[FAKER][COMMERCE][PRODUCT_NAME]")
        .setInstallments(installments)

--- a/guides/payments/web-tokenize-checkout/receiving-payment-by-card.pt.md
+++ b/guides/payments/web-tokenize-checkout/receiving-payment-by-card.pt.md
@@ -112,7 +112,7 @@ Somente deverá incluir uma *chamada à API* incluindo os dados que recebeu do c
 MercadoPago.SDK.setAccessToken("ENV_ACCESS_TOKEN");
 //...
 Payment payment = new Payment();
-payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200])
+payment.setTransactionAmount([FAKER][NUMBER][BETWEEN][100, 200]f)
        .setToken(token)
        .setDescription("[FAKER][COMMERCE][PRODUCT_NAME]")
        .setInstallments(installments)


### PR DESCRIPTION
## Description
Within the payment object the parameter [`transactionAmount` is `Float`,](https://github.com/mercadopago/dx-java/blob/2dd4258214f7f06b3552c49353ffc5f15267eac4/src/main/java/com/mercadopago/resources/Payment.java#L69) but in the examples an integer was being placed. 

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue/PR involved
Fixes what was reported on #656 

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [x] This request modifies code snippets. 
- [x] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
