### PR TITLE
added new column in reports glossary

### DIFF
--- a/guides/manage-account/reports/available-money/glossary.en.md
+++ b/guides/manage-account/reports/available-money/glossary.en.md
@@ -34,3 +34,4 @@ We know, some terms are technical and you may not be familiar with all of them. 
 | SHIPMENT_MODE | Shipping Mode. |
 | PACK_ID | Package identification in the cart. |
 | TAXES_DISAGGREGATED | Taxes disaggregated in JSON format. |
+| EFFECTIVE_COUPON_AMOUNT | Cost for offering discount. |

--- a/guides/manage-account/reports/available-money/glossary.es.md
+++ b/guides/manage-account/reports/available-money/glossary.es.md
@@ -34,6 +34,7 @@ Lo sabemos, algunos términos son técnicos y puede que no estés familiarizado 
 | SHIPMENT_MODE | Modalidad de envío. |
 | PACK_ID | Identificador del paquete en el carrito. |
 | TAXES_DISAGGREGATED | Impuestos desagregados en formato JSON. |
+| EFFECTIVE_COUPON_AMOUNT | Costo por ofrecer descuento. |
 
 <hr/>
 

--- a/guides/manage-account/reports/available-money/glossary.pt.md
+++ b/guides/manage-account/reports/available-money/glossary.pt.md
@@ -34,7 +34,7 @@ Sabemos que alguns termos são técnicos e você pode não estar familiarizado c
 | SHIPMENT_MODE | Modalidade de envio. |
 | PACK_ID | Identificador do pacote no carrinho. |
 | TAXES_DISAGGREGATED | Impostos desagregados no formato JSON. |
-
+| EFFECTIVE_COUPON_AMOUNT | Custo de oferecer desconto. |
 
 <hr/>
 

--- a/guides/manage-account/reports/released-money/glossary.en.md
+++ b/guides/manage-account/reports/released-money/glossary.en.md
@@ -34,6 +34,7 @@ We know, some terms are technical and you may not be familiar with all of them. 
 | SHIPMENT_MODE | Shipping Mode. |
 | PACK_ID | Package identification in the cart. |
 | TAXES_DISAGGREGATED | Taxes disaggregated in JSON format. |
+| EFFECTIVE_COUPON_AMOUNT | Cost for offering discount. |
 
 <hr/>
 

--- a/guides/manage-account/reports/released-money/glossary.es.md
+++ b/guides/manage-account/reports/released-money/glossary.es.md
@@ -34,6 +34,7 @@ Lo sabemos, algunos términos son técnicos y puede que no estés familiarizado 
 | SHIPMENT_MODE | Modalidad de envío. |
 | PACK_ID | Identificador del paquete en el carrito. |
 | TAXES_DISAGGREGATED | Impuestos desagregados en formato JSON. |
+| EFFECTIVE_COUPON_AMOUNT | Costo por ofrecer descuento. |
 
 <hr/>
 

--- a/guides/manage-account/reports/released-money/glossary.pt.md
+++ b/guides/manage-account/reports/released-money/glossary.pt.md
@@ -34,6 +34,7 @@ Sabemos que alguns termos são técnicos e você pode não estar familiarizado c
 | SHIPMENT_MODE | Modalidade de envio. |
 | PACK_ID | Identificador do pacote no carrinho. |
 | TAXES_DISAGGREGATED | Impostos desagregados no formato JSON. |
+| EFFECTIVE_COUPON_AMOUNT | Custo de oferecer desconto. |
 
 <hr/>
 


### PR DESCRIPTION
## Description
Se agrega nombre y descripción de nueva columna (**EFFECTIVE_COUPON_AMOUNT**) en los glosarios de los reportes bank y release.



<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #[MPRC-5824](https://mercadolibre.atlassian.net/browse/MPRC-5824)

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
