### PR TITLE
[Feature] Add pix in payment methods

### DIFF
--- a/guides/resources/localization/payment-methods.en.md
+++ b/guides/resources/localization/payment-methods.en.md
@@ -139,6 +139,7 @@ Boleto Bancario			| `ticket`                 | `bolbradesco`
 Account money	       		| `account_money`          | `account_money`
 Giftcard                	| `digital_currency`       | `giftcard`
 Paypal							| `digital_wallet` | `paypal`
+Pix						| `bank_transfer` 		   | `pix`
 
 
 ### Chile

--- a/guides/resources/localization/payment-methods.en.md
+++ b/guides/resources/localization/payment-methods.en.md
@@ -141,7 +141,6 @@ Giftcard                	| `digital_currency`       | `giftcard`
 Paypal							| `digital_wallet` | `paypal`
 Pix						| `bank_transfer` 		   | `pix`
 
-
 ### Chile
 
 Payment Method    		| Payment Type ID          | ID  

--- a/guides/resources/localization/payment-methods.es.md
+++ b/guides/resources/localization/payment-methods.es.md
@@ -139,6 +139,7 @@ Boleto Bancario			| `ticket`                 | `bolbradesco`
 Dinero en cuenta	       	| `account_money`          | `account_money`
 Giftcard                	| `digital_currency`       | `giftcard`
 Paypal							| `digital_wallet` | `paypal`
+Pix						| `bank_transfer` 		   | `pix`
 
 ### Chile
 

--- a/guides/resources/localization/payment-methods.pt.md
+++ b/guides/resources/localization/payment-methods.pt.md
@@ -121,6 +121,8 @@ Dinheiro em conta	       	| `account_money`          | `account_money`
 Giftcard                	| `digital_currency`       | `giftcard`
 Pagamento na Lotérica      	| `ticket`| `pec`
 Paypal							| `digital_wallet` | `paypal`
+Pix							| `bank_transfer` 		   | `pix`
+
 
 ### Chile
 

--- a/guides/resources/localization/products.en.md
+++ b/guides/resources/localization/products.en.md
@@ -67,13 +67,13 @@ Subscriptions | Checkout API | `naranja`, `nativa`, `shopping`, `debvisa`, `debm
 | :--- | :--- | :--- |
 | Payments | Payment link | N/A |
 | Payments | Checkout Pro | N/A |
-| Payments | Mobile Checkout | `account_money` |
-| Payments | Checkout API | N/A |
-| Subscriptions | Payment link | `bolbradesco`, `giftcard` |
-| Subscriptions | Checkout | `bolbradesco`, `giftcard` |
-| Subscriptions | Checkout API | `bolbradesco`, `giftcard` |
-| Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout API | N/A |
+| Payments | Mobile Checkout | `account_money`, `pix` |
+| Payments | Checkout API |`pix` |
+| Subscriptions | Payment link | `bolbradesco`, `giftcard`, `pix` |
+| Subscriptions | Checkout | `bolbradesco`, `giftcard`, `pix` |
+| Subscriptions | Checkout API | `bolbradesco`, `giftcard`, `pix` |
+| Marketplace | Checkout Pro | `pix` |
+| Marketplace | Checkout API | `pix` |
 
 ### Chile
 

--- a/guides/resources/localization/products.es.md
+++ b/guides/resources/localization/products.es.md
@@ -110,13 +110,13 @@ Suscripciones | Checkout API | `naranja`, `nativa`, `shopping`, `debvisa`, `debm
 | :--- | :--- | :--- |
 | Pagos | Link de pago | N/A |
 | Pagos | Checkout Pro | N/A |
-| Pagos | Mobile Checkout | `account_money` |
-| Pagos | Checkout Transparente | N/A |
-| Suscripciones | Link de pago | `bolbradesco`, `giftcard` |
-| Suscripciones | Checkout Pro | `bolbradesco`, `giftcard` |
-| Suscripciones | Checkout Transparente | `bolbradesco`, `giftcard` |
-| Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout Transparente | N/A |
+| Pagos | Mobile Checkout | `account_money`, `pix` |
+| Pagos | Checkout Transparente | `pix` |
+| Suscripciones | Link de pago | `bolbradesco`, `giftcard`, `pix` |
+| Suscripciones | Checkout Pro | `bolbradesco`, `giftcard`, `pix` |
+| Suscripciones | Checkout Transparente | `bolbradesco`, `giftcard`, `pix` |
+| Marketplace | Checkout Pro | `pix`|
+| Marketplace | Checkout Transparente | `pix` |
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
 | Producto | Solución | Medios de pago no disponibles |

