### PR TITLE
Add comma to NODE example

### DIFF
--- a/guides/payments/api/receiving-payment-by-card.pt.md
+++ b/guides/payments/api/receiving-payment-by-card.pt.md
@@ -294,7 +294,7 @@ mercadopago.configurations.setAccessToken("ENV_ACCESS_TOKEN");
 
 var payment_data = {
   transaction_amount: [FAKER][NUMBER][BETWEEN][100, 200],
-  token: 'ff8080814c11e237014c1ff593b57b4d'
+  token: 'ff8080814c11e237014c1ff593b57b4d',
   description: '[FAKER][COMMERCE][PRODUCT_NAME]',
   installments: 1,
   payment_method_id: 'visa',


### PR DESCRIPTION
## Description
On "receiving-payment-by-card" section, there is a comma missing in a nodeJS example

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #<issue>

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [x] This request modifies code snippets. 
- [x] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
