### PR TITLE
PHP command fix

### DIFF
--- a/guides/payments/api/previous-requirements.es.md
+++ b/guides/payments/api/previous-requirements.es.md
@@ -47,7 +47,7 @@ Instala un [SDKs oficial](https://www.mercadopago[FAKER][URL][DOMAIN]/developers
 
 Luego ejecuta el siguiente código en la línea de comandos:
 ===
-php composer.phar require "mercadopago/dx-php:dev-master"
+php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===

--- a/guides/payments/api/previous-requirements.pt.md
+++ b/guides/payments/api/previous-requirements.pt.md
@@ -48,7 +48,7 @@ Instale o [SDKs oficial](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/
 
 Execute o seguinte código na sua linha de comando:
 ===
-php composer.phar require "mercadopago/dx-php:dev-master"
+php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===

--- a/guides/payments/web-payment-checkout/latest/previous-requirements.en.md
+++ b/guides/payments/web-payment-checkout/latest/previous-requirements.en.md
@@ -58,7 +58,7 @@ If you don't have one yet, you can <a href="https://www.mercadopago.com.br/" tar
 
 Then run the following code on the command line:
 ===
-php composer.phar require "mercadopago/dx-php:dev-master"
+php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===

--- a/guides/payments/web-payment-checkout/latest/previous-requirements.es.md
+++ b/guides/payments/web-payment-checkout/latest/previous-requirements.es.md
@@ -58,7 +58,7 @@ Si aún no tienes una, puedes <a href="https://www.mercadopago.com.co/" target="
 
 Luego ejecuta el siguiente código en la línea de comandos:
 ===
-php composer.phar require "mercadopago/dx-php:dev-master"
+php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===

--- a/guides/payments/web-payment-checkout/latest/previous-requirements.pt.md
+++ b/guides/payments/web-payment-checkout/latest/previous-requirements.pt.md
@@ -57,7 +57,7 @@ Caso você ainda não tenha uma, pode <a href="https://www.mercadopago.com.br/" 
 <a href="https://getcomposer.org/download" target="_blank"> Instale o Composer </a> para usar o SDK.
 Em seguida, execute o seguinte código na linha de comandos:
 ===
-php composer.phar require "mercadopago/dx-php:dev-master"
+php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===

--- a/guides/sdks/official/php.en.md
+++ b/guides/sdks/official/php.en.md
@@ -12,7 +12,7 @@ This SDK supports PHP version 5.6 or newer.
 
 1) Download [Composer](https://getcomposer.org/download/) if not already installed.
 
-2) Go to your project directory and run `composer require "mercadopago/dx-php"` on the command line.
+2) Go to your project directory and run `php composer.phar require "mercadopago/dx-php"` on the command line.
 
 3) This how your directory structure would look like.
 

--- a/guides/sdks/official/php.es.md
+++ b/guides/sdks/official/php.es.md
@@ -12,7 +12,7 @@ Nuesto SDK es compatible con las versiones de PHP 5.6 o superior.
 
 1) Descargar [Composer](https://getcomposer.org/download/) (Si este no se encuentra instalado previamente).
 
-2) Dirigirse al directorio del proyecto y ejecutar `composer require "mercadopago/dx-php"` en la linea de comandos.
+2) Dirigirse al directorio del proyecto y ejecutar `php composer.phar require "mercadopago/dx-php"` en la linea de comandos.
 
 3) Ahora el directorio deberia verse asi.
 

--- a/guides/sdks/official/php.pt.md
+++ b/guides/sdks/official/php.pt.md
@@ -12,7 +12,7 @@ Nosso SDK é compatível com PHP versão 5.6 ou maior.
 
 1) Baixe o [Composer](https://getcomposer.org/download/), se não estiver instalado.
 
-2) Vá para o diretório do seu projeto e execute `composer require "mercadopago/dx-php"` na linha de comando.
+2) Vá para o diretório do seu projeto e execute `php composer.phar require "mercadopago/dx-php"` na linha de comando.
 
 3) Isso é como a sua estrutura de diretório se parece.
 


### PR DESCRIPTION
## Description
Correction del comando para descargar el SDK PHP desde: php composer.phar require "mercadopago/dx-php:dev-master" a php composer.phar require "mercadopago/dx-php"

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #<issue>

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [x] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