--- a/guides/resources/localization/products.es.md
+++ b/guides/resources/localization/products.es.md
@@ -123,13 +123,13 @@ Suscripciones | Checkout API | `naranja`, `nativa`, `shopping`, `debvisa`, `debm
 | :--- | :--- | :--- |
 | Pagos | Link de pago | N/A |
 | Pagos | Checkout Pro | N/A |
-| Pagos | Mobile Checkout | `account_money` |
-| Pagos | Checkout API | N/A |
-| Suscripciones | Link de pago | `bolbradesco`, `giftcard` |
-| Suscripciones | Checkout Pro | `bolbradesco`, `giftcard` |
-| Suscripciones | Checkout API | `bolbradesco`, `giftcard` |
-| Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout API | N/A |
+| Pagos | Mobile Checkout | `account_money`, `pix` |
+| Pagos | Checkout API | `pix` |
+| Suscripciones | Link de pago | `bolbradesco`, `giftcard`, `pix`  |
+| Suscripciones | Checkout Pro | `bolbradesco`, `giftcard`, `pix`  |
+| Suscripciones | Checkout API | `bolbradesco`, `giftcard`, `pix`  |
+| Marketplace | Checkout Pro | `pix` |
+| Marketplace | Checkout API | `pix` |
 ------------
 
 ### Chile

--- a/guides/resources/localization/products.pt.md
+++ b/guides/resources/localization/products.pt.md
@@ -110,13 +110,13 @@ Assinaturas | Checkout API | `naranja`, `nativa`, `shopping`, `debvisa`, `debmas
 | :--- | :--- | :--- |
 | Pagamentos | Link de pagamento | N/A |
 | Pagamentos | Checkout Pro | N/A |
-| Pagamentos | Mobile Checkout | `account_money` |
-| Pagamentos | Checkout Transparente | N/A |
-| Assinaturas | Link de pagamento | `bolbradesco`, `giftcard` |
-| Assinaturas | Checkout Pro | `bolbradesco`, `giftcard` |
-| Assinaturas | Checkout Transparente | `bolbradesco`, `giftcard` |
-| Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout Transparente | N/A |
+| Pagamentos | Mobile Checkout | `account_money`, `pix` |
+| Pagamentos | Checkout Transparente | `pix` |
+| Assinaturas | Link de pagamento | `bolbradesco`, `giftcard`, `pix` |
+| Assinaturas | Checkout Pro | `bolbradesco`, `giftcard`, `pix` |
+| Assinaturas | Checkout Transparente | `bolbradesco`, `giftcard`, `pix` |
+| Marketplace | Checkout Pro | `pix` |
+| Marketplace | Checkout Transparente | `pix` |
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
 | Produto | Solução | Meios de pagamento não disponíveis |

--- a/guides/resources/localization/products.pt.md
+++ b/guides/resources/localization/products.pt.md
@@ -123,13 +123,13 @@ Assinaturas | Checkout API | `naranja`, `nativa`, `shopping`, `debvisa`, `debmas
 | :--- | :--- | :--- |
 | Pagamentos | Link de pagamento | N/A |
 | Pagamentos | Checkout Pro | N/A |
-| Pagamentos | Mobile Checkout | `account_money` |
-| Pagamentos | Checkout API | N/A |
-| Assinaturas | Link de pagamento | `bolbradesco`, `giftcard` |
-| Assinaturas | Checkout Pro | `bolbradesco`, `giftcard` |
-| Assinaturas | Checkout API | `bolbradesco`, `giftcard` |
-| Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout API | N/A |
+| Pagamentos | Mobile Checkout | `account_money`, `pix` |
+| Pagamentos | Checkout API | `pix` |
+| Assinaturas | Link de pagamento | `bolbradesco`, `giftcard`, `pix`  |
+| Assinaturas | Checkout Pro | `bolbradesco`, `giftcard`, `pix`  |
+| Assinaturas | Checkout API | `bolbradesco`, `giftcard`, `pix`  |
+| Marketplace | Checkout Pro | `pix` |
+| Marketplace | Checkout API | `pix` |
 ------------
 
 


### PR DESCRIPTION
## Description
Lo que se hizo fue agregar en la sección de Localización, para el site MLB el medio de pago PIX.
Este medio se va a prender el el 17/12. 

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #<issue>

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
