### PR TITLE
Share credentials in FAQs/Changelog

### DIFF
--- a/guides/changelog/current-year.en.md
+++ b/guides/changelog/current-year.en.md
@@ -4,6 +4,24 @@ Find out everything about the new versions and updates of Mercado Pago integrati
 
 ---
 
+## August 2020
+
+### August 7th
+
+> CHANGELOG
+>
+> Request the credentials you need to integrate
+>
+> NEWS: NEWS
+>
+> PRODUCT: CREDENTIALS
+
+Are you going to integrate Mercado Pago for another account? Now you can request access to their credentials quickly and safely.
+
+[Learn more about how to request credentials](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/faqs/credentials/)
+
+---
+
 ## July 2020
 
 ### July 8th

--- a/guides/changelog/current-year.es.md
+++ b/guides/changelog/current-year.es.md
@@ -1,6 +1,24 @@
 # Changelog
 
-Entérate todo sobre las nuevas versiones y actualizaciones de las integraciones de Mercado Pago. 
+Entérate todo sobre las nuevas versiones y actualizaciones de las integraciones de Mercado Pago.
+
+---
+
+## Agosto 2020
+
+### 7 de agosto
+
+> CHANGELOG
+>
+> Solicita las credenciales que necesitas para integrar
+>
+> NEWS: NOVEDADES
+>
+> PRODUCT: CREDENCIALES
+
+¿Vas a integrar Mercado Pago para otra cuenta? Ahora puedes solicitar el acceso a sus credenciales de forma rápida y segura.
+
+[Conocer más sobre cómo solicitar credenciales](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/faqs/credentials/)
 
 ---
 

--- a/guides/changelog/current-year.pt.md
+++ b/guides/changelog/current-year.pt.md
@@ -4,6 +4,24 @@ Descubra tudo sobre as novas versões e atualizações das integrações do Merc
 
 ---
 
+## Agosto 2020
+
+### 7 de agosto
+
+> CHANGELOG
+>
+> Solicite as credenciais necessárias para integrar
+>
+> NEWS: NOVIDADES
+>
+> PRODUCT: CREDENCIAIS
+
+Vai integrar Mercado Pago para outra pessoa? Agora você pode solicitar acesso a suas credenciais de forma rápida e segura.
+
+[Saiba mais sobre como solicitar credenciais](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/faqs/credentials/)
+
+---
+
 ## Julho 2020
 
 ### 8 de julho

--- a/guides/faqs/credentials.en.md
+++ b/guides/faqs/credentials.en.md
@@ -1,12 +1,4 @@
----
-sites_supported:
-  - mla
-  - mlb
-  - global
----
-
 # Credentials
----
 
 ## What are my credentials and where can I find them
 
@@ -19,18 +11,42 @@ Your credentials include:
 | Public key  | Public key of the application that you will use in your frontend and will allow you, for example, to know available payment methods and encrypt card data.|
 | Access token | Private key of the application that you will use in your backend to generate payments. It is very important that this data is protected on your servers and is not accessible by any system user or attacker. |
 
