### PR TITLE
[Fix] Tokenizer's summary-charge customization typo

### DIFF
--- a/guides/payments/web-tokenize-checkout/personalization.en.md
+++ b/guides/payments/web-tokenize-checkout/personalization.en.md
@@ -127,7 +127,7 @@ The attributes that can be added and modified are the following.
 - Products: `data-summary-product`
 - Discount: `data-summary-discount`
 - Shipping: `data-summary-shipping`
-- Surcharges: `data-summary-charges`
+- Surcharges: `data-summary-charge`
 - Taxes: `data-summary-taxes`
 - Outstanding balance: `data-summary-arrears`
 
@@ -189,10 +189,10 @@ data-summary-shipping="10"
 
 #### Surcharges
 
-Using the attribute `data-summary-charges`, you can specify the amount of surcharges in the detail of the purchase. For example:
+Using the attribute `data-summary-charge`, you can specify the amount of surcharges in the detail of the purchase. For example:
 
 ```html
-data-summary-charges="10"
+data-summary-charge="10"
 ```
 
 It will appear in the detail of the purchase under the concept of *"Surcharges"*.

--- a/guides/payments/web-tokenize-checkout/personalization.es.md
+++ b/guides/payments/web-tokenize-checkout/personalization.es.md
@@ -127,7 +127,7 @@ Los atributos que pueden agregarse y modificarse son los siguientes.
 - Productos: `data-summary-product`
 - Descuento: `data-summary-discount`
 - Envío: `data-summary-shipping`
-- Recargos: `data-summary-charges`
+- Recargos: `data-summary-charge`
 - Impuestos: `data-summary-taxes`
 - Saldo pendiente: `data-summary-arrears`
 
@@ -190,10 +190,10 @@ data-summary-shipping="10"
 
 #### Recargos
 
-Usando el atributo `data-summary-charges`, puedes especificar el monto de recargos en el detalle de la compra. Por ejemplo:
+Usando el atributo `data-summary-charge`, puedes especificar el monto de recargos en el detalle de la compra. Por ejemplo:
 
 ```html
-data-summary-charges="10"
+data-summary-charge="10"
 ```
 
 Aparecerá en el detalle de la compra bajo el concepto de *"Recargos"*.

--- a/guides/payments/web-tokenize-checkout/personalization.pt.md
+++ b/guides/payments/web-tokenize-checkout/personalization.pt.md
@@ -125,7 +125,7 @@ Os atributos que podem ser adicionados e modificados são os seguintes.
 - Produtos: `data-summary-product`
 - Desconto: `data-summary-discount`
 - Envio: `data-summary-shipping`
-- Recarga: `data-summary-charges`
+- Recarga: `data-summary-charge`
 - Impostos: `data-summary-taxes`
 - Saldo pendente: `data-summary-arrears`
 
@@ -188,10 +188,10 @@ data-summary-shipping="10"
 
 #### Recarga
 
-Usando o atributo `data-summary-charges`, você pode especificar o montante da recarga no detalhe da compra. Por exemplo:
+Usando o atributo `data-summary-charge`, você pode especificar o montante da recarga no detalhe da compra. Por exemplo:
 
 ```html
-data-summary-charges="10"
+data-summary-charge="10"
 ```
 
 Aparecerá no detalhe da compra abaixo o conceito de *"Recarga"*.


### PR DESCRIPTION
## Description
Se ajusta un problema detectado en las customizaciones de Tokenizer

Se cambió el typo: `data-summary-charges` -> `data-summary-charge`

### Checklist:
Before sending your contribution, please specify the following: 
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
