### PR TITLE
Corrección de transactionAmount en snippets de Checkout API

### DIFF
--- a/guides/payments/api/receiving-payment-by-card.en.md
+++ b/guides/payments/api/receiving-payment-by-card.en.md
@@ -108,7 +108,7 @@ The following example assumes that `transactionAmount` and `description` data we
          <select type="text" id="installments" name="installments"></select>
        </div>
        <div>
-         <input type="hidden" name="transactionAmount" id="transactionAmount" value="0" />
+         <input type="hidden" name="transactionAmount" id="transactionAmount" value="100" />
          <input type="hidden" name="paymentMethodId" id="paymentMethodId" />
          <input type="hidden" name="description" id="description" />
          <br>
@@ -170,7 +170,7 @@ function setPaymentMethod(status, response) {
        } else {
            getInstallments(
                paymentMethod.id,
-               document.getElementById('amount').value
+               document.getElementById('transactionAmount').value
            );
        }
    } else {
@@ -206,7 +206,7 @@ function setIssuers(status, response) {
 
        getInstallments(
            document.getElementById('paymentMethodId').value,
-           document.getElementById('amount').value,
+           document.getElementById('transactionAmount').value,
            issuerSelect.value
        );
    } else {
@@ -222,10 +222,10 @@ function setIssuers(status, response) {
 The number of installments is also a mandatory field for credit card payments. You can use the function in the following example to fill out the _select_ type suggested field called `installments` and get the available installments.
 
 ```javascript
-function getInstallments(paymentMethodId, amount, issuerId){
+function getInstallments(paymentMethodId, transactionAmount, issuerId){
    window.Mercadopago.getInstallments({
        "payment_method_id": paymentMethodId,
-       "amount": parseFloat(amount),
+       "amount": parseFloat(transactionAmount),
        "issuer_id": issuerId ? parseInt(issuerId) : undefined
    }, setInstallments);
 }

--- a/guides/payments/api/receiving-payment-by-card.es.md
+++ b/guides/payments/api/receiving-payment-by-card.es.md
@@ -120,7 +120,7 @@ En el siguiente ejemplo se asume que los datos `transactionAmount` y `descriptio
          <select type="text" id="installments" name="installments"></select>
        </div>
        <div>
-         <input type="hidden" name="transactionAmount" id="transactionAmount" value="0" />
+         <input type="hidden" name="transactionAmount" id="transactionAmount" value="100" />
          <input type="hidden" name="paymentMethodId" id="paymentMethodId" />
          <input type="hidden" name="description" id="description" />
          <br>
@@ -182,7 +182,7 @@ function setPaymentMethod(status, response) {
        } else {
            getInstallments(
                paymentMethod.id,
-               document.getElementById('amount').value
+               document.getElementById('transactionAmount').value
            );
        }
    } else {
@@ -217,7 +217,7 @@ function setIssuers(status, response) {
 
        getInstallments(
            document.getElementById('paymentMethodId').value,
-           document.getElementById('amount').value,
+           document.getElementById('transactionAmount').value,
            issuerSelect.value
        );
    } else {
@@ -233,10 +233,10 @@ function setIssuers(status, response) {
 Otro de los campos obligatorios para pagos con tarjetas es la cantidad de cuotas. Para obtener las cuotas disponibles, puedes utilizar la siguiente función de ejemplo para completar el campo sugerido de tipo _select_ denominado `installments`.
 
 ```javascript
-function getInstallments(paymentMethodId, amount, issuerId){
+function getInstallments(paymentMethodId, transactionAmount, issuerId){
    window.Mercadopago.getInstallments({
        "payment_method_id": paymentMethodId,
-       "amount": parseFloat(amount),
+       "amount": parseFloat(transactionAmount),
        "issuer_id": issuerId ? parseInt(issuerId) : undefined
    }, setInstallments);
 }

--- a/guides/payments/api/receiving-payment-by-card.pt.md
+++ b/guides/payments/api/receiving-payment-by-card.pt.md
@@ -120,7 +120,7 @@ No seguinte exemplo se assume que os dados `transactionAmount` e `description` f
          <select type="text" id="installments" name="installments"></select>
        </div>
        <div>
-         <input type="hidden" name="transactionAmount" id="transactionAmount" value="0" />
+         <input type="hidden" name="transactionAmount" id="transactionAmount" value="100" />
          <input type="hidden" name="paymentMethodId" id="paymentMethodId" />
          <input type="hidden" name="description" id="description" />
          <br>
@@ -184,7 +184,7 @@ function setPaymentMethod(status, response) {
        } else {
            getInstallments(
                paymentMethod.id,
-               document.getElementById('amount').value
+               document.getElementById('transactionAmount').value
            );
        }
    } else {
@@ -219,7 +219,7 @@ function setIssuers(status, response) {
 
        getInstallments(
            document.getElementById('paymentMethodId').value,
-           document.getElementById('amount').value,
+           document.getElementById('transactionAmount').value,
            issuerSelect.value
        );
    } else {
@@ -235,10 +235,10 @@ function setIssuers(status, response) {
 Outro campo obrigatório para pagamento com cartão é a quantidade de parcelas. Para obter as parcelas diponíveis, utilize a seguinte função de exemplo para completar o campo sugerido de tipo _select_ denominado `installments`.
 
 ```javascript
-function getInstallments(paymentMethodId, amount, issuerId){
+function getInstallments(paymentMethodId, transactionAmount, issuerId){
    window.Mercadopago.getInstallments({
        "payment_method_id": paymentMethodId,
-       "amount": parseFloat(amount),
+       "amount": parseFloat(transactionAmount),
        "issuer_id": issuerId ? parseInt(issuerId) : undefined
    }, setInstallments);
 }


### PR DESCRIPTION
## Description
In few word, describe what’s your Pull Request about.

- Se unifica atributo de monto de compra en formulario y snippets para referirse siempre como `transactionAmount`
- Se modifica el value por defecto de dicho atributo a "100" en lugar de "0" para evitar error al probar

### Checklist:
Before sending your contribution, please specify the following: 
- [X] This request modifies code snippets. 
- [X] The contribution aligns with the information stated in the repository wiki.
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
