### PR TITLE
Fix: Payer.phone.number property as number

### DIFF
--- a/guides/online-payments/checkout-pro/latest/advanced-integration.pt.md
+++ b/guides/online-payments/checkout-pro/latest/advanced-integration.pt.md
@@ -26,7 +26,7 @@ Recomendamos detalhar todas as informações possíveis sobre o item e o comprad
   $payer->date_created = "2018-06-02T12:58:41.425-04:00";
   $payer->phone = array(
     "area_code" => "11",
-    "number" => "4444-4444"
+    "number" => 4444-4444
   );
     ----[mla, mlb, mlu, mco, mlc, mpe]----
   $payer->identification = array(
@@ -51,7 +51,7 @@ var payer = {
   date_created: "2015-06-02T12:58:41.425-04:00",
   phone: {
     area_code: "11",
-    number: "4444-4444"
+    number: 4444-4444
   },
   ----[mla, mlb, mlu, mco, mlc, mpe]----
   identification: {
@@ -76,7 +76,7 @@ payer.setName("Joao")
      .setDateCreated("2018-06-02T12:58:41.425-04:00")
      .setPhone(new Phone()
         .setAreaCode("11")
-        .setPhoneNumber("4444-4444"))
+        .setPhoneNumber(4444-4444))
       ----[mla, mlb, mlu, mco, mlc, mpe]----
      .setIdentification(new Identification()
         .setType("CPF")
@@ -97,7 +97,7 @@ payer = MercadoPago::Payer.new({
   date_created: Time.now
   phone: MercadoPago::Phone.new({
     area_code: "11",
-    number: "4444-4444"
+    number: 4444-4444
   })
   ----[mla, mlb, mlu, mco, mlc, mpe]----
   identification: MercadoPago::Identification.new({
@@ -126,7 +126,7 @@ Payer payer = new Payer()
     Phone = new Phone()
     {
         AreaCode = "11",
-        Number = "4444-4444"
+        Number = 4444-4444
     },
     ----[mla, mlb, mlu, mco, mlc, mpe]----
     Identification = new Identification()


### PR DESCRIPTION
Payer.phone.number should be a number instead of a string

## Description
Using mercadopago v.1.3.2, if Payer.phone.number is sent as a string type, the following error is thrown:
"The next fields are failing on validation: ".payer.phone.number": should be number."

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #<issue>

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [X] This request modifies code snippets. 
- [X] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