-They are available in your Mercado Pago account, in the [Credentials section]([FAKER][CREDENTIALS][URL]).
+They are available in the [Credentials]([FAKER][CREDENTIALS][URL]) panel or from your Mercado Pago account in [Your Business > Settings > Credentials](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials).
+
+We recommend to use first your test credentials, or those of a test user, to verify that everything works correctly in Sandbox and then you can use the productive ones to start receiving payments.
+
+## How to share my credentials
+
+Share your credentials in the safest way with those who help you integrate or configure your payment channels.
+
+In [Credentials](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials), select the “Share my credentials” option and enter the e-mail of the person you want to give access to. Note that the email address must be registered in Mercado Pago or Mercado Libre.
+
+> From your shared credentials, you can [remove permissions](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials) when your integration is complete.
+
+## Request access to keys from other accounts
+
+You can request access to another account´s credentials in order to integrate  Mercado Pago and have all the information needed on your panel at hand.
+
+In [Credentials > Other credentials](https://mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials/share), click on "Request credentials" and enter the e-mail of the account for which you need the data. Please note that the email address must be registered in Mercado Pago or Mercado Libre.
+
+At the end of the integrations, remove the access permissions to the credentials that were shared with you to take care of data security.
+
+## Where can I find the shared credentials
+
+Find the keys that someone shared with you in [Credentials > Other credentials](https://mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials/share).
+
+You can see the list of accounts that gave you access, those that are still pending approval and the option to remove the permissions that you no longer need.
 
 ## I am already integrated and tested, how do I implement in production?
 
-To go to production, you must activate your credentials in the [Credentials section]([FAKER][CREDENTIALS][URL]).
+To go to production, you must [activate your credentials]([FAKER][CREDENTIALS][URL]).
 
 > If they are already active, you don't have to do anything.
 
 ## I want to update my credentials, how can I renew them?
 
-You can renew your credentials from the [Credentials section]([FAKER][CREDENTIALS][URL]).
+You can renew your credentials from [Credentials]([FAKER][CREDENTIALS][URL]).
 
 For exceptional security reasons, your credentials may need to be updated. But don't worry, you can renew them as many times as necessary.
 
-Keep in mind that you have to replace the credentials you already used with the new ones.
+Please note that you have to replace the credentials previously used in your integration with the new ones.

--- a/guides/faqs/credentials.es.md
+++ b/guides/faqs/credentials.es.md
@@ -1,40 +1,3 @@
-----[mla, mlb]----
-
-# Credenciales
----
-
-## Qué son mis credenciales y dónde puedo encontrarlas
-
-Las credenciales son las claves que te proporcionamos para que puedas hacer tus integraciones.
-
-Tus credenciales son:
-
-| Clave | Descripción |
-| --- |--- |
-| Public key  | Clave pública de la aplicación que usarás normalmente en el frontend y te permitirá, por ejemplo, conocer los medios de pago y cifrar datos de tarjeta.|
-| Access token | Clave privada de la aplicación que usarás normalmente en el backend para generar pagos. Es muy importante que este dato quede protegido en tus servidores y no sea accesible por ningún usuario del sistema o atacante. |
-
-Están disponibles en tu cuenta de Mercado Pago, en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).<br>
-Recomendamos usar primero tus credenciales de prueba para comprobar que todo funcione correctamente en Sandbox y luego podrás utilizar las productivas para comenzar a recibir pagos.
-
-## Ya estoy integrado e hice pruebas, ¿cómo implemento en producción?
-
-Para ir a producción, tenés que activar tus credenciales en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-> Si ya se encuentran activas, no tenés que hacer nada.
-
-## Quiero actualizar mis credenciales, ¿cómo puedo renovarlas?
-
-Podés renovar tus credenciales desde la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-Por motivos de seguridad excepcionales, puede suceder que las credenciales necesiten actualizarse, pero no te preocupes, las podés renovar todas las veces que sea necesario.
-
-Tené en cuenta que tenés que reemplazar las credenciales que ya usabas por las nuevas.
-
-------------
-
-----[mlm]----
-
 # Credenciales
 
 ## Qué son mis credenciales y dónde puedo encontrarlas
@@ -48,158 +11,42 @@ Tus credenciales son:
 | Public key  | Clave pública de la aplicación que usarás normalmente en el frontend y te permitirá, por ejemplo, conocer los medios de pago y cifrar datos de tarjeta.|
 | Access token | Clave privada de la aplicación que usarás normalmente en el backend para generar pagos. Es muy importante que este dato quede protegido en tus servidores y no sea accesible por ningún usuario del sistema o atacante. |
 
+Están disponibles en el panel de [Credenciales]([FAKER][CREDENTIALS][URL]) o desde tu cuenta de Mercado Pago en [Tu Negocio > Configuraciones > Credenciales](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials).
 
- Están disponibles en tu cuenta de Mercado Pago, en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-Recomendamos usar primero tus credenciales de prueba para comprobar que todo funcione correctamente en Sandbox y luego podrás utilizar las productivas para comenzar a recibir pagos.
+Te recomendamos usar primero tus credenciales de prueba, o las de un usuario de prueba, para comprobar que todo funcione correctamente en Sandbox y luego podrás utilizar las productivas para comenzar a recibir pagos.
+
+## Cómo compartir mis credenciales
+
+Comparte tus credenciales de forma segura con quienes te ayuden a integrar o configurar tus canales de cobro.
+
+En [Credenciales](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials), elige la opción “Compartir mis credenciales” e ingresa el e-mail de la persona a la que quieres darle acceso. Ten en cuenta que su dirección de correo debe estar registrada en Mercado Pago o Mercado Libre.
+
+> Desde tus credenciales compartidas, puedes [eliminar los permisos](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials) cuando tu integración ya esté terminada.
+
+## Solicitar acceso a claves de otras cuentas
+
+Puedes pedir acceso a los datos de otra cuenta para hacer una integración con Mercado Pago cuando lo necesites y tener a mano toda la información desde tu panel.
+
+En [Credenciales > Otras credenciales](https://mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials/share), haz clic en “Solicitar credenciales” y completa el e-mail de la cuenta de la que necesitas los datos. Ten en cuenta que la dirección de correo debe estar registrada en Mercado Pago o Mercado Libre.
+
+Al finalizar las integraciones, elimina los permisos de acceso a las credenciales que te compartieron para cuidar la seguridad de los datos.
+
+## Dónde encuentro las credenciales compartidas
+
+Encuentra las claves que te compartieron en [Credenciales > Otras credenciales](https://mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials/share).
+
+Puedes ver el listado de cuentas que te dieron acceso, las que todavía están pendientes de aprobación y la opción de eliminar los permisos que ya no necesites.
 
 ## Ya estoy integrado e hice pruebas, ¿cómo implemento en producción?
 
-Para ir a producción, tienes que activar tus credenciales en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
+Para ir a producción, tienes que [activar tus credenciales]([FAKER][CREDENTIALS][URL]).
 
 > Si ya se encuentran activas, no tienes que hacer nada.
 
 ## Quiero actualizar mis credenciales, ¿cómo puedo renovarlas?
 
-Puedes renovar tus credenciales desde la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
+Puedes renovar tus claves desde tus [Credenciales]([FAKER][CREDENTIALS][URL]).
 
-Por motivos de seguridad excepcionales, puede suceder que las credenciales necesiten actualizarse. Pero no te preocupes, las puedes renovar todas las veces que sea necesario.
-Ten en cuenta que tienes que reemplazar las credenciales que ya usabas por las nuevas.
+Por motivos de seguridad excepcionales, puede suceder que las credenciales necesiten actualizarse. Pero no te preocupes, las puedes renovar todas las veces que sea necesario.<br>
 
-------------
-
-----[mpe]----
-
-# Credenciales
-
-## Qué son mis credenciales y dónde puedo encontrarlas
-
-Las credenciales son las claves que te proporcionamos para que puedas hacer tus integraciones.
-
-Tus credenciales son:
-
-| Clave | Descripción |
-| --- |--- |
-| Public key  | Clave pública de la aplicación que usarás normalmente en el frontend y te permitirá, por ejemplo, conocer los medios de pago y cifrar datos de tarjeta.|
-| Access token | Clave privada de la aplicación que usarás normalmente en el backend para generar pagos. Es muy importante que este dato quede protegido en tus servidores y no sea accesible por ningún usuario del sistema o atacante. |
-
-
- Están disponibles en tu cuenta de Mercado Pago, en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-Recomendamos usar primero tus credenciales de prueba para comprobar que todo funcione correctamente en Sandbox y luego podrás utilizar las productivas para comenzar a recibir pagos.
-
-## Ya estoy integrado e hice pruebas, ¿cómo implemento en producción?
-
-Para ir a producción, tienes que activar tus credenciales en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-> Si ya se encuentran activas, no tienes que hacer nada.
-
-## Quiero actualizar mis credenciales, ¿cómo puedo renovarlas?
-
-Puedes renovar tus credenciales desde la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-Por motivos de seguridad excepcionales, puede suceder que las credenciales necesiten actualizarse. Pero no te preocupes, las puedes renovar todas las veces que sea necesario.
-Ten en cuenta que tienes que reemplazar las credenciales que ya usabas por las nuevas.
-
-------------
-
-----[mco]----
-
-# Credenciales
-
-## Qué son mis credenciales y dónde puedo encontrarlas
-
-Las credenciales son las claves que te proporcionamos para que puedas hacer tus integraciones.
-
-Tus credenciales son:
-
-| Clave | Descripción |
-| --- |--- |
-| Public key  | Clave pública de la aplicación que usarás normalmente en el frontend y te permitirá, por ejemplo, conocer los medios de pago y cifrar datos de tarjeta.|
-| Access token | Clave privada de la aplicación que usarás normalmente en el backend para generar pagos. Es muy importante que este dato quede protegido en tus servidores y no sea accesible por ningún usuario del sistema o atacante. |
-
-
- Están disponibles en tu cuenta de Mercado Pago, en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-Recomendamos usar primero tus credenciales de prueba para comprobar que todo funcione correctamente en Sandbox y luego podrás utilizar las productivas para comenzar a recibir pagos.
-
-## Ya estoy integrado e hice pruebas, ¿cómo implemento en producción?
-
-Para ir a producción, tienes que activar tus credenciales en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-> Si ya se encuentran activas, no tienes que hacer nada.
-
-## Quiero actualizar mis credenciales, ¿cómo puedo renovarlas?
-
-Puedes renovar tus credenciales desde la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-Por motivos de seguridad excepcionales, puede suceder que las credenciales necesiten actualizarse. Pero no te preocupes, las puedes renovar todas las veces que sea necesario.
-Ten en cuenta que tienes que reemplazar las credenciales que ya usabas por las nuevas.
-
-------------
-
-----[mlu]----
-
-
-# Credenciales
-
-## Qué son mis credenciales y dónde puedo encontrarlas
-
-Las credenciales son las claves que te proporcionamos para que puedas hacer tus integraciones.
-
-Tus credenciales son:
-
-| Clave | Descripción |
-| --- |--- |
-| Public key  | Clave pública de la aplicación que usarás normalmente en el frontend y te permitirá, por ejemplo, conocer los medios de pago y cifrar datos de tarjeta.|
-| Access token | Clave privada de la aplicación que usarás normalmente en el backend para generar pagos. Es muy importante que este dato quede protegido en tus servidores y no sea accesible por ningún usuario del sistema o atacante. |
-
-
- Están disponibles en tu cuenta de Mercado Pago, en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-Recomendamos usar primero tus credenciales de prueba para comprobar que todo funcione correctamente en Sandbox y luego podrás utilizar las productivas para comenzar a recibir pagos.
-
-## Ya estoy integrado e hice pruebas, ¿cómo implemento en producción?
-
-Para ir a producción, tienes que activar tus credenciales en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-> Si ya se encuentran activas, no tienes que hacer nada.
-
-## Quiero actualizar mis credenciales, ¿cómo puedo renovarlas?
-
-Puedes renovar tus credenciales desde la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-Por motivos de seguridad excepcionales, puede suceder que las credenciales necesiten actualizarse. Pero no te preocupes, las puedes renovar todas las veces que sea necesario.
-Ten en cuenta que tienes que reemplazar las credenciales que ya usabas por las nuevas.
-
-------------
-
-----[mlc]----
-
-# Credenciales
-
-## Qué son mis credenciales y dónde puedo encontrarlas
-
-Las credenciales son las claves que te proporcionamos para que puedas hacer tus integraciones.
-
-Tus credenciales son:
-
-| Clave | Descripción |
-| --- |--- |
-| Public key  | Clave pública de la aplicación que usarás normalmente en el frontend y te permitirá, por ejemplo, conocer los medios de pago y cifrar datos de tarjeta.|
-| Access token | Clave privada de la aplicación que usarás normalmente en el backend para generar pagos. Es muy importante que este dato quede protegido en tus servidores y no sea accesible por ningún usuario del sistema o atacante. |
-
-
- Están disponibles en tu cuenta de Mercado Pago, en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-Recomendamos usar primero tus credenciales de prueba para comprobar que todo funcione correctamente en Sandbox y luego podrás utilizar las productivas para comenzar a recibir pagos.
-
-## Ya estoy integrado e hice pruebas, ¿cómo implemento en producción?
-
-Para ir a producción, tienes que activar tus credenciales en la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-> Si ya se encuentran activas, no tienes que hacer nada.
-
-## Quiero actualizar mis credenciales, ¿cómo puedo renovarlas?
-
-Puedes renovar tus credenciales desde la [sección Credenciales]([FAKER][CREDENTIALS][URL]).
-
-Por motivos de seguridad excepcionales, puede suceder que las credenciales necesiten actualizarse. Pero no te preocupes, las puedes renovar todas las veces que sea necesario.
-Ten en cuenta que tienes que reemplazar las credenciales que ya usabas por las nuevas.
-
-------------
+Ten en cuenta que tienes que reemplazar las credenciales que ya usabas por las nuevas en tu integración.

--- a/guides/faqs/credentials.pt.md
+++ b/guides/faqs/credentials.pt.md
@@ -1,16 +1,8 @@
----
-sites_supported:
-  - mla
-  - mlb
-  - global
----
-
 # Credenciais
----
 
 ## O que são minhas credenciais e onde posso encontrá-las?
 
-As credenciais são as Chaves que proporcionamos para que você possa fazer suas integrações. 
+As credenciais são as Chaves que proporcionamos para que você possa fazer suas integrações.
 
 Suas credenciais são:
 
@@ -19,19 +11,42 @@ Suas credenciais são:
 | Public key | Chave pública da aplicação que normalmente será usada no frontend e te permitirá, por exemplo, conhecer os meios de pagamento e criptografar os dados do cartão.|
 | Access token | Chave privada da aplicação normalmente será usada no backend para gerar pagamentos. É muito importante que este dado fique protegido em seus servidores e não seja acessível por nenhum usuário do sistema ou invasor. |
 
-Elas estão disponíveis na sua conta do Mercado Pago, na [seção "Credenciais"]([FAKER][CREDENTIALS][URL]).
-Recomendamos usar primeiro suas credenciais de teste para comprovar que tudo funcione corretamente em Sandbox e logo poderá utilizar as produtivas para começar a receber pagamentos.
+Eles estão disponíveis no painel de [Credenciais]([FAKER][CREDENTIALS][URL]) ou na sua conta do Mercado Pago em [Seu negócio > Configurações > Credenciais](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials).
 
-## Já estou integrado e fiz testes. Como implemento em produção?
+Recomendamos usar primeiro suas credenciais de teste, ou as de um usuário de teste,  para comprovar que tudo funcione corretamente em Sandbox e logo poderá utilizar as produtivas para começar a receber pagamentos.
 
-Para ir a produção, Você precisa ativar suas credenciais em na [seção "Credenciais"]([FAKER][CREDENTIALS][URL]).
+## Como compartilhar minhas credenciais?
+
+Compartilhe suas credenciais de forma segura com quem te ajuda a integrar ou configurar seus canais de pagamento.
+
+Em [Credenciales](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials), escolha a opção “Compartilhar minhas credenciais” e digite o e-mail da pessoa a quem você deseja dar acesso. Lembre-se de que o e-mail da pessoa deve estar cadastrado no Mercado Pago ou no Mercado Livre.
+
+> De suas credenciais compartilhadas, você pode [excluir essa permissões](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials) quando sua integração é completa.
+
+## Solicitar acesso a chaves de outras contas
+
+Você pode solicitar acesso aos dados de outra conta para fazer uma integração com o Mercado Pago quando precisar e ter em mãos todas as informações em seu painel.
+
+Em [Credenciais > Outras credenciais](https://mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials/share), clique em “Solicitar credenciais” y e digite o e-mail da conta para a qual você precisa dos dados. Lembre-se de que o e-mail deve estar cadastrado no Mercado Pago ou no Mercado Livre.
+
+No final das integrações, remova as permissões de acesso para as credenciais que foram compartilhadas para cuidar da segurança dos dados.
+
+## Onde encontro as credenciais compartilhadas?
+
+Encontrar as chaves que compartilharam com você em [Credenciais > Outras credenciais](https://mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials/share).
+
+Você pode ver a lista de contas que lhe deu acesso, aqueles que ainda estão pendentes de aprovação e a opção de excluir as permissões que você não precisa mais.
+
+## Já estou integrado e fiz testes, como implemento em produção?
+
+Para ir a produção, você precisa [ativar suas credenciais]([FAKER][CREDENTIALS][URL]).
 
 > Se eles já estiverem ativos, você não precisa fazer nada.
 
 ## Quero atualizar minhas credenciais, como posso renová-las?
 
-Você pode renovar suas credenciais pela [seção "Credenciais"]([FAKER][CREDENTIALS][URL]).
+Você pode renovar suas chaves em [Credenciais]([FAKER][CREDENTIALS][URL]).
 
 Por motivos de segurança excepcionais, pode ocorrer que as credenciais necessitem de atualização, mas não se preocupe, você pode renová-las sempre que necessário.
 
-Lembre-se que você deve substituir as credenciais que já usava pelas novas.
+Lembre-se que você deve substituir as credenciais que já usava pelas novas em sua integração.

--- a/guides/faqs/credentials.pt.md
+++ b/guides/faqs/credentials.pt.md
@@ -21,13 +21,13 @@ Compartilhe suas credenciais de forma segura com quem te ajuda a integrar ou con
 
 Em [Credenciales](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials), escolha a opção “Compartilhar minhas credenciais” e digite o e-mail da pessoa a quem você deseja dar acesso. Lembre-se de que o e-mail da pessoa deve estar cadastrado no Mercado Pago ou no Mercado Livre.
 
-> De suas credenciais compartilhadas, você pode [excluir essa permissões](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials) quando sua integração é completa.
+> A partir das suas credenciais compartilhadas, você pode [excluir essas permissões](https://www.mercadopago[FAKER][URL][DOMAIN]/settings/account/credentials) quando sua integração estiver completa.
 
 ## Solicitar acesso a chaves de outras contas
 
 Você pode solicitar acesso aos dados de outra conta para fazer uma integração com o Mercado Pago quando precisar e ter em mãos todas as informações em seu painel.
 
-Em [Credenciais > Outras credenciais](https://mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials/share), clique em “Solicitar credenciais” y e digite o e-mail da conta para a qual você precisa dos dados. Lembre-se de que o e-mail deve estar cadastrado no Mercado Pago ou no Mercado Livre.
+Em [Credenciais > Outras credenciais](https://mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials/share), clique em “Solicitar credenciais” e digite o e-mail da conta para a qual você precisa dos dados. Lembre-se de que o e-mail deve estar cadastrado no Mercado Pago ou no Mercado Livre.
 
 No final das integrações, remova as permissões de acesso para as credenciais que foram compartilhadas para cuidar da segurança dos dados.
 


### PR DESCRIPTION
## Description
Agregamos funcionalidad de compartir en credenciales en FAQs y Changelog.

**Impactos**

- Agregamos novedad en Changelog
- Sumamos nuevas preguntas frecuentes: 
				Cómo compartir mis credenciales 
				Solicitar acceso a claves de otras cuentas 
				Dónde encuentro las credenciales compartidas
- Iteramos nuevos accesos a credenciales según corresponda: panel de Credenciales o desde la cuenta de Mercado Pago. 

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [X] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [X] New features were communicated in changelog.
- [ ] Requires translations.
