### PR TITLE
Fix/reference links trailing slash

### DIFF
--- a/guides/in-person-payments/mp-point/how-to-integrate.en.md
+++ b/guides/in-person-payments/mp-point/how-to-integrate.en.md
@@ -264,7 +264,7 @@ In the article [notificaciones](https://www.mercadopago.com.ar/developers/en/gui
 
 
 ## Point payments
-Point payments can be search in the Payments API. You can find more information in the following article: [API's](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_id/get/)
+Point payments can be search in the Payments API. You can find more information in the following article: [API's](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_id/get)
 
 On the other hand, we have an exclusive Point API that has some additional information about the payments: 
 

--- a/guides/in-person-payments/mp-point/how-to-integrate.es.md
+++ b/guides/in-person-payments/mp-point/how-to-integrate.es.md
@@ -266,7 +266,7 @@ En el artículo de [notificaciones](https://www.mercadopago.com.ar/developers/es
 
 
 ## Pagos de Point
-Los pagos de Point se pueden buscar en la API de Payments. Podes encontrar más información en el artículo de [API's](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get/)
+Los pagos de Point se pueden buscar en la API de Payments. Podes encontrar más información en el artículo de [API's](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get)
 
 A su vez, existe una API exclusiva de Point que cuenta con alguna información adicional del pago: 
 

--- a/guides/in-person-payments/mp-point/how-to-integrate.pt.md
+++ b/guides/in-person-payments/mp-point/how-to-integrate.pt.md
@@ -266,7 +266,7 @@ No artigo de [notificações](https://www.mercadopago.com.br/developers/pt/guide
 
 ## Pagamentos de Point
 
-Os pagamentos de Point podem ser buscados na API de Payments. Pode-se encontrar mais informações no artigo de [API's](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get/)
+Os pagamentos de Point podem ser buscados na API de Payments. Pode-se encontrar mais informações no artigo de [API's](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get)
 
 Existe uma API exclusiva de Point que conta com informações adicionais do pagamento: 
 

--- a/guides/in-person-payments/qr-code-legacy/qr-gas-station.en.md
+++ b/guides/in-person-payments/qr-code-legacy/qr-gas-station.en.md
@@ -20,7 +20,7 @@
 
 1. Immediately after the payment is processed, we send to your server a notification [INP](https://www.mercadopago.com.mx/developers/es/guides/notifications/ipn/) informing that there is a novelty.
 
-1. With the payment identifier, you can [search](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_search/get/) the payment and continue with your internal processes.
+1. With the payment identifier, you can [search](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_search/get) the payment and continue with your internal processes.
 
    >
    > If the status is `approved`, the payment must be accredited. On the other hand, if it is `rejected`, the app will retry the payment requesting another means of payment.
@@ -167,7 +167,7 @@ Within to the previous concepts, you must also know the objects with which we go
 
 - `status_detail`: Detailed information about the current status or the reason for rejection.
 
-Consult the [full documentation](https://www.mercadopago.com.mx/developers/en/reference/payments/resource/) about this object in our API Reference.
+Consult the [full documentation](https://www.mercadopago.com.mx/developers/en/reference/payments/resource) about this object in our API Reference.
 
 ## Settings
 
@@ -236,7 +236,7 @@ https://api.mercadopago.com/pos \
    After the user makes the payment you can obtain the data using any of the following ways:
 
    1. [IPN](https://www.mercadopago.com.mx/developers/es/guides/notifications/ipn/): When the payment is created, we send a notification via webhook to the URL configured in the `notification_url` of the order, you will need to be subscribed to merchant_order's type notifications.
-   2. Do the [payment search](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_search/get/) using the `external_reference` as the search criteria.
+   2. Do the [payment search](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_search/get) using the `external_reference` as the search criteria.
 
 ## Refunds
 

--- a/guides/in-person-payments/qr-code-legacy/qr-gas-station.es.md
+++ b/guides/in-person-payments/qr-code-legacy/qr-gas-station.es.md
@@ -20,7 +20,7 @@
 
 6. Inmediatamente luego de ser procesado el pago, enviamos a tu servidor una notificación [IPN](https://www.mercadopago.com.mx/developers/es/guides/notifications/ipn/) informando que hay una novedad.
 
-7. Con el identificador del pago, puedes [buscar](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get/) el pago y continuar con tus procesos internos.
+7. Con el identificador del pago, puedes [buscar](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get) el pago y continuar con tus procesos internos.
 
    > Si el estatus es `approved` se debe acreditar el pago. En cambio si es `rejected`, la app reintentará el cobro solicitando otro medio de pago.
 
@@ -167,7 +167,7 @@ Además de los conceptos anteriores, también debes conocer los objetos con los 
 
 - `status_detail`: Información detallada del estado actual o el motivo de rechazo.
 
-Consultar la [documentación completa](https://www.mercadopago.com.mx/developers/es/reference/payments/resource/) sobre este objeto en nuestra Referencia API.
+Consultar la [documentación completa](https://www.mercadopago.com.mx/developers/es/reference/payments/resource) sobre este objeto en nuestra Referencia API.
 
 ## Configuración inicial
 
@@ -237,7 +237,7 @@ https://api.mercadopago.com/pos \
 Luego de que el usuario realiza el pago podrás obtener los datos usando cualquiera de las siguientes formas:
 
 1. [IPN](https://www.mercadopago.com.mx/developers/es/guides/notifications/ipn/): Cuando el pago es creado, enviamos una notificación vía webhook a la URL configurada en la `notification_url` de la orden, deberás estar suscrito a las notificaciones tipo `merchant_order`.
-2. Hacer la [búsqueda del pago](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get/) utilizando el `external_reference` como criterio de búsqueda.
+2. Hacer la [búsqueda del pago](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get) utilizando el `external_reference` como criterio de búsqueda.
 
 ## Devoluciones
 

--- a/guides/in-person-payments/qr-code-legacy/qr-gas-station.pt.md
+++ b/guides/in-person-payments/qr-code-legacy/qr-gas-station.pt.md
@@ -20,7 +20,7 @@
 
 6. Imediatamente após o processamento do pagamento é enviada uma notificação para o servidor [IPN] (https://www.mercadopago.com.br/developers/pt/guides/notifications/ipn/) relatando que há algo novo.
 
-7. Com o ID de pagamento, você pode [pesquisar] (https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get/) o pagamento e continuar os seus processos internos.
+7. Com o ID de pagamento, você pode [pesquisar] (https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get) o pagamento e continuar os seus processos internos.
 
    > Se o status for 'approved', o pagamento deve ser creditado. Por outro lado, se for `rejected`, o aplicativo tentará novamente o pagamento solicitando outro meio de pagamento.
 
@@ -167,7 +167,7 @@ Além dos conceitos anteriores, você também deve conhecer os objetos com os qu
 
 - `status_detail`: Informações detalhadas sobre o status atual ou o motivo da rejeição.
 
-Consulte a [documentação completa](https://www.mercadopago.com.br/developers/pt/reference/payments/resource/) sobre este objeto em nossa Referencia API.
+Consulte a [documentação completa](https://www.mercadopago.com.br/developers/pt/reference/payments/resource) sobre este objeto em nossa Referencia API.
 
 ## Configuração inicial
 
@@ -237,7 +237,7 @@ https://api.mercadopago.com/pos \
 Depois que o usuário fizer o pagamento, você poderá obter os dados usando qualquer uma das seguintes maneiras:
 
 1. [IPN](https://www.mercadopago.com.br/developers/pt/guides/notifications/ipn/): Quando o pagamento é criado, enviamos uma notificação via webhook para a URL configurado no `notification_url` da ordem, você deve se inscrever para o tipo de notificações `merchant_order`.
-2. Faça a [pesquisa de pagamento](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get/) usando o `external_reference` como critério de pesquisa.
+2. Faça a [pesquisa de pagamento](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get) usando o `external_reference` como critério de pesquisa.
 
 ## Devoluções
 

--- a/guides/in-person-payments/qr-code-legacy/qr-gas-station.pt.md
+++ b/guides/in-person-payments/qr-code-legacy/qr-gas-station.pt.md
@@ -20,7 +20,7 @@
 
 6. Imediatamente após o processamento do pagamento é enviada uma notificação para o servidor [IPN] (https://www.mercadopago.com.br/developers/pt/guides/notifications/ipn/) relatando que há algo novo.
 
-7. Com o ID de pagamento, você pode [pesquisar] (https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get) o pagamento e continuar os seus processos internos.
+7. Com o ID de pagamento, você pode [pesquisar](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get) o pagamento e continuar os seus processos internos.
 
    > Se o status for 'approved', o pagamento deve ser creditado. Por outro lado, se for `rejected`, o aplicativo tentará novamente o pagamento solicitando outro meio de pagamento.
 

--- a/guides/in-person-payments/qr-code-legacy/qr-pos.en.md
+++ b/guides/in-person-payments/qr-code-legacy/qr-pos.en.md
@@ -103,7 +103,7 @@ In addition to the previous concepts, you must also know the objects with which 
 
 - `status_detail`: Detailed information about the current status or the reason for rejection.
 
-Consult the [full documentation](https://www.mercadopago.com.mx/developers/en/reference/payments/resource/) about this object in our API Reference.
+Consult the [full documentation](https://www.mercadopago.com.mx/developers/en/reference/payments/resource) about this object in our API Reference.
 
 ## Payments
 
@@ -159,7 +159,7 @@ For example, if you want it to be available for 5 minutes you should send the he
 After the user makes the payment you can obtain the data using any of the following ways:
 
 1. [IPN](https://www.mercadopago.com.mx/developers/es/guides/notifications/ipn/): When the payment is created, we send a notification via webhook to the URL configured in the `notification_url` of the order, you will need to be subscribed to merchant_order's type notifications.
-2. Do the [payment search](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_search/get/) using the `external_reference` as the search criteria.
+2. Do the [payment search](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_search/get) using the `external_reference` as the search criteria.
 
 ### Delete order
 

--- a/guides/in-person-payments/qr-code-legacy/qr-pos.es.md
+++ b/guides/in-person-payments/qr-code-legacy/qr-pos.es.md
@@ -103,7 +103,7 @@ Además de los conceptos anteriores, también debes conocer los objetos con los 
 
 * `status_detail`: Información detallada del estado actual o el motivo de rechazo.
 
-Consultar la [documentación completa](https://www.mercadopago.com.mx/developers/es/reference/payments/resource/) sobre este objeto en nuestra Referencia API.
+Consultar la [documentación completa](https://www.mercadopago.com.mx/developers/es/reference/payments/resource) sobre este objeto en nuestra Referencia API.
 
 ## Cobros
 
@@ -159,7 +159,7 @@ Por ejemplo si deseas que esté disponible durante 5 minutos se debe enviar el h
 Luego de que el usuario realiza el pago podrás obtener los datos usando cualquiera de las siguientes formas:
 
 1. [IPN](https://www.mercadopago.com.mx/developers/es/guides/notifications/ipn/): Cuando el pago es creado, enviamos una notificación vía webhook a la URL configurada en la `notification_url` de la orden, deberás estar suscrito a las notificaciones tipo `merchant_order`.
-2. Hacer la [búsqueda del pago](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get/) utilizando el `external_reference` como criterio de búsqueda.
+2. Hacer la [búsqueda del pago](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get) utilizando el `external_reference` como criterio de búsqueda.
 
 ### Eliminar orden
 

--- a/guides/in-person-payments/qr-code-legacy/qr-pos.pt.md
+++ b/guides/in-person-payments/qr-code-legacy/qr-pos.pt.md
@@ -104,7 +104,7 @@ Além dos conceitos anteriores, também deve conhecer os objetos com que trabalh
 
 - `status_detail`: Informação detalhada sobre o status atual ou motivo da rejeição.
 
-Consultar a [documentação completa](https://www.mercadopago.com.br/developers/pt/reference/payments/resource/) sobre este objeto na nossa referência da API.
+Consultar a [documentação completa](https://www.mercadopago.com.br/developers/pt/reference/payments/resource) sobre este objeto na nossa referência da API.
 
 ## Cobranças
 
@@ -160,7 +160,7 @@ Por exemplo se deseja que esteja disponível por 5 minutos se deve enviar o head
 Depois que o usuário fizer o pagamento, você poderá obter os dados usando qualquer uma das seguintes maneiras:
 
 1. [Webhooks](https://www.mercadopago.com.br/developers/pt/guides/notifications/webhooks/): Quando o pagamento é criado, enviamos uma notificação via webhook para a URL configurada no campo `notification_url` do pedido. 
-2. Fazer [busca do pagamento](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get/) utilizando o `external_reference` como critério de busca.
+2. Fazer [busca do pagamento](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) utilizando o `external_reference` como critério de busca.
 
 ### Eliminar pedido
 

--- a/guides/in-person-payments/qr-code/advanced-integration.en.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.en.md
@@ -32,7 +32,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Obtain more information in our [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
+Obtain more information in our [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 ## Generate reports of your sales
 

--- a/guides/in-person-payments/qr-code/advanced-integration.en.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.en.md
@@ -32,7 +32,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Obtain more information in our [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
+Obtain more information in our [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 ## Generate reports of your sales
 

--- a/guides/in-person-payments/qr-code/advanced-integration.en.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.en.md
@@ -32,7 +32,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Obtain more information in our [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get/).
+Obtain more information in our [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 ## Generate reports of your sales
 

--- a/guides/in-person-payments/qr-code/advanced-integration.en.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.en.md
@@ -32,7 +32,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Obtain more information in our [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
+Obtain more information in our [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 ## Generate reports of your sales
 

--- a/guides/in-person-payments/qr-code/advanced-integration.es.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.es.md
@@ -32,7 +32,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get/).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 
 ## Genera reportes de tus ventas

--- a/guides/in-person-payments/qr-code/advanced-integration.es.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.es.md
@@ -32,7 +32,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 
 ## Genera reportes de tus ventas

--- a/guides/in-person-payments/qr-code/advanced-integration.es.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.es.md
@@ -32,7 +32,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 
 ## Genera reportes de tus ventas

--- a/guides/in-person-payments/qr-code/advanced-integration.es.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.es.md
@@ -32,7 +32,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 
 ## Genera reportes de tus ventas

--- a/guides/in-person-payments/qr-code/advanced-integration.pt.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.pt.md
@@ -31,7 +31,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Pode obter mais informações em [Referências do API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
+Pode obter mais informações em [Referências do API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 
 ## Gere relatórios de suas vendas

--- a/guides/in-person-payments/qr-code/advanced-integration.pt.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.pt.md
@@ -31,7 +31,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Pode obter mais informações em [Referências do API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
+Pode obter mais informações em [Referências do API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 
 ## Gere relatórios de suas vendas

--- a/guides/in-person-payments/qr-code/advanced-integration.pt.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.pt.md
@@ -31,7 +31,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Pode obter mais informações em [Referências do API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get/).
+Pode obter mais informações em [Referências do API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 
 ## Gere relatórios de suas vendas

--- a/guides/in-person-payments/qr-code/advanced-integration.pt.md
+++ b/guides/in-person-payments/qr-code/advanced-integration.pt.md
@@ -31,7 +31,7 @@ curl -X GET \
 -H 'Authorization: Bearer ACCESS_TOKEN' \
 https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/pos/EXTERNAL_POS_ID/orders
 ```
-Pode obter mais informações em [Referências do API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
+Pode obter mais informações em [Referências do API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_pos_external_pos_id_orders/get).
 
 
 ## Gere relatórios de suas vendas

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
@@ -57,7 +57,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
 }
 ```
 
-Obtain more information in our [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
+Obtain more information in our [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Once the order is created, it is available to be **scanned and paid**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
@@ -57,7 +57,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
 }
 ```
 
-Obtain more information in our [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put/).
+Obtain more information in our [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Once the order is created, it is available to be **scanned and paid**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
@@ -57,7 +57,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
 }
 ```
 
-Obtain more information in our [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
+Obtain more information in our [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Once the order is created, it is available to be **scanned and paid**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
@@ -57,7 +57,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
 }
 ```
 
-Obtain more information in our [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
+Obtain more information in our [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Once the order is created, it is available to be **scanned and paid**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
@@ -56,7 +56,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
     }
 }
 ```
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Una vez creada la orden, ya se encuentra disponible para ser **escaneada y pagada**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
@@ -56,7 +56,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
     }
 }
 ```
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Una vez creada la orden, ya se encuentra disponible para ser **escaneada y pagada**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
@@ -56,7 +56,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
     }
 }
 ```
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Una vez creada la orden, ya se encuentra disponible para ser **escaneada y pagada**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
@@ -56,7 +56,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
     }
 }
 ```
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put/).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Una vez creada la orden, ya se encuentra disponible para ser **escaneada y pagada**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
@@ -55,7 +55,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
     }
 }
 ```
-Pode obter mais informações em [Referências do API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
+Pode obter mais informações em [Referências do API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Assim que o pedido for criado, ele estará disponível para ser **digitalizado e pago**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
@@ -55,7 +55,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
     }
 }
 ```
-Pode obter mais informações em [Referências do API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
+Pode obter mais informações em [Referências do API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Assim que o pedido for criado, ele estará disponível para ser **digitalizado e pago**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
@@ -55,7 +55,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
     }
 }
 ```
-Pode obter mais informações em [Referências do API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put/).
+Pode obter mais informações em [Referências do API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Assim que o pedido for criado, ele estará disponível para ser **digitalizado e pago**.
 

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
@@ -55,7 +55,7 @@ https://api.mercadopago.com/instore/qr/seller/collectors/USER_ID/stores/EXTERNAL
     }
 }
 ```
-Pode obter mais informações em [Referências do API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
+Pode obter mais informações em [Referências do API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/instore_orders_v2/_instore_qr_seller_collectors_user_id_stores_external_store_id_pos_external_pos_id_orders/put).
 
 Assim que o pedido for criado, ele estará disponível para ser **digitalizado e pago**.
 

--- a/guides/in-person-payments/qr-code/stores-pos.en.md
+++ b/guides/in-person-payments/qr-code/stores-pos.en.md
@@ -75,7 +75,7 @@ https://api.mercadopago.com/users/$USER_ID/stores \
 ```
 ]]]
 
-Learn more with our [API reference](https://www.mercadopago.com.ar/developers/en/reference/stores/_users_user_id_stores/post/).
+Learn more with our [API reference](https://www.mercadopago.com.ar/developers/en/reference/stores/_users_user_id_stores/post).
 
 > WARNING
 >
@@ -116,7 +116,7 @@ https://api.mercadopago.com/pos \
 ```
 ]]]
 
-Learn more with our [API Reference](https://www.mercadopago.com.ar/developers/en/reference/pos/_pos/post/).
+Learn more with our [API Reference](https://www.mercadopago.com.ar/developers/en/reference/pos/_pos/post).
 
 Once Point of Sale is created, you’ll be able to see the QR files in the _Response_ section, along with other relevant data. 
 

--- a/guides/in-person-payments/qr-code/stores-pos.es.md
+++ b/guides/in-person-payments/qr-code/stores-pos.es.md
@@ -76,7 +76,7 @@ https://api.mercadopago.com/users/$USER_ID/stores \
 ```
 ]]]
 
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago.com.ar/developers/es/reference/stores/_users_user_id_stores/post/).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago.com.ar/developers/es/reference/stores/_users_user_id_stores/post).
 
 > WARNING
 > 
@@ -116,7 +116,7 @@ https://api.mercadopago.com/pos \
 ```
 ]]]
 
-Puedes obtener más información en la [Referencias de API](https://www.mercadopago.com.ar/developers/es/reference/pos/_pos/post/).
+Puedes obtener más información en la [Referencias de API](https://www.mercadopago.com.ar/developers/es/reference/pos/_pos/post).
 
 Una vez creada la caja, podremos ver en el _Response_ los links a distintos entregables del QR, junto con otros datos relevantes de la caja. 
 

--- a/guides/in-person-payments/qr-code/stores-pos.pt.md
+++ b/guides/in-person-payments/qr-code/stores-pos.pt.md
@@ -75,7 +75,7 @@ https://api.mercadopago.com/users/$USER_ID/stores \
 ```
 ]]]
 
-Você pode obter mais informações nas [Referências de API](https://www.mercadopago.com.br/developers/pt/reference/stores/_users_user_id_stores/post/).
+Você pode obter mais informações nas [Referências de API](https://www.mercadopago.com.br/developers/pt/reference/stores/_users_user_id_stores/post).
 
 > WARNING
 >
@@ -116,7 +116,7 @@ https://api.mercadopago.com/pos \
 ```
 ]]]
 
-Você pode obter mais informações em [Referências de API](https://www.mercadopago.com.br/developers/pt/reference/pos/_pos/post/).
+Você pode obter mais informações em [Referências de API](https://www.mercadopago.com.br/developers/pt/reference/pos/_pos/post).
 
 Uma vez criado o caixa, poderemos ver no _Response_ os links para diferentes entregáveis do QR, junto com outros dados relevantes do caixa. 
 

--- a/guides/manage-account/account/chargebacks.en.md
+++ b/guides/manage-account/account/chargebacks.en.md
@@ -55,7 +55,7 @@ Send the payment voucher by e-mail or sms so that your customer remembers what t
 ### Detail all payment data
 
 For enhanced validation of payment security, send us as much information as possible when creating the payment.  For example, if you send us information about the buyer, we can detect if that buyer made any suspicious payment some other time and prevent it.
-Find more information about each attribute in [API References](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments/post/).
+Find more information about each attribute in [API References](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments/post).
 
 ### Return suspicious payments
 
@@ -114,7 +114,7 @@ You will get the following information:
 >
 > Nota
 >
-> Find more information in [API References](https://www.mercadopago.com.ar/developers/es/reference/chargebacks/_chargebacks_id/get/).
+> Find more information in [API References](https://www.mercadopago.com.ar/developers/es/reference/chargebacks/_chargebacks_id/get).
 
 ### Understanding coverage
 

--- a/guides/manage-account/account/chargebacks.es.md
+++ b/guides/manage-account/account/chargebacks.es.md
@@ -55,7 +55,7 @@ Es importante que mandes el comprobante del pago por e-mail o por mensaje de tex
 ### Detalla toda la información sobre el pago
 
 Para optimizar la validación de seguridad de los pagos, envíanos la mayor cantidad de datos posibles al momento de crear el pago. Por ejemplo, si nos envías datos del comprador, podemos detectar si realizó pagos sospechosos en otro momento y prevenirlo.
-Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments/post/).
+Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments/post).
 
 ### Devuelve los pagos sospechosos
 
@@ -114,7 +114,7 @@ Vas a obtener la siguiente información:
 >
 > Nota
 >
-> Puedes obtener más información en la [referencia de API](https://www.mercadopago.com.ar/developers/es/reference/chargebacks/_chargebacks_id/get/).
+> Puedes obtener más información en la [referencia de API](https://www.mercadopago.com.ar/developers/es/reference/chargebacks/_chargebacks_id/get).
 
 ### Entendimiento de cobertura
 

--- a/guides/manage-account/account/chargebacks.pt.md
+++ b/guides/manage-account/account/chargebacks.pt.md
@@ -55,7 +55,7 @@ Vamos te ajudar a detectar comportamentos incomuns dos clientes com o nosso cód
 ### Detalhe toda a informação sobre o pagamento
 
 Para otimizar a validação de segurança dos pagamentos, encaminhe para nós a maior quantidade de dados possíveis no momento de criar o pagamento. Por exemplo, se você encaminhar para nós os dados do comprador, podemos detectar se realizou pagamentos suspeitos em outro momento e alertá-lo sobre isso.
-Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments/post/).
+Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments/post).
 
 ### Faça a devolução de pagamentos suspeitos
 
@@ -114,7 +114,7 @@ Você vai obter as seguintes informações:
 >
 > Nota
 >
-> Você pode obter mais informações nas [Referências de API](https://www.mercadopago.com.ar/developers/es/reference/chargebacks/_chargebacks_id/get/).
+> Você pode obter mais informações nas [Referências de API](https://www.mercadopago.com.ar/developers/es/reference/chargebacks/_chargebacks_id/get).
 
 ### Compreensão de cobertura
 

--- a/guides/manage-account/account/payment-rejections.en.md
+++ b/guides/manage-account/account/payment-rejections.en.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Learn all about these attributes in our [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments/post).
+Learn all about these attributes in our [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ### Industry Data
 

--- a/guides/manage-account/account/payment-rejections.en.md
+++ b/guides/manage-account/account/payment-rejections.en.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Learn all about these attributes in our [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post/).
+Learn all about these attributes in our [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ### Industry Data
 

--- a/guides/manage-account/account/payment-rejections.en.md
+++ b/guides/manage-account/account/payment-rejections.en.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Learn all about these attributes in our [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
+Learn all about these attributes in our [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ### Industry Data
 

--- a/guides/manage-account/account/payment-rejections.en.md
+++ b/guides/manage-account/account/payment-rejections.en.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Learn all about these attributes in our [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
+Learn all about these attributes in our [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ### Industry Data
 

--- a/guides/manage-account/account/payment-rejections.es.md
+++ b/guides/manage-account/account/payment-rejections.es.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ### Datos de industria
 

--- a/guides/manage-account/account/payment-rejections.es.md
+++ b/guides/manage-account/account/payment-rejections.es.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ### Datos de industria
 

--- a/guides/manage-account/account/payment-rejections.es.md
+++ b/guides/manage-account/account/payment-rejections.es.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post/).
+Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ### Datos de industria
 

--- a/guides/manage-account/account/payment-rejections.es.md
+++ b/guides/manage-account/account/payment-rejections.es.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+Puedes obtener más información sobre cada atributo en las [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ### Datos de industria
 

--- a/guides/manage-account/account/payment-rejections.pt.md
+++ b/guides/manage-account/account/payment-rejections.pt.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ### Dados de indústria
 

--- a/guides/manage-account/account/payment-rejections.pt.md
+++ b/guides/manage-account/account/payment-rejections.pt.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ### Dados de indústria
 

--- a/guides/manage-account/account/payment-rejections.pt.md
+++ b/guides/manage-account/account/payment-rejections.pt.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post/).
+Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ### Dados de indústria
 

--- a/guides/manage-account/account/payment-rejections.pt.md
+++ b/guides/manage-account/account/payment-rejections.pt.md
@@ -288,7 +288,7 @@ preference.Items.Add(
 ```
 ]]]
 
-Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+Você pode obter mais informações sobre cada atributo nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ### Dados de indústria
 

--- a/guides/manage-account/account/retrieving-payments.es.md
+++ b/guides/manage-account/account/retrieving-payments.es.md
@@ -47,7 +47,7 @@ Respuesta esperada:
 }
 ```
 
-Puedes obtener información sobre todos las variables devueltas en la [referencia de la API del recurso Payments](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get/).
+Puedes obtener información sobre todos las variables devueltas en la [referencia de la API del recurso Payments](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get).
 
 ## Buscar pagos
 

--- a/guides/manage-account/account/retrieving-payments.pt.md
+++ b/guides/manage-account/account/retrieving-payments.pt.md
@@ -47,7 +47,7 @@ Resposta esperada:
 }
 ```
 
-As informações sobre todas as variáveis retornadas podem ser obtidas na [referência da API do recurso Payments](https://www.mercadopago.com.ar/developers/pt/reference/payments/_payments_id/get/).
+As informações sobre todas as variáveis retornadas podem ser obtidas na [referência da API do recurso Payments](https://www.mercadopago.com.ar/developers/pt/reference/payments/_payments_id/get).
 
 ## Buscar pagamentos
 

--- a/guides/notifications/ipn.en.md
+++ b/guides/notifications/ipn.en.md
@@ -47,9 +47,9 @@ After that, you will be able to get full information about the notified resource
 
 | Type | URL | Documentation |
 | --- | --- | --- |
-| payment | /v1/payments/[ID] | [see documentation](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_id/get/) |
+| payment | /v1/payments/[ID] | [see documentation](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_id/get) |
 | chargebacks | /v1/chargebacks/[ID]| - |
-| merchant_orders | /merchant\_orders/[ID] | [see documentation](https://www.mercadopago.com.ar/developers/en/reference/merchant_orders/_merchant_orders_id/get/) |
+| merchant_orders | /merchant\_orders/[ID] | [see documentation](https://www.mercadopago.com.ar/developers/en/reference/merchant_orders/_merchant_orders_id/get) |
 
 With this information you can make the necessary updates on your platform, such as registering an approved payment or a closed order.
 
@@ -132,7 +132,7 @@ curl -X GET \
     https://api.mercadopago.com/merchant_orders?external_reference=$EXTERNAL_REFERENCE
 ```
 
-Find more information in [API Reference](https://www.mercadopago.com.ar/developers/en/reference/merchant_orders/_merchant_orders_search/get/).
+Find more information in [API Reference](https://www.mercadopago.com.ar/developers/en/reference/merchant_orders/_merchant_orders_search/get).
 
 There are two ways to implement **search** by `external_reference`:
 

--- a/guides/notifications/ipn.es.md
+++ b/guides/notifications/ipn.es.md
@@ -49,9 +49,9 @@ Luego de esto, puedes obtener la información completa del recurso notificado ac
 
 | Tipo | URL | Documentación |
 | --- | --- | --- |
-| payment | /v1/payments/[ID] | [ver documentación](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
+| payment | /v1/payments/[ID] | [ver documentación](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
 | chargebacks | /v1/chargebacks/[ID] | - |
-| merchant_orders | /merchant\_orders/[ID] | [ver documentación](https://www.mercadopago.com.ar/developers/es/reference/merchant_orders/_merchant_orders_id/get) |
+| merchant_orders | /merchant\_orders/[ID] | [ver documentación](https://www.mercadopago.com.ar/developers/es/reference/merchant_orders/_merchant_orders_idget) |
 
 Con esta información puedes realizar las actualizaciones necesarias en tu plataforma, por ejemplo registrar un pago acreditado o una orden cerrada. 
 
@@ -130,7 +130,7 @@ curl -X GET \
     https://api.mercadopago.com/merchant_orders?external_reference=$EXTERNAL_REFERENCE
 ```
 
-Más información en la [Referencia de API](https://www.mercadopago.com.ar/developers/es/reference/merchant_orders/_merchant_orders_search/get/).
+Más información en la [Referencia de API](https://www.mercadopago.com.ar/developers/es/reference/merchant_orders/_merchant_orders_search/get).
 
 Se puede implementar la **búsqueda** por `external_reference` de dos formas:
 

--- a/guides/notifications/ipn.es.md
+++ b/guides/notifications/ipn.es.md
@@ -49,9 +49,9 @@ Luego de esto, puedes obtener la información completa del recurso notificado ac
 
 | Tipo | URL | Documentación |
 | --- | --- | --- |
-| payment | /v1/payments/[ID] | [ver documentación](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
+| payment | /v1/payments/[ID] | [ver documentación](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
 | chargebacks | /v1/chargebacks/[ID] | - |
-| merchant_orders | /merchant\_orders/[ID] | [ver documentación](https://www.mercadopago.com.ar/developers/es/reference/merchant_orders/_merchant_orders_idget) |
+| merchant_orders | /merchant\_orders/[ID] | [ver documentación](https://www.mercadopago.com.ar/developers/es/reference/merchant_orders/_merchant_orders_id/get) |
 
 Con esta información puedes realizar las actualizaciones necesarias en tu plataforma, por ejemplo registrar un pago acreditado o una orden cerrada. 
 

--- a/guides/notifications/ipn.pt.md
+++ b/guides/notifications/ipn.pt.md
@@ -45,9 +45,9 @@ Depois disso, você poderá obter a informação completa do recurso notificado 
 
 | Tipo | URL | Documentação |
 | --- | --- | --- |
-| payment | /v1/payments/[ID] | [ver documentação](https://www.mercadopago.com.ar/developers/pt/reference/payments/_payments_id/get/) |
+| payment | /v1/payments/[ID] | [ver documentação](https://www.mercadopago.com.ar/developers/pt/reference/payments/_payments_id/get) |
 | chargebacks | /v1/chargebacks/[ID]| - |
-| merchant_orders | /merchant\_orders/[ID] | [ver documentação](https://www.mercadopago.com.ar/developers/pt/reference/merchant_orders/_merchant_orders_id/get/) |
+| merchant_orders | /merchant\_orders/[ID] | [ver documentação](https://www.mercadopago.com.ar/developers/pt/reference/merchant_orders/_merchant_orders_id/get) |
 
 
 Com essas informações, você poderá realizar as atualizações necessárias na sua plataforma, por exemplo: atualizar um pagamento aprovado o un pedido fechado.
@@ -128,7 +128,7 @@ curl -X GET \
     -H 'Authorization: Bearer $ACCESS_TOKEN' \
     https://api.mercadopago.com/merchant_orders?external_reference=$EXTERNAL_REFERENCE
 ```
-Mais informações na [Referência de API](https://www.mercadopago.com.br/developers/pt/reference/merchant_orders/_merchant_orders_search/get/).
+Mais informações na [Referência de API](https://www.mercadopago.com.br/developers/pt/reference/merchant_orders/_merchant_orders_search/get).
 
 A **pesquisa** pode ser realizada por `external_reference` de duas formas:
 

--- a/guides/notifications/webhooks.en.md
+++ b/guides/notifications/webhooks.en.md
@@ -86,7 +86,7 @@ After this, you must obtain the complete information of the notified resource by
 
 | Type | URL | Documentation |
 | --- | --- | --- |
-| payment | https://api.mercadopago.com/v1/payments/[ID] | [see documentation](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_id/get/) |
+| payment | https://api.mercadopago.com/v1/payments/[ID] | [see documentation](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments_id/get) |
 | plan | https://api.mercadopago.com/v1/plans/[ID] | - |
 | subscription | https://api.mercadopago.com/v1/subscriptions/[ID] | - |
 | invoice | https://api.mercadopago.com/v1/invoices/[ID] | - |

--- a/guides/notifications/webhooks.es.md
+++ b/guides/notifications/webhooks.es.md
@@ -83,7 +83,7 @@ Luego de esto, tienes que obtener la información completa del recurso notificad
 
 | Tipo | URL | Documentación |
 | --- | --- | --- |
-| payment | https://api.mercadopago.com/v1/payments/[ID] | [Ver documentación](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get/) |
+| payment | https://api.mercadopago.com/v1/payments/[ID] | [Ver documentación](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
 | plan | https://api.mercadopago.com/v1/plans/[ID] | - |
 | subscription | https://api.mercadopago.com/v1/subscriptions/[ID] | - |
 | invoice | https://api.mercadopago.com/v1/invoices/[ID] | - |

--- a/guides/notifications/webhooks.pt.md
+++ b/guides/notifications/webhooks.pt.md
@@ -86,7 +86,7 @@ Depois disso, você deve obter as informações completas do recurso notificado 
 
 | Tipo | URL | Documentação |
 | --- | --- | --- |
-| payment | https://api.mercadopago.com/v1/payments/[ID] | [ver documentação](https://www.mercadopago.com.ar/developers/pt/reference/payments/_payments_id/get/) |
+| payment | https://api.mercadopago.com/v1/payments/[ID] | [ver documentação](https://www.mercadopago.com.ar/developers/pt/reference/payments/_payments_id/get) |
 | plan | https://api.mercadopago.com/v1/plans/[ID] | - |
 | subscription | https://api.mercadopago.com/v1/subscriptions/[ID] | - |
 | invoice | https://api.mercadopago.com/v1/invoices/[ID] | - |

--- a/guides/online-payments/checkout-api/advanced-integration.en.md
+++ b/guides/online-payments/checkout-api/advanced-integration.en.md
@@ -699,4 +699,4 @@ For more information, check the [Refunds and Cancellations section](https://www.
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/)
+> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.en.md
+++ b/guides/online-payments/checkout-api/advanced-integration.en.md
@@ -699,4 +699,4 @@ For more information, check the [Refunds and Cancellations section](https://www.
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.en.md
+++ b/guides/online-payments/checkout-api/advanced-integration.en.md
@@ -699,4 +699,4 @@ For more information, check the [Refunds and Cancellations section](https://www.
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.en.md
+++ b/guides/online-payments/checkout-api/advanced-integration.en.md
@@ -699,4 +699,4 @@ For more information, check the [Refunds and Cancellations section](https://www.
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.es.md
+++ b/guides/online-payments/checkout-api/advanced-integration.es.md
@@ -699,4 +699,4 @@ Puedes encontrar toda la información en la [sección Devoluciones y cancelacion
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.es.md
+++ b/guides/online-payments/checkout-api/advanced-integration.es.md
@@ -699,4 +699,4 @@ Puedes encontrar toda la información en la [sección Devoluciones y cancelacion
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.es.md
+++ b/guides/online-payments/checkout-api/advanced-integration.es.md
@@ -699,4 +699,4 @@ Puedes encontrar toda la información en la [sección Devoluciones y cancelacion
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.es.md
+++ b/guides/online-payments/checkout-api/advanced-integration.es.md
@@ -699,4 +699,4 @@ Puedes encontrar toda la información en la [sección Devoluciones y cancelacion
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.pt.md
+++ b/guides/online-payments/checkout-api/advanced-integration.pt.md
@@ -700,4 +700,4 @@ Encontre mais informações na [seção de Devoluções e cancelamentos](https:/
 >
 > Encontre toda informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/)
+> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.pt.md
+++ b/guides/online-payments/checkout-api/advanced-integration.pt.md
@@ -700,4 +700,4 @@ Encontre mais informações na [seção de Devoluções e cancelamentos](https:/
 >
 > Encontre toda informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.pt.md
+++ b/guides/online-payments/checkout-api/advanced-integration.pt.md
@@ -700,4 +700,4 @@ Encontre mais informações na [seção de Devoluções e cancelamentos](https:/
 >
 > Encontre toda informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/advanced-integration.pt.md
+++ b/guides/online-payments/checkout-api/advanced-integration.pt.md
@@ -700,4 +700,4 @@ Encontre mais informações na [seção de Devoluções e cancelamentos](https:/
 >
 > Encontre toda informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/goto-production.en.md
+++ b/guides/online-payments/checkout-api/goto-production.en.md
@@ -76,4 +76,4 @@ You need to have a policy on terms and conditions and make it clear that you are
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/goto-production.en.md
+++ b/guides/online-payments/checkout-api/goto-production.en.md
@@ -76,4 +76,4 @@ You need to have a policy on terms and conditions and make it clear that you are
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/)
+> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/goto-production.en.md
+++ b/guides/online-payments/checkout-api/goto-production.en.md
@@ -76,4 +76,4 @@ You need to have a policy on terms and conditions and make it clear that you are
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/goto-production.en.md
+++ b/guides/online-payments/checkout-api/goto-production.en.md
@@ -76,4 +76,4 @@ You need to have a policy on terms and conditions and make it clear that you are
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/goto-production.es.md
+++ b/guides/online-payments/checkout-api/goto-production.es.md
@@ -76,4 +76,4 @@ Debes disponer de una política de términos y condiciones y aclarar que sos res
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/goto-production.es.md
+++ b/guides/online-payments/checkout-api/goto-production.es.md
@@ -76,4 +76,4 @@ Debes disponer de una política de términos y condiciones y aclarar que sos res
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/goto-production.es.md
+++ b/guides/online-payments/checkout-api/goto-production.es.md
@@ -76,4 +76,4 @@ Debes disponer de una política de términos y condiciones y aclarar que sos res
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/goto-production.es.md
+++ b/guides/online-payments/checkout-api/goto-production.es.md
@@ -76,4 +76,4 @@ Debes disponer de una política de términos y condiciones y aclarar que sos res
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/goto-production.pt.md
+++ b/guides/online-payments/checkout-api/goto-production.pt.md
@@ -74,4 +74,4 @@ Disponibilize uma política de termos e condições e deixe claro que é respons
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/goto-production.pt.md
+++ b/guides/online-payments/checkout-api/goto-production.pt.md
@@ -74,4 +74,4 @@ Disponibilize uma política de termos e condições e deixe claro que é respons
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/goto-production.pt.md
+++ b/guides/online-payments/checkout-api/goto-production.pt.md
@@ -74,4 +74,4 @@ Disponibilize uma política de termos e condições e deixe claro que é respons
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/)
+> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/goto-production.pt.md
+++ b/guides/online-payments/checkout-api/goto-production.pt.md
@@ -74,4 +74,4 @@ Disponibilize uma política de termos e condições e deixe claro que é respons
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.en.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.en.md
@@ -157,4 +157,4 @@ Now, **you just need to initialize our CardForm. Link the ID of each form field 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/)
+> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.en.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.en.md
@@ -157,4 +157,4 @@ Now, **you just need to initialize our CardForm. Link the ID of each form field 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.en.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.en.md
@@ -157,4 +157,4 @@ Now, **you just need to initialize our CardForm. Link the ID of each form field 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.en.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.en.md
@@ -157,4 +157,4 @@ Now, **you just need to initialize our CardForm. Link the ID of each form field 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.es.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.es.md
@@ -171,4 +171,4 @@ Ahora, **solo debes inicializar nuestro CardForm relacionando el ID de cada camp
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.es.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.es.md
@@ -171,4 +171,4 @@ Ahora, **solo debes inicializar nuestro CardForm relacionando el ID de cada camp
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.es.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.es.md
@@ -171,4 +171,4 @@ Ahora, **solo debes inicializar nuestro CardForm relacionando el ID de cada camp
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.es.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.es.md
@@ -171,4 +171,4 @@ Ahora, **solo debes inicializar nuestro CardForm relacionando el ID de cada camp
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.pt.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.pt.md
@@ -171,4 +171,4 @@ Agora, **você apenas deve inicializar nosso CardForm relacionando o ID de cada 
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.pt.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.pt.md
@@ -171,4 +171,4 @@ Agora, **você apenas deve inicializar nosso CardForm relacionando o ID de cada 
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.pt.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.pt.md
@@ -171,4 +171,4 @@ Agora, **você apenas deve inicializar nosso CardForm relacionando o ID de cada 
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/guide-mercadopagojs-v2.pt.md
+++ b/guides/online-payments/checkout-api/guide-mercadopagojs-v2.pt.md
@@ -171,4 +171,4 @@ Agora, **você apenas deve inicializar nosso CardForm relacionando o ID de cada 
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/handling-responses.en.md
+++ b/guides/online-payments/checkout-api/handling-responses.en.md
@@ -8,7 +8,7 @@ For example, if the card has insufficient balance, you can suggest trying again 
 >
 > Note
 >
-> To get more information about the possible errors, view the [API reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+> To get more information about the possible errors, view the [API reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 ## Collection creation results
 
@@ -94,4 +94,4 @@ For example, if the card has insufficient balance, you can suggest trying again 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/handling-responses.en.md
+++ b/guides/online-payments/checkout-api/handling-responses.en.md
@@ -8,7 +8,7 @@ For example, if the card has insufficient balance, you can suggest trying again 
 >
 > Note
 >
-> To get more information about the possible errors, view the [API reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+> To get more information about the possible errors, view the [API reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 ## Collection creation results
 
@@ -94,4 +94,4 @@ For example, if the card has insufficient balance, you can suggest trying again 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/handling-responses.en.md
+++ b/guides/online-payments/checkout-api/handling-responses.en.md
@@ -8,7 +8,7 @@ For example, if the card has insufficient balance, you can suggest trying again 
 >
 > Note
 >
-> To get more information about the possible errors, view the [API reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+> To get more information about the possible errors, view the [API reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 ## Collection creation results
 
@@ -94,4 +94,4 @@ For example, if the card has insufficient balance, you can suggest trying again 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/)
+> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/handling-responses.en.md
+++ b/guides/online-payments/checkout-api/handling-responses.en.md
@@ -8,7 +8,7 @@ For example, if the card has insufficient balance, you can suggest trying again 
 >
 > Note
 >
-> To get more information about the possible errors, view the [API reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+> To get more information about the possible errors, view the [API reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 ## Collection creation results
 
@@ -94,4 +94,4 @@ For example, if the card has insufficient balance, you can suggest trying again 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/handling-responses.es.md
+++ b/guides/online-payments/checkout-api/handling-responses.es.md
@@ -8,7 +8,7 @@ Por ejemplo, si la tarjeta no tiene saldo suficiente para la compra, puedes reco
 >
 > Nota
 >
-> Para conocer información sobre los posibles errores, consulta la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+> Para conocer información sobre los posibles errores, consulta la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 ## Resultados de creación de un cobro
 
@@ -94,4 +94,4 @@ Por ejemplo, si la tarjeta no tiene saldo suficiente para la compra, puedes reco
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/handling-responses.es.md
+++ b/guides/online-payments/checkout-api/handling-responses.es.md
@@ -8,7 +8,7 @@ Por ejemplo, si la tarjeta no tiene saldo suficiente para la compra, puedes reco
 >
 > Nota
 >
-> Para conocer información sobre los posibles errores, consulta la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+> Para conocer información sobre los posibles errores, consulta la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 ## Resultados de creación de un cobro
 
@@ -94,4 +94,4 @@ Por ejemplo, si la tarjeta no tiene saldo suficiente para la compra, puedes reco
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/handling-responses.es.md
+++ b/guides/online-payments/checkout-api/handling-responses.es.md
@@ -8,7 +8,7 @@ Por ejemplo, si la tarjeta no tiene saldo suficiente para la compra, puedes reco
 >
 > Nota
 >
-> Para conocer información sobre los posibles errores, consulta la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+> Para conocer información sobre los posibles errores, consulta la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 ## Resultados de creación de un cobro
 
@@ -94,4 +94,4 @@ Por ejemplo, si la tarjeta no tiene saldo suficiente para la compra, puedes reco
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/handling-responses.es.md
+++ b/guides/online-payments/checkout-api/handling-responses.es.md
@@ -8,7 +8,7 @@ Por ejemplo, si la tarjeta no tiene saldo suficiente para la compra, puedes reco
 >
 > Nota
 >
-> Para conocer información sobre los posibles errores, consulta la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+> Para conocer información sobre los posibles errores, consulta la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 ## Resultados de creación de un cobro
 
@@ -94,4 +94,4 @@ Por ejemplo, si la tarjeta no tiene saldo suficiente para la compra, puedes reco
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/handling-responses.pt.md
+++ b/guides/online-payments/checkout-api/handling-responses.pt.md
@@ -8,7 +8,7 @@ Por exemplo, se o cartão não possui saldo suficiente para a compra, pode-se re
 >
 > Nota
 >
-> Para saber mais sobre os possíveis erros, confira a [Referência de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+> Para saber mais sobre os possíveis erros, confira a [Referência de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 ## Resultados da criação de uma cobrança
 
@@ -93,4 +93,4 @@ Por exemplo, se o cartão não possui saldo suficiente para a compra, pode-se re
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/)
+> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/handling-responses.pt.md
+++ b/guides/online-payments/checkout-api/handling-responses.pt.md
@@ -8,7 +8,7 @@ Por exemplo, se o cartão não possui saldo suficiente para a compra, pode-se re
 >
 > Nota
 >
-> Para saber mais sobre os possíveis erros, confira a [Referência de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+> Para saber mais sobre os possíveis erros, confira a [Referência de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 ## Resultados da criação de uma cobrança
 
@@ -93,4 +93,4 @@ Por exemplo, se o cartão não possui saldo suficiente para a compra, pode-se re
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/handling-responses.pt.md
+++ b/guides/online-payments/checkout-api/handling-responses.pt.md
@@ -8,7 +8,7 @@ Por exemplo, se o cartão não possui saldo suficiente para a compra, pode-se re
 >
 > Nota
 >
-> Para saber mais sobre os possíveis erros, confira a [Referência de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+> Para saber mais sobre os possíveis erros, confira a [Referência de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 ## Resultados da criação de uma cobrança
 
@@ -93,4 +93,4 @@ Por exemplo, se o cartão não possui saldo suficiente para a compra, pode-se re
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/handling-responses.pt.md
+++ b/guides/online-payments/checkout-api/handling-responses.pt.md
@@ -8,7 +8,7 @@ Por exemplo, se o cartão não possui saldo suficiente para a compra, pode-se re
 >
 > Nota
 >
-> Para saber mais sobre os possíveis erros, confira a [Referência de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+> Para saber mais sobre os possíveis erros, confira a [Referência de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 ## Resultados da criação de uma cobrança
 
@@ -93,4 +93,4 @@ Por exemplo, se o cartão não possui saldo suficiente para a compra, pode-se re
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/introduction.en.md
+++ b/guides/online-payments/checkout-api/introduction.en.md
@@ -36,4 +36,4 @@ You can use the official SDKs or interact directly with our APIs.
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/)
+> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/introduction.en.md
+++ b/guides/online-payments/checkout-api/introduction.en.md
@@ -36,4 +36,4 @@ You can use the official SDKs or interact directly with our APIs.
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/introduction.en.md
+++ b/guides/online-payments/checkout-api/introduction.en.md
@@ -36,4 +36,4 @@ You can use the official SDKs or interact directly with our APIs.
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/introduction.en.md
+++ b/guides/online-payments/checkout-api/introduction.en.md
@@ -36,4 +36,4 @@ You can use the official SDKs or interact directly with our APIs.
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/introduction.es.md
+++ b/guides/online-payments/checkout-api/introduction.es.md
@@ -40,4 +40,4 @@ Puedes usar las SDKs oficiales o interactuar directamente con nuestras APIs.
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/introduction.es.md
+++ b/guides/online-payments/checkout-api/introduction.es.md
@@ -40,4 +40,4 @@ Puedes usar las SDKs oficiales o interactuar directamente con nuestras APIs.
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/introduction.es.md
+++ b/guides/online-payments/checkout-api/introduction.es.md
@@ -40,4 +40,4 @@ Puedes usar las SDKs oficiales o interactuar directamente con nuestras APIs.
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/introduction.es.md
+++ b/guides/online-payments/checkout-api/introduction.es.md
@@ -40,4 +40,4 @@ Puedes usar las SDKs oficiales o interactuar directamente con nuestras APIs.
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/introduction.pt.md
+++ b/guides/online-payments/checkout-api/introduction.pt.md
@@ -40,4 +40,4 @@ Use nossos SDKs oficiais ou interaja diretamente com nossas APIs.
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/introduction.pt.md
+++ b/guides/online-payments/checkout-api/introduction.pt.md
@@ -40,4 +40,4 @@ Use nossos SDKs oficiais ou interaja diretamente com nossas APIs.
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/introduction.pt.md
+++ b/guides/online-payments/checkout-api/introduction.pt.md
@@ -40,4 +40,4 @@ Use nossos SDKs oficiais ou interaja diretamente com nossas APIs.
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/introduction.pt.md
+++ b/guides/online-payments/checkout-api/introduction.pt.md
@@ -40,4 +40,4 @@ Use nossos SDKs oficiais ou interaja diretamente com nossas APIs.
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/other-features.en.md
+++ b/guides/online-payments/checkout-api/other-features.en.md
@@ -389,4 +389,4 @@ curl -X PUT \
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/)
+> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/other-features.en.md
+++ b/guides/online-payments/checkout-api/other-features.en.md
@@ -389,4 +389,4 @@ curl -X PUT \
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/other-features.en.md
+++ b/guides/online-payments/checkout-api/other-features.en.md
@@ -389,4 +389,4 @@ curl -X PUT \
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/other-features.en.md
+++ b/guides/online-payments/checkout-api/other-features.en.md
@@ -389,4 +389,4 @@ curl -X PUT \
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/other-features.es.md
+++ b/guides/online-payments/checkout-api/other-features.es.md
@@ -389,4 +389,4 @@ curl -X PUT \
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/other-features.es.md
+++ b/guides/online-payments/checkout-api/other-features.es.md
@@ -389,4 +389,4 @@ curl -X PUT \
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/other-features.es.md
+++ b/guides/online-payments/checkout-api/other-features.es.md
@@ -389,4 +389,4 @@ curl -X PUT \
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/other-features.es.md
+++ b/guides/online-payments/checkout-api/other-features.es.md
@@ -389,4 +389,4 @@ curl -X PUT \
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/other-features.pt.md
+++ b/guides/online-payments/checkout-api/other-features.pt.md
@@ -390,4 +390,4 @@ curl -X PUT \
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/other-features.pt.md
+++ b/guides/online-payments/checkout-api/other-features.pt.md
@@ -390,4 +390,4 @@ curl -X PUT \
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/other-features.pt.md
+++ b/guides/online-payments/checkout-api/other-features.pt.md
@@ -390,4 +390,4 @@ curl -X PUT \
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/other-features.pt.md
+++ b/guides/online-payments/checkout-api/other-features.pt.md
@@ -390,4 +390,4 @@ curl -X PUT \
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/other-payment-ways.en.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.en.md
@@ -115,7 +115,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -629,7 +629,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -1017,7 +1017,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -1421,7 +1421,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2023,7 +2023,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2550,7 +2550,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2927,7 +2927,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.en.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.en.md
@@ -115,7 +115,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -629,7 +629,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -1017,7 +1017,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -1421,7 +1421,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2023,7 +2023,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2550,7 +2550,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2927,7 +2927,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.en.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.en.md
@@ -115,7 +115,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -629,7 +629,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -1017,7 +1017,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -1421,7 +1421,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2023,7 +2023,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2550,7 +2550,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2927,7 +2927,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.en.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.en.md
@@ -115,7 +115,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -629,7 +629,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -1017,7 +1017,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -1421,7 +1421,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2023,7 +2023,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2550,7 +2550,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>
@@ -2927,7 +2927,7 @@ Keep in mind that the answer will return all the payments methods. For this reas
 ]
 ```
 
-> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.es.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.es.md
@@ -119,7 +119,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -634,7 +634,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -1023,7 +1023,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -1429,7 +1429,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2032,7 +2032,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2560,7 +2560,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2939,7 +2939,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.es.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.es.md
@@ -119,7 +119,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -634,7 +634,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -1023,7 +1023,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -1429,7 +1429,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2032,7 +2032,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2560,7 +2560,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2939,7 +2939,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.es.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.es.md
@@ -119,7 +119,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -634,7 +634,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -1023,7 +1023,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -1429,7 +1429,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2032,7 +2032,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2560,7 +2560,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2939,7 +2939,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.es.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.es.md
@@ -119,7 +119,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -634,7 +634,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -1023,7 +1023,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -1429,7 +1429,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2032,7 +2032,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2560,7 +2560,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>
@@ -2939,7 +2939,7 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
 ]
 ```
 
-> Puedes obtener más información en la [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+> Puedes obtener más información en la [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.pt.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.pt.md
@@ -120,7 +120,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -632,7 +632,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -1022,7 +1022,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -1425,7 +1425,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2027,7 +2027,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2555,7 +2555,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2932,7 +2932,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.pt.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.pt.md
@@ -120,7 +120,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -632,7 +632,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -1022,7 +1022,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -1425,7 +1425,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2027,7 +2027,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2555,7 +2555,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2932,7 +2932,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.pt.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.pt.md
@@ -120,7 +120,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -632,7 +632,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -1022,7 +1022,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -1425,7 +1425,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2027,7 +2027,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2555,7 +2555,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2932,7 +2932,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/other-payment-ways.pt.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.pt.md
@@ -120,7 +120,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -632,7 +632,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -1022,7 +1022,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -1425,7 +1425,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2027,7 +2027,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2555,7 +2555,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>
@@ -2932,7 +2932,7 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
 ]
 ```
 
-> Obtenha mais informação nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informação nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 <br>
 <span></span>

--- a/guides/online-payments/checkout-api/previous-requirements.en.md
+++ b/guides/online-payments/checkout-api/previous-requirements.en.md
@@ -88,7 +88,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Learn our API References
 
-If you can't use our official SDKs, you will have all the information about data queries and responses available to interact directly with our APIs in [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post/).
+If you can't use our official SDKs, you will have all the information about data queries and responses available to interact directly with our APIs in [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ## Meet the requirements for the production environment
 
@@ -115,4 +115,4 @@ Once your integration is ready, you just need to fill out the form for to go to 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/)
+> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.en.md
+++ b/guides/online-payments/checkout-api/previous-requirements.en.md
@@ -88,7 +88,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Learn our API References
 
-If you can't use our official SDKs, you will have all the information about data queries and responses available to interact directly with our APIs in [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments/post).
+If you can't use our official SDKs, you will have all the information about data queries and responses available to interact directly with our APIs in [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ## Meet the requirements for the production environment
 
@@ -115,4 +115,4 @@ Once your integration is ready, you just need to fill out the form for to go to 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.en.md
+++ b/guides/online-payments/checkout-api/previous-requirements.en.md
@@ -88,7 +88,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Learn our API References
 
-If you can't use our official SDKs, you will have all the information about data queries and responses available to interact directly with our APIs in [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
+If you can't use our official SDKs, you will have all the information about data queries and responses available to interact directly with our APIs in [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ## Meet the requirements for the production environment
 
@@ -115,4 +115,4 @@ Once your integration is ready, you just need to fill out the form for to go to 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.en.md
+++ b/guides/online-payments/checkout-api/previous-requirements.en.md
@@ -88,7 +88,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Learn our API References
 
-If you can't use our official SDKs, you will have all the information about data queries and responses available to interact directly with our APIs in [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
+If you can't use our official SDKs, you will have all the information about data queries and responses available to interact directly with our APIs in [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ## Meet the requirements for the production environment
 
@@ -115,4 +115,4 @@ Once your integration is ready, you just need to fill out the form for to go to 
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.es.md
+++ b/guides/online-payments/checkout-api/previous-requirements.es.md
@@ -87,7 +87,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Conoce nuestras Referencias de API
 
-Si no puedes utilizar nuestros SDK oficiales, tienes disponible toda la información sobre consultas y respuestas de datos para interactuar directamente con nuestras APIs en [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+Si no puedes utilizar nuestros SDK oficiales, tienes disponible toda la información sobre consultas y respuestas de datos para interactuar directamente con nuestras APIs en [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ## Cumple los requisitos para ir a producción
 
@@ -122,4 +122,4 @@ Cuando tengas lista tu integración y quieras comenzar a recibir pagos, solo tie
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.es.md
+++ b/guides/online-payments/checkout-api/previous-requirements.es.md
@@ -87,7 +87,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Conoce nuestras Referencias de API
 
-Si no puedes utilizar nuestros SDK oficiales, tienes disponible toda la información sobre consultas y respuestas de datos para interactuar directamente con nuestras APIs en [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+Si no puedes utilizar nuestros SDK oficiales, tienes disponible toda la información sobre consultas y respuestas de datos para interactuar directamente con nuestras APIs en [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ## Cumple los requisitos para ir a producción
 
@@ -122,4 +122,4 @@ Cuando tengas lista tu integración y quieras comenzar a recibir pagos, solo tie
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.es.md
+++ b/guides/online-payments/checkout-api/previous-requirements.es.md
@@ -87,7 +87,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Conoce nuestras Referencias de API
 
-Si no puedes utilizar nuestros SDK oficiales, tienes disponible toda la información sobre consultas y respuestas de datos para interactuar directamente con nuestras APIs en [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+Si no puedes utilizar nuestros SDK oficiales, tienes disponible toda la información sobre consultas y respuestas de datos para interactuar directamente con nuestras APIs en [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ## Cumple los requisitos para ir a producción
 
@@ -122,4 +122,4 @@ Cuando tengas lista tu integración y quieras comenzar a recibir pagos, solo tie
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.es.md
+++ b/guides/online-payments/checkout-api/previous-requirements.es.md
@@ -87,7 +87,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Conoce nuestras Referencias de API
 
-Si no puedes utilizar nuestros SDK oficiales, tienes disponible toda la información sobre consultas y respuestas de datos para interactuar directamente con nuestras APIs en [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post/).
+Si no puedes utilizar nuestros SDK oficiales, tienes disponible toda la información sobre consultas y respuestas de datos para interactuar directamente con nuestras APIs en [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ## Cumple los requisitos para ir a producción
 
@@ -122,4 +122,4 @@ Cuando tengas lista tu integración y quieras comenzar a recibir pagos, solo tie
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.pt.md
+++ b/guides/online-payments/checkout-api/previous-requirements.pt.md
@@ -88,7 +88,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Conheça nossas Referências de API
 
-Se não pode utilizar nossos SDKs oficiais, tenha disponível toda a informação sobre consultas e respostas de dados para interagir diretamente com nossas APIs em [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+Se não pode utilizar nossos SDKs oficiais, tenha disponível toda a informação sobre consultas e respostas de dados para interagir diretamente com nossas APIs em [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ## Cumpra com os requisitos para ir a produção
 
@@ -124,4 +124,4 @@ Quando sua integração estiver pronta e quiser começar a receber pagamentos, c
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.pt.md
+++ b/guides/online-payments/checkout-api/previous-requirements.pt.md
@@ -88,7 +88,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Conheça nossas Referências de API
 
-Se não pode utilizar nossos SDKs oficiais, tenha disponível toda a informação sobre consultas e respostas de dados para interagir diretamente com nossas APIs em [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+Se não pode utilizar nossos SDKs oficiais, tenha disponível toda a informação sobre consultas e respostas de dados para interagir diretamente com nossas APIs em [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ## Cumpra com os requisitos para ir a produção
 
@@ -124,4 +124,4 @@ Quando sua integração estiver pronta e quiser começar a receber pagamentos, c
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.pt.md
+++ b/guides/online-payments/checkout-api/previous-requirements.pt.md
@@ -88,7 +88,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Conheça nossas Referências de API
 
-Se não pode utilizar nossos SDKs oficiais, tenha disponível toda a informação sobre consultas e respostas de dados para interagir diretamente com nossas APIs em [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+Se não pode utilizar nossos SDKs oficiais, tenha disponível toda a informação sobre consultas e respostas de dados para interagir diretamente com nossas APIs em [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ## Cumpra com os requisitos para ir a produção
 
@@ -124,4 +124,4 @@ Quando sua integração estiver pronta e quiser começar a receber pagamentos, c
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/previous-requirements.pt.md
+++ b/guides/online-payments/checkout-api/previous-requirements.pt.md
@@ -88,7 +88,7 @@ PM> Install-Package mercadopago-sdk -Version 1.0.57
 
 ## Conheça nossas Referências de API
 
-Se não pode utilizar nossos SDKs oficiais, tenha disponível toda a informação sobre consultas e respostas de dados para interagir diretamente com nossas APIs em [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post/).
+Se não pode utilizar nossos SDKs oficiais, tenha disponível toda a informação sobre consultas e respostas de dados para interagir diretamente com nossas APIs em [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ## Cumpra com os requisitos para ir a produção
 
@@ -124,4 +124,4 @@ Quando sua integração estiver pronta e quiser começar a receber pagamentos, c
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/)
+> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
@@ -19,7 +19,7 @@ With our Mercado Pago Checkout API, you should take into account two aspects: da
 
 Both for frontend and backend, we recommend [our libraries](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/checkout-api/previous-requirements/#bookmark_always_use_our_libraries) to collect user sensitive data securely.
 
-> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 
@@ -505,7 +505,7 @@ curl -X POST \
 }
 ```
 
-> Check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments/post) to learn about all the available fields for full payments.
+> Check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post) to learn about all the available fields for full payments.
 
 ## Response Handling
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
@@ -19,7 +19,7 @@ With our Mercado Pago Checkout API, you should take into account two aspects: da
 
 Both for frontend and backend, we recommend [our libraries](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/checkout-api/previous-requirements/#bookmark_always_use_our_libraries) to collect user sensitive data securely.
 
-> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 
@@ -505,7 +505,7 @@ curl -X POST \
 }
 ```
 
-> Check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post) to learn about all the available fields for full payments.
+> Check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post) to learn about all the available fields for full payments.
 
 ## Response Handling
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
@@ -19,7 +19,7 @@ With our Mercado Pago Checkout API, you should take into account two aspects: da
 
 Both for frontend and backend, we recommend [our libraries](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/checkout-api/previous-requirements/#bookmark_always_use_our_libraries) to collect user sensitive data securely.
 
-> For more information, check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+> For more information, check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 <br>
 
@@ -505,7 +505,7 @@ curl -X POST \
 }
 ```
 
-> Check [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post/) to learn about all the available fields for full payments.
+> Check [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post) to learn about all the available fields for full payments.
 
 ## Response Handling
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
@@ -19,7 +19,7 @@ With our Mercado Pago Checkout API, you should take into account two aspects: da
 
 Both for frontend and backend, we recommend [our libraries](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/checkout-api/previous-requirements/#bookmark_always_use_our_libraries) to collect user sensitive data securely.
 
-> For more information, check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+> For more information, check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 <br>
 
@@ -505,7 +505,7 @@ curl -X POST \
 }
 ```
 
-> Check [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post) to learn about all the available fields for full payments.
+> Check [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments/post) to learn about all the available fields for full payments.
 
 ## Response Handling
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
@@ -32,7 +32,7 @@ Al usar nuestro Checkout API de Mercado Pago, es importante tener en cuenta dos 
 
 Tanto para el frontend como para el backend, recomendamos utilizar [nuestras librerías](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/previous-requirements/#bookmark_utiliza_nuestras_librerías_siempre) para poder recolectar los datos sensibles de tus usuarios de manera segura.
 
-> Puedes obtener más información en las [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en las [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 
@@ -517,7 +517,7 @@ curl -X POST \
 }
 ```
 
-> Conoce todos los campos disponibles para realizar un pago completo en las [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+> Conoce todos los campos disponibles para realizar un pago completo en las [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ## Mensajes de respuestas
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
@@ -32,7 +32,7 @@ Al usar nuestro Checkout API de Mercado Pago, es importante tener en cuenta dos 
 
 Tanto para el frontend como para el backend, recomendamos utilizar [nuestras librerías](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/previous-requirements/#bookmark_utiliza_nuestras_librerías_siempre) para poder recolectar los datos sensibles de tus usuarios de manera segura.
 
-> Puedes obtener más información en las [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en las [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 
@@ -517,7 +517,7 @@ curl -X POST \
 }
 ```
 
-> Conoce todos los campos disponibles para realizar un pago completo en las [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+> Conoce todos los campos disponibles para realizar un pago completo en las [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ## Mensajes de respuestas
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
@@ -32,7 +32,7 @@ Al usar nuestro Checkout API de Mercado Pago, es importante tener en cuenta dos 
 
 Tanto para el frontend como para el backend, recomendamos utilizar [nuestras librerías](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/previous-requirements/#bookmark_utiliza_nuestras_librerías_siempre) para poder recolectar los datos sensibles de tus usuarios de manera segura.
 
-> Puedes obtener más información en las [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+> Puedes obtener más información en las [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 <br>
 
@@ -517,7 +517,7 @@ curl -X POST \
 }
 ```
 
-> Conoce todos los campos disponibles para realizar un pago completo en las [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+> Conoce todos los campos disponibles para realizar un pago completo en las [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ## Mensajes de respuestas
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
@@ -32,7 +32,7 @@ Al usar nuestro Checkout API de Mercado Pago, es importante tener en cuenta dos 
 
 Tanto para el frontend como para el backend, recomendamos utilizar [nuestras librerías](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/previous-requirements/#bookmark_utiliza_nuestras_librerías_siempre) para poder recolectar los datos sensibles de tus usuarios de manera segura.
 
-> Puedes obtener más información en las [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+> Puedes obtener más información en las [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 <br>
 
@@ -517,7 +517,7 @@ curl -X POST \
 }
 ```
 
-> Conoce todos los campos disponibles para realizar un pago completo en las [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post/).
+> Conoce todos los campos disponibles para realizar un pago completo en las [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ## Mensajes de respuestas
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
@@ -32,7 +32,7 @@ Ao usar nosso Checkout API do Mercado Pago, é importante ter em conta duas inst
 
 Tanto para o frontend como para o backend, recomendamos utilizar [nossos SDKs](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/previous-requirements/#bookmark_sempre_utilize_nossas_bibliotecas) para poder coletar os dados sensíveis dos seus usuários de maneira segura.
 
-> Obtenha mais informações nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informações nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 
@@ -524,7 +524,7 @@ curl -X POST \
 }
 ```
 
-> Conheça todos os campos disponíveis para realizar um pagamento completo nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+> Conheça todos os campos disponíveis para realizar um pagamento completo nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ## Mensagens de respostas
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
@@ -32,7 +32,7 @@ Ao usar nosso Checkout API do Mercado Pago, é importante ter em conta duas inst
 
 Tanto para o frontend como para o backend, recomendamos utilizar [nossos SDKs](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/previous-requirements/#bookmark_sempre_utilize_nossas_bibliotecas) para poder coletar os dados sensíveis dos seus usuários de maneira segura.
 
-> Obtenha mais informações nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informações nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 
@@ -524,7 +524,7 @@ curl -X POST \
 }
 ```
 
-> Conheça todos os campos disponíveis para realizar um pagamento completo nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+> Conheça todos os campos disponíveis para realizar um pagamento completo nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ## Mensagens de respostas
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
@@ -32,7 +32,7 @@ Ao usar nosso Checkout API do Mercado Pago, é importante ter em conta duas inst
 
 Tanto para o frontend como para o backend, recomendamos utilizar [nossos SDKs](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/previous-requirements/#bookmark_sempre_utilize_nossas_bibliotecas) para poder coletar os dados sensíveis dos seus usuários de maneira segura.
 
-> Obtenha mais informações nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+> Obtenha mais informações nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 <br>
 
@@ -524,7 +524,7 @@ curl -X POST \
 }
 ```
 
-> Conheça todos os campos disponíveis para realizar um pagamento completo nas [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+> Conheça todos os campos disponíveis para realizar um pagamento completo nas [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ## Mensagens de respostas
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
@@ -32,7 +32,7 @@ Ao usar nosso Checkout API do Mercado Pago, é importante ter em conta duas inst
 
 Tanto para o frontend como para o backend, recomendamos utilizar [nossos SDKs](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/previous-requirements/#bookmark_sempre_utilize_nossas_bibliotecas) para poder coletar os dados sensíveis dos seus usuários de maneira segura.
 
-> Obtenha mais informações nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+> Obtenha mais informações nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 <br>
 
@@ -524,7 +524,7 @@ curl -X POST \
 }
 ```
 
-> Conheça todos os campos disponíveis para realizar um pagamento completo nas [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post/).
+> Conheça todos os campos disponíveis para realizar um pagamento completo nas [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ## Mensagens de respostas
 

--- a/guides/online-payments/checkout-api/testing.en.md
+++ b/guides/online-payments/checkout-api/testing.en.md
@@ -175,4 +175,4 @@ Before activating them, verify that the credentials in your integration are thos
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/)
+> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/testing.en.md
+++ b/guides/online-payments/checkout-api/testing.en.md
@@ -175,4 +175,4 @@ Before activating them, verify that the credentials in your integration are thos
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/testing.en.md
+++ b/guides/online-payments/checkout-api/testing.en.md
@@ -175,4 +175,4 @@ Before activating them, verify that the credentials in your integration are thos
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/testing.en.md
+++ b/guides/online-payments/checkout-api/testing.en.md
@@ -175,4 +175,4 @@ Before activating them, verify that the credentials in your integration are thos
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)

--- a/guides/online-payments/checkout-api/testing.es.md
+++ b/guides/online-payments/checkout-api/testing.es.md
@@ -175,4 +175,4 @@ Antes de activarlas, verifica que las credenciales en tu integración sean las d
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/testing.es.md
+++ b/guides/online-payments/checkout-api/testing.es.md
@@ -175,4 +175,4 @@ Antes de activarlas, verifica que las credenciales en tu integración sean las d
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/testing.es.md
+++ b/guides/online-payments/checkout-api/testing.es.md
@@ -175,4 +175,4 @@ Antes de activarlas, verifica que las credenciales en tu integración sean las d
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/testing.es.md
+++ b/guides/online-payments/checkout-api/testing.es.md
@@ -175,4 +175,4 @@ Antes de activarlas, verifica que las credenciales en tu integración sean las d
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/checkout-api/testing.pt.md
+++ b/guides/online-payments/checkout-api/testing.pt.md
@@ -174,4 +174,4 @@ Antes de ativá-las, certifique-se de que as credenciais na sua integração sej
 >
 > Encontre toda informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/testing.pt.md
+++ b/guides/online-payments/checkout-api/testing.pt.md
@@ -174,4 +174,4 @@ Antes de ativá-las, certifique-se de que as credenciais na sua integração sej
 >
 > Encontre toda informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/)
+> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/testing.pt.md
+++ b/guides/online-payments/checkout-api/testing.pt.md
@@ -174,4 +174,4 @@ Antes de ativá-las, certifique-se de que as credenciais na sua integração sej
 >
 > Encontre toda informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/testing.pt.md
+++ b/guides/online-payments/checkout-api/testing.pt.md
@@ -174,4 +174,4 @@ Antes de ativá-las, certifique-se de que as credenciais na sua integração sej
 >
 > Encontre toda informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/checkout-api/wallet-integration.en.md
+++ b/guides/online-payments/checkout-api/wallet-integration.en.md
@@ -226,7 +226,7 @@ Then, from your frontend, add the following code to display the Checkout Pro Wal
 ]]]
 
 
-For more information on each attribute, please check the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post/). 
+For more information on each attribute, please check the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post). 
 
 Done! You already have the Mercado Pago wallet integrated on your website. 
 

--- a/guides/online-payments/checkout-api/wallet-integration.en.md
+++ b/guides/online-payments/checkout-api/wallet-integration.en.md
@@ -226,7 +226,7 @@ Then, from your frontend, add the following code to display the Checkout Pro Wal
 ]]]
 
 
-For more information on each attribute, please check the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post). 
+For more information on each attribute, please check the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post). 
 
 Done! You already have the Mercado Pago wallet integrated on your website. 
 

--- a/guides/online-payments/checkout-api/wallet-integration.en.md
+++ b/guides/online-payments/checkout-api/wallet-integration.en.md
@@ -226,7 +226,7 @@ Then, from your frontend, add the following code to display the Checkout Pro Wal
 ]]]
 
 
-For more information on each attribute, please check the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post). 
+For more information on each attribute, please check the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post). 
 
 Done! You already have the Mercado Pago wallet integrated on your website. 
 

--- a/guides/online-payments/checkout-api/wallet-integration.en.md
+++ b/guides/online-payments/checkout-api/wallet-integration.en.md
@@ -226,7 +226,7 @@ Then, from your frontend, add the following code to display the Checkout Pro Wal
 ]]]
 
 
-For more information on each attribute, please check the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post). 
+For more information on each attribute, please check the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post). 
 
 Done! You already have the Mercado Pago wallet integrated on your website. 
 

--- a/guides/online-payments/checkout-api/wallet-integration.es.md
+++ b/guides/online-payments/checkout-api/wallet-integration.es.md
@@ -221,7 +221,7 @@ Luego, desde tu frontend, agrega el siguiente código para mostrar el botón de 
 ]]]
 
 
-Para más información sobre cada atributo, consulta la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post/). 
+Para más información sobre cada atributo, consulta la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post). 
 
 ¡Y listo! Ya tienes integrada la billetera de Mercado Pago en tu sitio. 
 

--- a/guides/online-payments/checkout-api/wallet-integration.es.md
+++ b/guides/online-payments/checkout-api/wallet-integration.es.md
@@ -221,7 +221,7 @@ Luego, desde tu frontend, agrega el siguiente código para mostrar el botón de 
 ]]]
 
 
-Para más información sobre cada atributo, consulta la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post). 
+Para más información sobre cada atributo, consulta la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post). 
 
 ¡Y listo! Ya tienes integrada la billetera de Mercado Pago en tu sitio. 
 

--- a/guides/online-payments/checkout-api/wallet-integration.es.md
+++ b/guides/online-payments/checkout-api/wallet-integration.es.md
@@ -221,7 +221,7 @@ Luego, desde tu frontend, agrega el siguiente código para mostrar el botón de 
 ]]]
 
 
-Para más información sobre cada atributo, consulta la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post). 
+Para más información sobre cada atributo, consulta la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post). 
 
 ¡Y listo! Ya tienes integrada la billetera de Mercado Pago en tu sitio. 
 

--- a/guides/online-payments/checkout-api/wallet-integration.es.md
+++ b/guides/online-payments/checkout-api/wallet-integration.es.md
@@ -221,7 +221,7 @@ Luego, desde tu frontend, agrega el siguiente código para mostrar el botón de 
 ]]]
 
 
-Para más información sobre cada atributo, consulta la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post). 
+Para más información sobre cada atributo, consulta la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post). 
 
 ¡Y listo! Ya tienes integrada la billetera de Mercado Pago en tu sitio. 
 

--- a/guides/online-payments/checkout-api/wallet-integration.pt.md
+++ b/guides/online-payments/checkout-api/wallet-integration.pt.md
@@ -221,7 +221,7 @@ Depois, do seu frontend, adicione o seguinte código para exibir o botão de pag
 ]]]
 
 
-Para mais informações sobre cada atributo, confira a [Referência de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post). 
+Para mais informações sobre cada atributo, confira a [Referência de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post). 
 
 Pronto! você já tem a carteira do Mercado Pago integrada no seu site.
 

--- a/guides/online-payments/checkout-api/wallet-integration.pt.md
+++ b/guides/online-payments/checkout-api/wallet-integration.pt.md
@@ -221,7 +221,7 @@ Depois, do seu frontend, adicione o seguinte código para exibir o botão de pag
 ]]]
 
 
-Para mais informações sobre cada atributo, confira a [Referência de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post/). 
+Para mais informações sobre cada atributo, confira a [Referência de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post). 
 
 Pronto! você já tem a carteira do Mercado Pago integrada no seu site.
 

--- a/guides/online-payments/checkout-api/wallet-integration.pt.md
+++ b/guides/online-payments/checkout-api/wallet-integration.pt.md
@@ -221,7 +221,7 @@ Depois, do seu frontend, adicione o seguinte código para exibir o botão de pag
 ]]]
 
 
-Para mais informações sobre cada atributo, confira a [Referência de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post). 
+Para mais informações sobre cada atributo, confira a [Referência de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post). 
 
 Pronto! você já tem a carteira do Mercado Pago integrada no seu site.
 

--- a/guides/online-payments/checkout-api/wallet-integration.pt.md
+++ b/guides/online-payments/checkout-api/wallet-integration.pt.md
@@ -221,7 +221,7 @@ Depois, do seu frontend, adicione o seguinte código para exibir o botão de pag
 ]]]
 
 
-Para mais informações sobre cada atributo, confira a [Referência de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post). 
+Para mais informações sobre cada atributo, confira a [Referência de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post). 
 
 Pronto! você já tem a carteira do Mercado Pago integrada no seu site.
 

--- a/guides/online-payments/checkout-pro/configurations.en.md
+++ b/guides/online-payments/checkout-pro/configurations.en.md
@@ -1,7 +1,7 @@
 # Other functionalities
 
 
-You can adapt the integration to your business by adding attributes in the preference. There is a lot of [details in a preference](https://www.mercadopago.com.ar/developers/en/reference/preferences/resource/) that can be set, but always keep in mind what your business needs.
+You can adapt the integration to your business by adding attributes in the preference. There is a lot of [details in a preference](https://www.mercadopago.com.ar/developers/en/reference/preferences/resource) that can be set, but always keep in mind what your business needs.
 
 ----[mla, mlb]----
 If you offer purchases of high amounts, for example, you can accept [payments with two credit cards](https://www.mercadopago.com.ar/developers/en/guides/online-payments/checkout-pro/configurations#bookmark_payments_with_two_credit_cards) or, also, [exclude payment methods](https://www.mercadopago.com.ar/developers/en/guides/online-payments/checkout-pro/configurations#bookmark_attributes_for_the_preference) that you do not want to accept.

--- a/guides/online-payments/checkout-pro/configurations.es.md
+++ b/guides/online-payments/checkout-pro/configurations.es.md
@@ -1,7 +1,7 @@
 # Otras funcionalidades
 
 
-Puedes adaptar la integración a tu negocio sumando atributos en la preferencia. Hay muchos [datos en una preferencia](https://www.mercadopago.com.ar/developers/es/reference/preferences/resource/) que se pueden configurar, pero siempre ten en cuenta qué es lo que tu negocio necesita.
+Puedes adaptar la integración a tu negocio sumando atributos en la preferencia. Hay muchos [datos en una preferencia](https://www.mercadopago.com.ar/developers/es/reference/preferences/resource) que se pueden configurar, pero siempre ten en cuenta qué es lo que tu negocio necesita.
 
 ----[mla, mlb]----
 Si ofreces compras de montos altos, por ejemplo, puedes aceptar [pagos con dos tarjetas de crédito](https://www.mercadopago.com.ar/developers/es/guides/online-payments/checkout-pro/configurations#bookmark_pagos_con_dos_tarjetas_de_crédito) o también, [excluir medios de pago](https://www.mercadopago.com.ar/developers/es/guides/online-payments/checkout-pro/configurations#bookmark_atributos_para_la_preferencia) que no quieras aceptar.

--- a/guides/online-payments/checkout-pro/configurations.pt.md
+++ b/guides/online-payments/checkout-pro/configurations.pt.md
@@ -1,7 +1,7 @@
 # Outras funcionalidades
 
 
-Você pode adaptar a integração ao seu negócio adicionando atributos na preferência. Há muitos [dados em uma preferência](https://www.mercadopago.com.br/developers/pt/reference/preferences/resource/) que podem ser configurados, mas lembre-se sempre do quê seus negócios precisam.
+Você pode adaptar a integração ao seu negócio adicionando atributos na preferência. Há muitos [dados em uma preferência](https://www.mercadopago.com.br/developers/pt/reference/preferences/resource) que podem ser configurados, mas lembre-se sempre do quê seus negócios precisam.
 
 ----[mla, mlb]----
 Se você oferece compras de valores altos, por exemplo, você pode aceitar [pagamentos com dois cartões de crédito](https://www.mercadopago.com.br/developers/pt/guides/online-payments/checkout-pro/configurations#bookmark_pagamentos_com_2_cartão_de_crédito) ou tambén, [excluir meios de pagamento](https://www.mercadopago.com.br/developers/pt/guides/online-payments/checkout-pro/configurations#bookmark_atributos_para_a_preferência) que você não quiser aceitar

--- a/guides/online-payments/marketplace/advanced-payments/supported-payment-methods.en.md
+++ b/guides/online-payments/marketplace/advanced-payments/supported-payment-methods.en.md
@@ -18,4 +18,4 @@ The payments methods that are currently supported are the following:
 >
 > Note
 >
-> For more information, please go to the reference of [Payment Methods](https://www.mercadopago.com.br/developers/en/reference/payment_methods/_payment_methods/get/).
+> For more information, please go to the reference of [Payment Methods](https://www.mercadopago.com.br/developers/en/reference/payment_methods/_payment_methods/get).

--- a/guides/online-payments/marketplace/advanced-payments/supported-payment-methods.es.md
+++ b/guides/online-payments/marketplace/advanced-payments/supported-payment-methods.es.md
@@ -18,4 +18,4 @@ Actualmente los medios de pagos soportados son los siguientes:
 >
 > Nota
 >
-> Para más información dirigirse a la referencia de [Payment Methods](https://www.mercadopago.com.ar/developers/es/reference/payment_methods/_payment_methods/get/).
+> Para más información dirigirse a la referencia de [Payment Methods](https://www.mercadopago.com.ar/developers/es/reference/payment_methods/_payment_methods/get).

--- a/guides/online-payments/marketplace/advanced-payments/supported-payment-methods.pt.md
+++ b/guides/online-payments/marketplace/advanced-payments/supported-payment-methods.pt.md
@@ -18,4 +18,4 @@ Atualmente os meios de pagamento aceitos são os seguintes:
 >
 > Nota
 >
-> Para mais informações, consulte a referência de [Payment Methods](https://www.mercadopago.com.br/developers/pt/reference/payment_methods/_payment_methods/get/).
+> Para mais informações, consulte a referência de [Payment Methods](https://www.mercadopago.com.br/developers/pt/reference/payment_methods/_payment_methods/get).

--- a/guides/online-payments/marketplace/checkout-api/goto-production.en.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.en.md
@@ -76,5 +76,5 @@ You need to have a policy on terms and conditions and make it clear that you are
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
 

--- a/guides/online-payments/marketplace/checkout-api/goto-production.en.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.en.md
@@ -76,5 +76,5 @@ You need to have a policy on terms and conditions and make it clear that you are
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/)
+> [API References](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference)
 

--- a/guides/online-payments/marketplace/checkout-api/goto-production.en.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.en.md
@@ -76,5 +76,5 @@ You need to have a policy on terms and conditions and make it clear that you are
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference)
 

--- a/guides/online-payments/marketplace/checkout-api/goto-production.en.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.en.md
@@ -76,5 +76,5 @@ You need to have a policy on terms and conditions and make it clear that you are
 >
 > Find all the information required to interact with our APIs.
 >
-> [API References](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference)
+> [API References](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference)
 

--- a/guides/online-payments/marketplace/checkout-api/goto-production.es.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.es.md
@@ -76,4 +76,4 @@ Debes disponer de una política de términos y condiciones y aclarar que sos res
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/marketplace/checkout-api/goto-production.es.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.es.md
@@ -76,4 +76,4 @@ Debes disponer de una política de términos y condiciones y aclarar que sos res
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/)
+> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/marketplace/checkout-api/goto-production.es.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.es.md
@@ -76,4 +76,4 @@ Debes disponer de una política de términos y condiciones y aclarar que sos res
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/marketplace/checkout-api/goto-production.es.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.es.md
@@ -76,4 +76,4 @@ Debes disponer de una política de términos y condiciones y aclarar que sos res
 >
 > Encuentra toda la información necesaria para interactuar con nuestras APIs.
 >
-> [Referencias de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference)
+> [Referencias de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference)

--- a/guides/online-payments/marketplace/checkout-api/goto-production.pt.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.pt.md
@@ -73,4 +73,4 @@ Disponibilize uma política de termos e condições e deixe claro que é respons
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/marketplace/checkout-api/goto-production.pt.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.pt.md
@@ -73,4 +73,4 @@ Disponibilize uma política de termos e condições e deixe claro que é respons
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/marketplace/checkout-api/goto-production.pt.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.pt.md
@@ -73,4 +73,4 @@ Disponibilize uma política de termos e condições e deixe claro que é respons
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/)
+> [Referências de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/marketplace/checkout-api/goto-production.pt.md
+++ b/guides/online-payments/marketplace/checkout-api/goto-production.pt.md
@@ -73,4 +73,4 @@ Disponibilize uma política de termos e condições e deixe claro que é respons
 >
 > Encontre toda a informação necessária para interagir com nossas APIs.
 >
-> [Referências de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference)
+> [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference)

--- a/guides/online-payments/mobile-checkout/v3/personalization.en.md
+++ b/guides/online-payments/mobile-checkout/v3/personalization.en.md
@@ -234,7 +234,7 @@ If you need to perform any validation on your server at the time of making the p
 
 In the `ServicePreference` class you can set up the URL and URI of your service together with a Map so that you can send the information you want.
 
-At the moment of posting the payment, the SDK will do it at your service, [creating the payment](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments/post/) and performing the validations inherent to your business. The SDK will expect to receive a payment, according to the response of Mercado Pago service.
+At the moment of posting the payment, the SDK will do it at your service, [creating the payment](https://www.mercadopago.com.ar/developers/en/reference/payments/_payments/post) and performing the validations inherent to your business. The SDK will expect to receive a payment, according to the response of Mercado Pago service.
 
 As soon as the `ServicePreference` has been created, you must start the payment flow of MercadoPago, as shown in the following code:
 

--- a/guides/online-payments/mobile-checkout/v3/personalization.es.md
+++ b/guides/online-payments/mobile-checkout/v3/personalization.es.md
@@ -238,7 +238,7 @@ Si necesitas hacer alguna validación en tu servidor al momento de realizar el p
 
 En la clase _ServicePreference_ puedes configurar la URL y la URI de tu servicio junto con un _Map_ para que puedas enviar la información que desees.
 
-Al momento de postear el pago, el SDK lo hará a tu servicio, [el cual deberá crear el pago](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments/post/) y hacer la validaciones inherentes a tu negocio. El SDK esperará recibir un pago, tal como responde el servicio de Mercado Pago.
+Al momento de postear el pago, el SDK lo hará a tu servicio, [el cual deberá crear el pago](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments/post) y hacer la validaciones inherentes a tu negocio. El SDK esperará recibir un pago, tal como responde el servicio de Mercado Pago.
 
 Una vez creada la _ServicePreference_, debes iniciar el flujo de pago de Mercado Pago, tal como se muestra en el siguiente código:
 

--- a/guides/online-payments/mobile-checkout/v3/personalization.pt.md
+++ b/guides/online-payments/mobile-checkout/v3/personalization.pt.md
@@ -236,7 +236,7 @@ Se precisar fazer alguma validação em seu servidor no momento do pagamento, vo
 
 Na classe ServicePreference, você pode configurar a URL e a URI do seu serviço juntamente com um Map para que possa enviar as informações que deseja.
 
-No momento de postar o pagamento, o SDK o fará em seu lugar, [o qual deverá criar o pagamento](https://www.mercadopago.com.ar/developers/pt/reference/payments/_payments/post/) e efetuar as validações inerentes ao seu negócio. O SDK irá esperar receber um pagamento, da mesma forma que o serviço do Mercado Pago responde.
+No momento de postar o pagamento, o SDK o fará em seu lugar, [o qual deverá criar o pagamento](https://www.mercadopago.com.ar/developers/pt/reference/payments/_payments/post) e efetuar as validações inerentes ao seu negócio. O SDK irá esperar receber um pagamento, da mesma forma que o serviço do Mercado Pago responde.
 Assim que a ServicePreference é criada, você deve iniciar o fluxo de pagamento do Mercado Pago, conforme indicado no código abaixo:
 
 [[[

--- a/guides/online-payments/subscriptions/advanced-integration.en.md
+++ b/guides/online-payments/subscriptions/advanced-integration.en.md
@@ -110,7 +110,7 @@ With the subscription `application_id` you want to update, make the following ca
 ```
 ]]]
 
->To get more information about the available fields, view the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API references</a>.
+>To get more information about the available fields, view the <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API references<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.en.md
+++ b/guides/online-payments/subscriptions/advanced-integration.en.md
@@ -110,7 +110,7 @@ With the subscription `application_id` you want to update, make the following ca
 ```
 ]]]
 
->To get more information about the available fields, view the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API references<a>.
+>To get more information about the available fields, view the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API references</a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.en.md
+++ b/guides/online-payments/subscriptions/advanced-integration.en.md
@@ -110,7 +110,7 @@ With the subscription `application_id` you want to update, make the following ca
 ```
 ]]]
 
->To get more information about the available fields, view the <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API references<a>.
+>To get more information about the available fields, view the <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/" target="_blank">API references<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.en.md
+++ b/guides/online-payments/subscriptions/advanced-integration.en.md
@@ -110,7 +110,7 @@ With the subscription `application_id` you want to update, make the following ca
 ```
 ]]]
 
->To get more information about the available fields, view the <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/" target="_blank">API references<a>.
+>To get more information about the available fields, view the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API references<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.en.md
+++ b/guides/online-payments/subscriptions/advanced-integration.en.md
@@ -110,7 +110,7 @@ With the subscription `application_id` you want to update, make the following ca
 ```
 ]]]
 
->To get more information about the available fields, view the <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API references<a>.
+>To get more information about the available fields, view the <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API references<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.es.md
+++ b/guides/online-payments/subscriptions/advanced-integration.es.md
@@ -110,7 +110,7 @@ Con el `application_id` de la suscripción que quieras actualizar, realiza la si
 ```
 ]]]
 
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.es.md
+++ b/guides/online-payments/subscriptions/advanced-integration.es.md
@@ -110,7 +110,7 @@ Con el `application_id` de la suscripción que quieras actualizar, realiza la si
 ```
 ]]]
 
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.es.md
+++ b/guides/online-payments/subscriptions/advanced-integration.es.md
@@ -110,7 +110,7 @@ Con el `application_id` de la suscripción que quieras actualizar, realiza la si
 ```
 ]]]
 
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API</a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.es.md
+++ b/guides/online-payments/subscriptions/advanced-integration.es.md
@@ -110,7 +110,7 @@ Con el `application_id` de la suscripción que quieras actualizar, realiza la si
 ```
 ]]]
 
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.es.md
+++ b/guides/online-payments/subscriptions/advanced-integration.es.md
@@ -110,7 +110,7 @@ Con el `application_id` de la suscripción que quieras actualizar, realiza la si
 ```
 ]]]
 
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API</a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.pt.md
+++ b/guides/online-payments/subscriptions/advanced-integration.pt.md
@@ -108,7 +108,7 @@ Com o `application_id` da assinatura que quiser atualizar, faça a seguinte cham
 ```
 ]]]
 
->Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API</a>.
+>Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.pt.md
+++ b/guides/online-payments/subscriptions/advanced-integration.pt.md
@@ -108,7 +108,7 @@ Com o `application_id` da assinatura que quiser atualizar, faça a seguinte cham
 ```
 ]]]
 
->Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API<a>.
+>Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API</a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.pt.md
+++ b/guides/online-payments/subscriptions/advanced-integration.pt.md
@@ -108,7 +108,7 @@ Com o `application_id` da assinatura que quiser atualizar, faça a seguinte cham
 ```
 ]]]
 
->Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API<a>.
+>Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.pt.md
+++ b/guides/online-payments/subscriptions/advanced-integration.pt.md
@@ -108,7 +108,7 @@ Com o `application_id` da assinatura que quiser atualizar, faça a seguinte cham
 ```
 ]]]
 
->Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API<a>.
+>Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.pt.md
+++ b/guides/online-payments/subscriptions/advanced-integration.pt.md
@@ -108,7 +108,7 @@ Com o `application_id` da assinatura que quiser atualizar, faça a seguinte cham
 ```
 ]]]
 
->Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API<a>.
+>Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API<a>.
 
 
 ------------

--- a/guides/online-payments/subscriptions/integration.en.md
+++ b/guides/online-payments/subscriptions/integration.en.md
@@ -157,7 +157,7 @@ Once you have generated your plan and obtained your `preapproval_plan_id`, creat
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference</a>.
+>You can get more information about the fields in the <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference<a>.
 
 Done! You have already created a subscription with an associated plan.
 
@@ -283,7 +283,7 @@ In order to subscribe, the card data must be uploaded with our form. Only the li
 }
 ```
 
-> You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API reference</a>.
+> You can get more information about the fields in the <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API reference<a>.
 
 
 Attributes

--- a/guides/online-payments/subscriptions/integration.en.md
+++ b/guides/online-payments/subscriptions/integration.en.md
@@ -157,7 +157,7 @@ Once you have generated your plan and obtained your `preapproval_plan_id`, creat
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference<a>.
+>You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference</a>.
 
 Done! You have already created a subscription with an associated plan.
 
@@ -283,7 +283,7 @@ In order to subscribe, the card data must be uploaded with our form. Only the li
 }
 ```
 
-> You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API reference<a>.
+> You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API reference</a>.
 
 
 Attributes

--- a/guides/online-payments/subscriptions/integration.en.md
+++ b/guides/online-payments/subscriptions/integration.en.md
@@ -157,7 +157,7 @@ Once you have generated your plan and obtained your `preapproval_plan_id`, creat
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->You can get more information about the fields in the <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference<a>.
+>You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference<a>.
 
 Done! You have already created a subscription with an associated plan.
 
@@ -283,7 +283,7 @@ In order to subscribe, the card data must be uploaded with our form. Only the li
 }
 ```
 
-> You can get more information about the fields in the <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/" target="_blank">API reference<a>.
+> You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API reference<a>.
 
 
 Attributes

--- a/guides/online-payments/subscriptions/integration.en.md
+++ b/guides/online-payments/subscriptions/integration.en.md
@@ -157,7 +157,7 @@ Once you have generated your plan and obtained your `preapproval_plan_id`, creat
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->You can get more information about the fields in the <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference<a>.
+>You can get more information about the fields in the <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference<a>.
 
 Done! You have already created a subscription with an associated plan.
 
@@ -283,7 +283,7 @@ In order to subscribe, the card data must be uploaded with our form. Only the li
 }
 ```
 
-> You can get more information about the fields in the <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API reference<a>.
+> You can get more information about the fields in the <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/" target="_blank">API reference<a>.
 
 
 Attributes

--- a/guides/online-payments/subscriptions/integration.en.md
+++ b/guides/online-payments/subscriptions/integration.en.md
@@ -157,7 +157,7 @@ Once you have generated your plan and obtained your `preapproval_plan_id`, creat
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->You can get more information about the fields in the <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference<a>.
+>You can get more information about the fields in the <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference<a>.
 
 Done! You have already created a subscription with an associated plan.
 
@@ -283,7 +283,7 @@ In order to subscribe, the card data must be uploaded with our form. Only the li
 }
 ```
 
-> You can get more information about the fields in the <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API reference<a>.
+> You can get more information about the fields in the <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API reference<a>.
 
 
 Attributes

--- a/guides/online-payments/subscriptions/integration.es.md
+++ b/guides/online-payments/subscriptions/integration.es.md
@@ -157,7 +157,7 @@ Una vez generado tu plan y obtenido tu `preapproval_plan_id`, crea la suscripci�
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 ¡Y listo! Ya creaste una suscripción con un plan asociado.
 
@@ -283,7 +283,7 @@ Para poder adherirse, la carga de los datos de la tarjeta se debe realizar con n
 }
 ```
 
-> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.es.md
+++ b/guides/online-payments/subscriptions/integration.es.md
@@ -157,7 +157,7 @@ Una vez generado tu plan y obtenido tu `preapproval_plan_id`, crea la suscripci�
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 ¡Y listo! Ya creaste una suscripción con un plan asociado.
 
@@ -283,7 +283,7 @@ Para poder adherirse, la carga de los datos de la tarjeta se debe realizar con n
 }
 ```
 
-> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.es.md
+++ b/guides/online-payments/subscriptions/integration.es.md
@@ -157,7 +157,7 @@ Una vez generado tu plan y obtenido tu `preapproval_plan_id`, crea la suscripci�
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 ¡Y listo! Ya creaste una suscripción con un plan asociado.
 
@@ -283,7 +283,7 @@ Para poder adherirse, la carga de los datos de la tarjeta se debe realizar con n
 }
 ```
 
-> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.es.md
+++ b/guides/online-payments/subscriptions/integration.es.md
@@ -157,7 +157,7 @@ Una vez generado tu plan y obtenido tu `preapproval_plan_id`, crea la suscripci�
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API</a>.
 
 ¡Y listo! Ya creaste una suscripción con un plan asociado.
 
@@ -283,7 +283,7 @@ Para poder adherirse, la carga de los datos de la tarjeta se debe realizar con n
 }
 ```
 
-> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
+> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API</a>.
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.es.md
+++ b/guides/online-payments/subscriptions/integration.es.md
@@ -157,7 +157,7 @@ Una vez generado tu plan y obtenido tu `preapproval_plan_id`, crea la suscripci�
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API</a>.
+>Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 ¡Y listo! Ya creaste una suscripción con un plan asociado.
 
@@ -283,7 +283,7 @@ Para poder adherirse, la carga de los datos de la tarjeta se debe realizar con n
 }
 ```
 
-> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API</a>.
+> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API<a>.
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.pt.md
+++ b/guides/online-payments/subscriptions/integration.pt.md
@@ -157,7 +157,7 @@ Uma vez que você tenha gerado seu plano e obtido seu `preapproval_plan_id`, cri
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
+>Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
 
 Prono! Você criou uma assinatura com um plano associado.
 
@@ -283,7 +283,7 @@ Para o cadastro, os detalhes do cartão devem ser informados usando nosso formul
 }
 ```
 
-> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
+> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.pt.md
+++ b/guides/online-payments/subscriptions/integration.pt.md
@@ -157,7 +157,7 @@ Uma vez que você tenha gerado seu plano e obtido seu `preapproval_plan_id`, cri
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
+>Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API</a>.
 
 Prono! Você criou uma assinatura com um plano associado.
 
@@ -283,7 +283,7 @@ Para o cadastro, os detalhes do cartão devem ser informados usando nosso formul
 }
 ```
 
-> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
+> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API</a>.
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.pt.md
+++ b/guides/online-payments/subscriptions/integration.pt.md
@@ -157,7 +157,7 @@ Uma vez que você tenha gerado seu plano e obtido seu `preapproval_plan_id`, cri
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
+>Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
 
 Prono! Você criou uma assinatura com um plano associado.
 
@@ -283,7 +283,7 @@ Para o cadastro, os detalhes do cartão devem ser informados usando nosso formul
 }
 ```
 
-> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
+> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.pt.md
+++ b/guides/online-payments/subscriptions/integration.pt.md
@@ -157,7 +157,7 @@ Uma vez que você tenha gerado seu plano e obtido seu `preapproval_plan_id`, cri
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API</a>.
+>Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
 
 Prono! Você criou uma assinatura com um plano associado.
 
@@ -283,7 +283,7 @@ Para o cadastro, os detalhes do cartão devem ser informados usando nosso formul
 }
 ```
 
-> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API</a>.
+> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.pt.md
+++ b/guides/online-payments/subscriptions/integration.pt.md
@@ -157,7 +157,7 @@ Uma vez que você tenha gerado seu plano e obtido seu `preapproval_plan_id`, cri
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
+>Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
 
 Prono! Você criou uma assinatura com um plano associado.
 
@@ -283,7 +283,7 @@ Para o cadastro, os detalhes do cartão devem ser informados usando nosso formul
 }
 ```
 
-> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
+> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API<a>.
 
 
 Atributos

--- a/guides/plugins/unofficial/spreedly.pt.md
+++ b/guides/plugins/unofficial/spreedly.pt.md
@@ -350,7 +350,7 @@ Para processar com Mercado Pago e para obter maiores níveis de aprovação em s
 
 ### Payer Identification
 
-Para processar com Mercado Pago é necessário enviar a identificação do pagador em cada pagamento. Esta informação é OBRIGATÓRIA para todos os sítios de Mercado Pago a exceção de México. Para mais detalhes, [acesse o seguinte link](https://www.mercadopago.com.br/developers/pt/reference/identification_types/_identification_types/get/).
+Para processar com Mercado Pago é necessário enviar a identificação do pagador em cada pagamento. Esta informação é OBRIGATÓRIA para todos os sítios de Mercado Pago a exceção de México. Para mais detalhes, [acesse o seguinte link](https://www.mercadopago.com.br/developers/pt/reference/identification_types/_identification_types/get).
 
 ### Parcelas
 

--- a/guides/resources/changelog/current-year.en.md
+++ b/guides/resources/changelog/current-year.en.md
@@ -271,7 +271,7 @@ We added sample projects to get your Checkout API up and running instantly. You 
 
 From now on, you must start adding your Access Token to the request headers instead of sending by URL when consuming our APIs in order to guarantee the security of your token. For now, both forms are valid but we recommend using the new one. If you use our official SDKs you just have to make sure you are using the latest version.
 
-You can see all the information in the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
+You can see all the information in the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 
 ### September 21st
@@ -307,7 +307,7 @@ We have released the new version 4.4.0 for WooCommerce.
 
 We update our data protection protocols to meet the highest security standards. After October 12th, we will stop displaying the payer's e-mail when creating orders.
 
-You can see all the information in the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
+You can see all the information in the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
 
 ### September 10th
 
@@ -380,7 +380,7 @@ We have released the new version 4.3.0 for WooCommerce.
 Our payment IDs will now be 11 digits long. Our APIs and SDKs operate on data type `long` so this change should not impact your integration with Mercado Pago.
 If you have any doubts, we recommend reviewing how you manage and store our Payment ID in your integration in order to avoid any inconvenience.
 
-For further information, visit our [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments/post).
+For further information, visit our [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ### August 13th
 
@@ -468,7 +468,7 @@ We have released the new version 4.2.2 for WooCommerce.
 
 We update our data protection protocols to meet the highest security standards. After July 8th, we will stop displaying the seller's e-mail when creating orders. The change shouldn't cause any problems in the integration, since it's information of the person who is creating the order.
 
-You can see all the information in the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
+You can see all the information in the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
 
 ### July 7th
 

--- a/guides/resources/changelog/current-year.en.md
+++ b/guides/resources/changelog/current-year.en.md
@@ -271,7 +271,7 @@ We added sample projects to get your Checkout API up and running instantly. You 
 
 From now on, you must start adding your Access Token to the request headers instead of sending by URL when consuming our APIs in order to guarantee the security of your token. For now, both forms are valid but we recommend using the new one. If you use our official SDKs you just have to make sure you are using the latest version.
 
-You can see all the information in the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/).
+You can see all the information in the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
 
 
 ### September 21st
@@ -307,7 +307,7 @@ We have released the new version 4.4.0 for WooCommerce.
 
 We update our data protection protocols to meet the highest security standards. After October 12th, we will stop displaying the payer's e-mail when creating orders.
 
-You can see all the information in the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource/).
+You can see all the information in the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
 
 ### September 10th
 
@@ -380,7 +380,7 @@ We have released the new version 4.3.0 for WooCommerce.
 Our payment IDs will now be 11 digits long. Our APIs and SDKs operate on data type `long` so this change should not impact your integration with Mercado Pago.
 If you have any doubts, we recommend reviewing how you manage and store our Payment ID in your integration in order to avoid any inconvenience.
 
-For further information, visit our [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post/).
+For further information, visit our [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ### August 13th
 
@@ -468,7 +468,7 @@ We have released the new version 4.2.2 for WooCommerce.
 
 We update our data protection protocols to meet the highest security standards. After July 8th, we will stop displaying the seller's e-mail when creating orders. The change shouldn't cause any problems in the integration, since it's information of the person who is creating the order.
 
-You can see all the information in the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource/).
+You can see all the information in the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
 
 ### July 7th
 

--- a/guides/resources/changelog/current-year.en.md
+++ b/guides/resources/changelog/current-year.en.md
@@ -271,7 +271,7 @@ We added sample projects to get your Checkout API up and running instantly. You 
 
 From now on, you must start adding your Access Token to the request headers instead of sending by URL when consuming our APIs in order to guarantee the security of your token. For now, both forms are valid but we recommend using the new one. If you use our official SDKs you just have to make sure you are using the latest version.
 
-You can see all the information in the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
+You can see all the information in the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference).
 
 
 ### September 21st
@@ -307,7 +307,7 @@ We have released the new version 4.4.0 for WooCommerce.
 
 We update our data protection protocols to meet the highest security standards. After October 12th, we will stop displaying the payer's e-mail when creating orders.
 
-You can see all the information in the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
+You can see all the information in the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
 
 ### September 10th
 
@@ -380,7 +380,7 @@ We have released the new version 4.3.0 for WooCommerce.
 Our payment IDs will now be 11 digits long. Our APIs and SDKs operate on data type `long` so this change should not impact your integration with Mercado Pago.
 If you have any doubts, we recommend reviewing how you manage and store our Payment ID in your integration in order to avoid any inconvenience.
 
-For further information, visit our [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
+For further information, visit our [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ### August 13th
 
@@ -468,7 +468,7 @@ We have released the new version 4.2.2 for WooCommerce.
 
 We update our data protection protocols to meet the highest security standards. After July 8th, we will stop displaying the seller's e-mail when creating orders. The change shouldn't cause any problems in the integration, since it's information of the person who is creating the order.
 
-You can see all the information in the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
+You can see all the information in the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
 
 ### July 7th
 

--- a/guides/resources/changelog/current-year.en.md
+++ b/guides/resources/changelog/current-year.en.md
@@ -271,7 +271,7 @@ We added sample projects to get your Checkout API up and running instantly. You 
 
 From now on, you must start adding your Access Token to the request headers instead of sending by URL when consuming our APIs in order to guarantee the security of your token. For now, both forms are valid but we recommend using the new one. If you use our official SDKs you just have to make sure you are using the latest version.
 
-You can see all the information in the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference).
+You can see all the information in the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference).
 
 
 ### September 21st
@@ -307,7 +307,7 @@ We have released the new version 4.4.0 for WooCommerce.
 
 We update our data protection protocols to meet the highest security standards. After October 12th, we will stop displaying the payer's e-mail when creating orders.
 
-You can see all the information in the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
+You can see all the information in the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
 
 ### September 10th
 
@@ -380,7 +380,7 @@ We have released the new version 4.3.0 for WooCommerce.
 Our payment IDs will now be 11 digits long. Our APIs and SDKs operate on data type `long` so this change should not impact your integration with Mercado Pago.
 If you have any doubts, we recommend reviewing how you manage and store our Payment ID in your integration in order to avoid any inconvenience.
 
-For further information, visit our [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
+For further information, visit our [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments/post).
 
 ### August 13th
 
@@ -468,7 +468,7 @@ We have released the new version 4.2.2 for WooCommerce.
 
 We update our data protection protocols to meet the highest security standards. After July 8th, we will stop displaying the seller's e-mail when creating orders. The change shouldn't cause any problems in the integration, since it's information of the person who is creating the order.
 
-You can see all the information in the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
+You can see all the information in the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/merchant_orders/resource).
 
 ### July 7th
 

--- a/guides/resources/changelog/current-year.es.md
+++ b/guides/resources/changelog/current-year.es.md
@@ -284,7 +284,7 @@ Sumamos ejemplos descargables de integración de pagos con tarjeta para que prue
 
 A partir de ahora, deberás dejar de enviar tu Access Token por URL al consumir nuestras APIs y comenzar a sumarlo en los headers de la solicitud para mayor seguridad. Por el momento, ambas formas son válidas pero te recomendamos que comiences a usar la nueva. Si usas nuestras SDKs oficiales solo tienes que mantenerla actualizada a la última versión.
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 
 ### 21 de septiembre
@@ -320,7 +320,7 @@ Lanzamos la nueva versión 4.4.0 para WooCommerce.
 
 Actualizamos nuestras medidas de protección de datos para cumplir con los más altos estándares de seguridad. A partir del lunes 12 de octubre, vamos a dejar de mostrar el e-mail del comprador en la creación de órdenes. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
 
 ### 10 de septiembre
 
@@ -393,7 +393,7 @@ Lanzamos la nueva versión 4.3.0 para WooCommerce.
 Los IDs de pagos pasarán de tener 10 dígitos a 11 dígitos. Nuestras APIs y SDKs operan con un tipo de dato `long` por lo que no habrá ningún impacto en la operatoria con Mercado Pago. 
 Si tienes dudas, te recomendamos revisar la administración y almacenamiento de nuestro Payment ID en tu integración para evitar cualquier inconveniente. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ### 13 de agosto
 
@@ -481,7 +481,7 @@ Lanzamos la nueva versión 4.2.2 para WooCommerce.
 
 Actualizamos nuestras medidas de protección de datos para cumplir con los más altos estándares de seguridad. Desde el miércoles 8 de julio, vamos a dejar de mostrar el e-mail del vendedor en la creación de órdenes. El cambio no debería generar ningún problema en la integración, ya que es información de la persona que se encuentra creando la orden. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
 
 ### 7 de julio
 

--- a/guides/resources/changelog/current-year.es.md
+++ b/guides/resources/changelog/current-year.es.md
@@ -284,7 +284,7 @@ Sumamos ejemplos descargables de integración de pagos con tarjeta para que prue
 
 A partir de ahora, deberás dejar de enviar tu Access Token por URL al consumir nuestras APIs y comenzar a sumarlo en los headers de la solicitud para mayor seguridad. Por el momento, ambas formas son válidas pero te recomendamos que comiences a usar la nueva. Si usas nuestras SDKs oficiales solo tienes que mantenerla actualizada a la última versión.
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference).
 
 
 ### 21 de septiembre
@@ -320,7 +320,7 @@ Lanzamos la nueva versión 4.4.0 para WooCommerce.
 
 Actualizamos nuestras medidas de protección de datos para cumplir con los más altos estándares de seguridad. A partir del lunes 12 de octubre, vamos a dejar de mostrar el e-mail del comprador en la creación de órdenes. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
 
 ### 10 de septiembre
 
@@ -393,7 +393,7 @@ Lanzamos la nueva versión 4.3.0 para WooCommerce.
 Los IDs de pagos pasarán de tener 10 dígitos a 11 dígitos. Nuestras APIs y SDKs operan con un tipo de dato `long` por lo que no habrá ningún impacto en la operatoria con Mercado Pago. 
 Si tienes dudas, te recomendamos revisar la administración y almacenamiento de nuestro Payment ID en tu integración para evitar cualquier inconveniente. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ### 13 de agosto
 
@@ -481,7 +481,7 @@ Lanzamos la nueva versión 4.2.2 para WooCommerce.
 
 Actualizamos nuestras medidas de protección de datos para cumplir con los más altos estándares de seguridad. Desde el miércoles 8 de julio, vamos a dejar de mostrar el e-mail del vendedor en la creación de órdenes. El cambio no debería generar ningún problema en la integración, ya que es información de la persona que se encuentra creando la orden. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
 
 ### 7 de julio
 

--- a/guides/resources/changelog/current-year.es.md
+++ b/guides/resources/changelog/current-year.es.md
@@ -284,7 +284,7 @@ Sumamos ejemplos descargables de integración de pagos con tarjeta para que prue
 
 A partir de ahora, deberás dejar de enviar tu Access Token por URL al consumir nuestras APIs y comenzar a sumarlo en los headers de la solicitud para mayor seguridad. Por el momento, ambas formas son válidas pero te recomendamos que comiences a usar la nueva. Si usas nuestras SDKs oficiales solo tienes que mantenerla actualizada a la última versión.
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference).
 
 
 ### 21 de septiembre
@@ -320,7 +320,7 @@ Lanzamos la nueva versión 4.4.0 para WooCommerce.
 
 Actualizamos nuestras medidas de protección de datos para cumplir con los más altos estándares de seguridad. A partir del lunes 12 de octubre, vamos a dejar de mostrar el e-mail del comprador en la creación de órdenes. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
 
 ### 10 de septiembre
 
@@ -393,7 +393,7 @@ Lanzamos la nueva versión 4.3.0 para WooCommerce.
 Los IDs de pagos pasarán de tener 10 dígitos a 11 dígitos. Nuestras APIs y SDKs operan con un tipo de dato `long` por lo que no habrá ningún impacto en la operatoria con Mercado Pago. 
 Si tienes dudas, te recomendamos revisar la administración y almacenamiento de nuestro Payment ID en tu integración para evitar cualquier inconveniente. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ### 13 de agosto
 
@@ -481,7 +481,7 @@ Lanzamos la nueva versión 4.2.2 para WooCommerce.
 
 Actualizamos nuestras medidas de protección de datos para cumplir con los más altos estándares de seguridad. Desde el miércoles 8 de julio, vamos a dejar de mostrar el e-mail del vendedor en la creación de órdenes. El cambio no debería generar ningún problema en la integración, ya que es información de la persona que se encuentra creando la orden. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
 
 ### 7 de julio
 

--- a/guides/resources/changelog/current-year.es.md
+++ b/guides/resources/changelog/current-year.es.md
@@ -284,7 +284,7 @@ Sumamos ejemplos descargables de integración de pagos con tarjeta para que prue
 
 A partir de ahora, deberás dejar de enviar tu Access Token por URL al consumir nuestras APIs y comenzar a sumarlo en los headers de la solicitud para mayor seguridad. Por el momento, ambas formas son válidas pero te recomendamos que comiences a usar la nueva. Si usas nuestras SDKs oficiales solo tienes que mantenerla actualizada a la última versión.
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference).
 
 
 ### 21 de septiembre
@@ -320,7 +320,7 @@ Lanzamos la nueva versión 4.4.0 para WooCommerce.
 
 Actualizamos nuestras medidas de protección de datos para cumplir con los más altos estándares de seguridad. A partir del lunes 12 de octubre, vamos a dejar de mostrar el e-mail del comprador en la creación de órdenes. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource/).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
 
 ### 10 de septiembre
 
@@ -393,7 +393,7 @@ Lanzamos la nueva versión 4.3.0 para WooCommerce.
 Los IDs de pagos pasarán de tener 10 dígitos a 11 dígitos. Nuestras APIs y SDKs operan con un tipo de dato `long` por lo que no habrá ningún impacto en la operatoria con Mercado Pago. 
 Si tienes dudas, te recomendamos revisar la administración y almacenamiento de nuestro Payment ID en tu integración para evitar cualquier inconveniente. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post/).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments/post).
 
 ### 13 de agosto
 
@@ -481,7 +481,7 @@ Lanzamos la nueva versión 4.2.2 para WooCommerce.
 
 Actualizamos nuestras medidas de protección de datos para cumplir con los más altos estándares de seguridad. Desde el miércoles 8 de julio, vamos a dejar de mostrar el e-mail del vendedor en la creación de órdenes. El cambio no debería generar ningún problema en la integración, ya que es información de la persona que se encuentra creando la orden. 
 
-Puedes ver toda la información en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource/).
+Puedes ver toda la información en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/merchant_orders/resource).
 
 ### 7 de julio
 

--- a/guides/resources/changelog/current-year.pt.md
+++ b/guides/resources/changelog/current-year.pt.md
@@ -284,7 +284,7 @@ Adicionamos exemplos de integração de pagamento com cartão para download, par
 
 A partir de agora, você deve deixar de enviar seu Access Token por URL ao consumir nossas APIs e começar a adicioná-lo nos headers da solicitação para maior segurança. No momento, ambas as formas são válidas, mas recomendamos que comece a usar a nova. Se usa nossos SDKs oficiais, basta mantê-los atualizados com a versão mais recente.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
+Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
 
 
 ### 21 de setembro
@@ -320,7 +320,7 @@ Lançamos a nova versão 4.4.0 para WooCommerce.
 
 Atualizamos nossas medidas de proteção de dados para atender aos mais altos padrões de segurança. A partir de segunda-feira, 12 de outubro, deixaremos de exibir o e-mail do comprador ao criar pedidos.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
+Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
 
 ### 10 de setembro
 
@@ -393,7 +393,7 @@ Lançamos a nova versão 4.3.0 para WooCommerce.
 Os IDs de pagamento passarão de 10 para 11 dígitos. Nossas APIs e SDKs operam com um tipo de dado `long`, portanto não haverá impacto na operação com o Mercado Pago. 
 Caso tenha dúvidas, recomendamos que revise a administração e armazenamento do nosso Payment ID na sua integração para evitar qualquer inconveniente. 
 
-Veja todas as informações em [Referência API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+Veja todas as informações em [Referência API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ### 13 de agosto
 
@@ -481,7 +481,7 @@ Lançamos a nova versão 4.2.2 para WooCommerce.
 
 Atualizamos nossas medidas de proteção de dados para atender aos mais altos padrões de segurança. A partir de quarta-feira, 8 de julho, deixaremos de exibir o e-mail do vendedor ao criar pedidos. A mudança não deve gerar nenhum problema na integração, pois são informações da pessoa que está criando o pedido.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
+Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
 
 ### 7 de julho
 

--- a/guides/resources/changelog/current-year.pt.md
+++ b/guides/resources/changelog/current-year.pt.md
@@ -284,7 +284,7 @@ Adicionamos exemplos de integração de pagamento com cartão para download, par
 
 A partir de agora, você deve deixar de enviar seu Access Token por URL ao consumir nossas APIs e começar a adicioná-lo nos headers da solicitação para maior segurança. No momento, ambas as formas são válidas, mas recomendamos que comece a usar a nova. Se usa nossos SDKs oficiais, basta mantê-los atualizados com a versão mais recente.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/).
+Veja todas as informações na [Referência da API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
 
 
 ### 21 de setembro
@@ -320,7 +320,7 @@ Lançamos a nova versão 4.4.0 para WooCommerce.
 
 Atualizamos nossas medidas de proteção de dados para atender aos mais altos padrões de segurança. A partir de segunda-feira, 12 de outubro, deixaremos de exibir o e-mail do comprador ao criar pedidos.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource/).
+Veja todas as informações na [Referência da API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
 
 ### 10 de setembro
 
@@ -393,7 +393,7 @@ Lançamos a nova versão 4.3.0 para WooCommerce.
 Os IDs de pagamento passarão de 10 para 11 dígitos. Nossas APIs e SDKs operam com um tipo de dado `long`, portanto não haverá impacto na operação com o Mercado Pago. 
 Caso tenha dúvidas, recomendamos que revise a administração e armazenamento do nosso Payment ID na sua integração para evitar qualquer inconveniente. 
 
-Veja todas as informações em [Referência API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post/).
+Veja todas as informações em [Referência API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ### 13 de agosto
 
@@ -481,7 +481,7 @@ Lançamos a nova versão 4.2.2 para WooCommerce.
 
 Atualizamos nossas medidas de proteção de dados para atender aos mais altos padrões de segurança. A partir de quarta-feira, 8 de julho, deixaremos de exibir o e-mail do vendedor ao criar pedidos. A mudança não deve gerar nenhum problema na integração, pois são informações da pessoa que está criando o pedido.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource/).
+Veja todas as informações na [Referência da API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
 
 ### 7 de julho
 

--- a/guides/resources/changelog/current-year.pt.md
+++ b/guides/resources/changelog/current-year.pt.md
@@ -284,7 +284,7 @@ Adicionamos exemplos de integração de pagamento com cartão para download, par
 
 A partir de agora, você deve deixar de enviar seu Access Token por URL ao consumir nossas APIs e começar a adicioná-lo nos headers da solicitação para maior segurança. No momento, ambas as formas são válidas, mas recomendamos que comece a usar a nova. Se usa nossos SDKs oficiais, basta mantê-los atualizados com a versão mais recente.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference).
+Veja todas as informações na [Referência da API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 
 ### 21 de setembro
@@ -320,7 +320,7 @@ Lançamos a nova versão 4.4.0 para WooCommerce.
 
 Atualizamos nossas medidas de proteção de dados para atender aos mais altos padrões de segurança. A partir de segunda-feira, 12 de outubro, deixaremos de exibir o e-mail do comprador ao criar pedidos.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
+Veja todas as informações na [Referência da API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
 
 ### 10 de setembro
 
@@ -393,7 +393,7 @@ Lançamos a nova versão 4.3.0 para WooCommerce.
 Os IDs de pagamento passarão de 10 para 11 dígitos. Nossas APIs e SDKs operam com um tipo de dado `long`, portanto não haverá impacto na operação com o Mercado Pago. 
 Caso tenha dúvidas, recomendamos que revise a administração e armazenamento do nosso Payment ID na sua integração para evitar qualquer inconveniente. 
 
-Veja todas as informações em [Referência API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+Veja todas as informações em [Referência API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ### 13 de agosto
 
@@ -481,7 +481,7 @@ Lançamos a nova versão 4.2.2 para WooCommerce.
 
 Atualizamos nossas medidas de proteção de dados para atender aos mais altos padrões de segurança. A partir de quarta-feira, 8 de julho, deixaremos de exibir o e-mail do vendedor ao criar pedidos. A mudança não deve gerar nenhum problema na integração, pois são informações da pessoa que está criando o pedido.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
+Veja todas as informações na [Referência da API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
 
 ### 7 de julho
 

--- a/guides/resources/changelog/current-year.pt.md
+++ b/guides/resources/changelog/current-year.pt.md
@@ -284,7 +284,7 @@ Adicionamos exemplos de integração de pagamento com cartão para download, par
 
 A partir de agora, você deve deixar de enviar seu Access Token por URL ao consumir nossas APIs e começar a adicioná-lo nos headers da solicitação para maior segurança. No momento, ambas as formas são válidas, mas recomendamos que comece a usar a nova. Se usa nossos SDKs oficiais, basta mantê-los atualizados com a versão mais recente.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference).
+Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 
 ### 21 de setembro
@@ -320,7 +320,7 @@ Lançamos a nova versão 4.4.0 para WooCommerce.
 
 Atualizamos nossas medidas de proteção de dados para atender aos mais altos padrões de segurança. A partir de segunda-feira, 12 de outubro, deixaremos de exibir o e-mail do comprador ao criar pedidos.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
+Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
 
 ### 10 de setembro
 
@@ -393,7 +393,7 @@ Lançamos a nova versão 4.3.0 para WooCommerce.
 Os IDs de pagamento passarão de 10 para 11 dígitos. Nossas APIs e SDKs operam com um tipo de dado `long`, portanto não haverá impacto na operação com o Mercado Pago. 
 Caso tenha dúvidas, recomendamos que revise a administração e armazenamento do nosso Payment ID na sua integração para evitar qualquer inconveniente. 
 
-Veja todas as informações em [Referência API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
+Veja todas as informações em [Referência API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments/post).
 
 ### 13 de agosto
 
@@ -481,7 +481,7 @@ Lançamos a nova versão 4.2.2 para WooCommerce.
 
 Atualizamos nossas medidas de proteção de dados para atender aos mais altos padrões de segurança. A partir de quarta-feira, 8 de julho, deixaremos de exibir o e-mail do vendedor ao criar pedidos. A mudança não deve gerar nenhum problema na integração, pois são informações da pessoa que está criando o pedido.
 
-Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
+Veja todas as informações na [Referência da API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/merchant_orders/resource).
 
 ### 7 de julho
 

--- a/guides/resources/changelog/migration-guides/ipn-ow-guide.en.md
+++ b/guides/resources/changelog/migration-guides/ipn-ow-guide.en.md
@@ -22,7 +22,7 @@ Until now you received “x-www-form-urlencoded”, so you have to adapt the log
 
 > It is necessary that after receiving the notification we reply us a 200 immediately to avoid a resending of notification before 10 seconds.
 
-The JSON will have basic payment information. If you need more information, [perform a GET to the payment ID](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get/).
+The JSON will have basic payment information. If you need more information, [perform a GET to the payment ID](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get).
 
 > It is necessary for your server to have HTTPS certificates.
 

--- a/guides/resources/changelog/migration-guides/ipn-ow-guide.es.md
+++ b/guides/resources/changelog/migration-guides/ipn-ow-guide.es.md
@@ -22,7 +22,7 @@ Hasta ahora recibías “x-www-form-urlencoded”, por lo que tenés que adaptar
 
 > Es necesario que después de recibir la notificación nos respondas un 200 inmediatamente para evitar un reenvío de notificación antes de los 10 segundos.
 
-El JSON va a tener información básica del pago. Y si necesitas más información, [realizá un GET al ID del pago](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get/).
+El JSON va a tener información básica del pago. Y si necesitas más información, [realizá un GET al ID del pago](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get).
 
 > Es necesario que tu servidor tenga certificados HTTPS.
 

--- a/guides/resources/changelog/migration-guides/ipn-ow-guide.pt.md
+++ b/guides/resources/changelog/migration-guides/ipn-ow-guide.pt.md
@@ -22,7 +22,7 @@ Até agora você recebia "x-www-form-urlencoded", portanto, é necessário adapt
 
 > É importante que, após receber a notificação você responda imediatamente a 200 para evitar o reenvio da notificação antes de 10 segundos
 
-O JSON terá as informações básicas de pagamento. Caso você precise de mais informações, [faça um GET para o ID de pagamento](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get/).  
+O JSON terá as informações básicas de pagamento. Caso você precise de mais informações, [faça um GET para o ID de pagamento](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get).  
 
 > É necessário que seu servidor tenha certificados HTTPS.
 

--- a/guides/resources/faqs/payments.en.md
+++ b/guides/resources/faqs/payments.en.md
@@ -54,7 +54,7 @@ Because of this, according to the amount selected, you can only see some payment
 ----[mlb]----
 ## How to generate the same ticket again
 
-To generate a duplicate of the ticket, it is necessary to use the [GET method from the API of Payments](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments_id/get) sending the payment ID and the seller’s Access Token.
+To generate a duplicate of the ticket, it is necessary to use the [GET method from the API of Payments](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments_id/get) sending the payment ID and the seller’s Access Token.
 
 The query would be as follows:
 
@@ -74,7 +74,7 @@ You can remove the ticket option through the payment preference. For more detail
 
 You can remove it directly from your frontend. Get the payment methods excluding the ticket in the call with the parameter `"payment_type_id" = credit_card` as filter, for example.
 
-> For more details please refer to the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payment_methods/_payment_methods/get).
+> For more details please refer to the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins and e-commerce solutions ready to use
 

--- a/guides/resources/faqs/payments.en.md
+++ b/guides/resources/faqs/payments.en.md
@@ -54,7 +54,7 @@ Because of this, according to the amount selected, you can only see some payment
 ----[mlb]----
 ## How to generate the same ticket again
 
-To generate a duplicate of the ticket, it is necessary to use the [GET method from the API of Payments](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments_id/get) sending the payment ID and the seller’s Access Token.
+To generate a duplicate of the ticket, it is necessary to use the [GET method from the API of Payments](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments_id/get) sending the payment ID and the seller’s Access Token.
 
 The query would be as follows:
 
@@ -74,7 +74,7 @@ You can remove the ticket option through the payment preference. For more detail
 
 You can remove it directly from your frontend. Get the payment methods excluding the ticket in the call with the parameter `"payment_type_id" = credit_card` as filter, for example.
 
-> For more details please refer to the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payment_methods/_payment_methods/get).
+> For more details please refer to the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins and e-commerce solutions ready to use
 

--- a/guides/resources/faqs/payments.en.md
+++ b/guides/resources/faqs/payments.en.md
@@ -54,7 +54,7 @@ Because of this, according to the amount selected, you can only see some payment
 ----[mlb]----
 ## How to generate the same ticket again
 
-To generate a duplicate of the ticket, it is necessary to use the [GET method from the API of Payments](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments_id/get) sending the payment ID and the seller’s Access Token.
+To generate a duplicate of the ticket, it is necessary to use the [GET method from the API of Payments](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payments/_payments_id/get) sending the payment ID and the seller’s Access Token.
 
 The query would be as follows:
 
@@ -74,7 +74,7 @@ You can remove the ticket option through the payment preference. For more detail
 
 You can remove it directly from your frontend. Get the payment methods excluding the ticket in the call with the parameter `"payment_type_id" = credit_card` as filter, for example.
 
-> For more details please refer to the [API Reference](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/en/reference/payment_methods/_payment_methods/get).
+> For more details please refer to the [API Reference](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/en/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins and e-commerce solutions ready to use
 

--- a/guides/resources/faqs/payments.en.md
+++ b/guides/resources/faqs/payments.en.md
@@ -54,7 +54,7 @@ Because of this, according to the amount selected, you can only see some payment
 ----[mlb]----
 ## How to generate the same ticket again
 
-To generate a duplicate of the ticket, it is necessary to use the [GET method from the API of Payments](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments_id/get/) sending the payment ID and the seller’s Access Token.
+To generate a duplicate of the ticket, it is necessary to use the [GET method from the API of Payments](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments_id/get) sending the payment ID and the seller’s Access Token.
 
 The query would be as follows:
 
@@ -74,7 +74,7 @@ You can remove the ticket option through the payment preference. For more detail
 
 You can remove it directly from your frontend. Get the payment methods excluding the ticket in the call with the parameter `"payment_type_id" = credit_card` as filter, for example.
 
-> For more details please refer to the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payment_methods/_payment_methods/get/).
+> For more details please refer to the [API Reference](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/en/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins and e-commerce solutions ready to use
 

--- a/guides/resources/faqs/payments.es.md
+++ b/guides/resources/faqs/payments.es.md
@@ -52,7 +52,7 @@ Esto genera que, según el monto elegido, puedas visualizar algunos medios de pa
 
 ## Cómo generar el mismo ticket nuevamente
 
-Para generar un duplicado del boleto es necesario que uses el [método GET de la API de Payments](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments_id/get) enviando el ID del pago y el Access Token del vendedor.
+Para generar un duplicado del boleto es necesario que uses el [método GET de la API de Payments](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments_id/get) enviando el ID del pago y el Access Token del vendedor.
 
 La consulta sería de la siguiente forma:
 
@@ -72,7 +72,7 @@ Es posible remover la opción de boleto a través de la preferencia de pago. Pue
 
 Puedes removerlo directamente desde tu frontend. Obtén los medios de pago y excluye a boleto en la llamada con el parámetro `"payment_type_id" = credit_card` como filtro, por ejemplo.
 
-> Puedes encontrar más detalle en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payment_methods/_payment_methods/get).
+> Puedes encontrar más detalle en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins y soluciones de e-commerce listas para usar
 

--- a/guides/resources/faqs/payments.es.md
+++ b/guides/resources/faqs/payments.es.md
@@ -52,7 +52,7 @@ Esto genera que, según el monto elegido, puedas visualizar algunos medios de pa
 
 ## Cómo generar el mismo ticket nuevamente
 
-Para generar un duplicado del boleto es necesario que uses el [método GET de la API de Payments](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payments/_payments_id/get) enviando el ID del pago y el Access Token del vendedor.
+Para generar un duplicado del boleto es necesario que uses el [método GET de la API de Payments](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments_id/get) enviando el ID del pago y el Access Token del vendedor.
 
 La consulta sería de la siguiente forma:
 
@@ -72,7 +72,7 @@ Es posible remover la opción de boleto a través de la preferencia de pago. Pue
 
 Puedes removerlo directamente desde tu frontend. Obtén los medios de pago y excluye a boleto en la llamada con el parámetro `"payment_type_id" = credit_card` como filtro, por ejemplo.
 
-> Puedes encontrar más detalle en la [Referencia de API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/es/reference/payment_methods/_payment_methods/get).
+> Puedes encontrar más detalle en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins y soluciones de e-commerce listas para usar
 

--- a/guides/resources/faqs/payments.es.md
+++ b/guides/resources/faqs/payments.es.md
@@ -52,7 +52,7 @@ Esto genera que, según el monto elegido, puedas visualizar algunos medios de pa
 
 ## Cómo generar el mismo ticket nuevamente
 
-Para generar un duplicado del boleto es necesario que uses el [método GET de la API de Payments](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments_id/get) enviando el ID del pago y el Access Token del vendedor.
+Para generar un duplicado del boleto es necesario que uses el [método GET de la API de Payments](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments_id/get) enviando el ID del pago y el Access Token del vendedor.
 
 La consulta sería de la siguiente forma:
 
@@ -72,7 +72,7 @@ Es posible remover la opción de boleto a través de la preferencia de pago. Pue
 
 Puedes removerlo directamente desde tu frontend. Obtén los medios de pago y excluye a boleto en la llamada con el parámetro `"payment_type_id" = credit_card` como filtro, por ejemplo.
 
-> Puedes encontrar más detalle en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payment_methods/_payment_methods/get).
+> Puedes encontrar más detalle en la [Referencia de API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/es/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins y soluciones de e-commerce listas para usar
 

--- a/guides/resources/faqs/payments.es.md
+++ b/guides/resources/faqs/payments.es.md
@@ -52,7 +52,7 @@ Esto genera que, según el monto elegido, puedas visualizar algunos medios de pa
 
 ## Cómo generar el mismo ticket nuevamente
 
-Para generar un duplicado del boleto es necesario que uses el [método GET de la API de Payments](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments_id/get/) enviando el ID del pago y el Access Token del vendedor.
+Para generar un duplicado del boleto es necesario que uses el [método GET de la API de Payments](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments_id/get) enviando el ID del pago y el Access Token del vendedor.
 
 La consulta sería de la siguiente forma:
 
@@ -72,7 +72,7 @@ Es posible remover la opción de boleto a través de la preferencia de pago. Pue
 
 Puedes removerlo directamente desde tu frontend. Obtén los medios de pago y excluye a boleto en la llamada con el parámetro `"payment_type_id" = credit_card` como filtro, por ejemplo.
 
-> Puedes encontrar más detalle en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payment_methods/_payment_methods/get/).
+> Puedes encontrar más detalle en la [Referencia de API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/es/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins y soluciones de e-commerce listas para usar
 

--- a/guides/resources/faqs/payments.pt.md
+++ b/guides/resources/faqs/payments.pt.md
@@ -52,7 +52,7 @@ Isso ocorre porque, de acordo com o valor escolhido, você pode visualizar algun
 
 ## Como gerar a segunda via do boleto
 
-Para gerar uma segunda via do boleto será necessário [utilizar o método GET da API de Payment](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments_id/get/) passando o ID do pagamento e a Access Token do vendedor.
+Para gerar uma segunda via do boleto será necessário [utilizar o método GET da API de Payment](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments_id/get) passando o ID do pagamento e a Access Token do vendedor.
 
 A consulta será da seguinte forma:
 
@@ -72,7 +72,7 @@ Dependendo do seu tipo de checkout e integração o processo pode ser diferente.
 
 A remoção é realizada diretamente no seu frontend. Você pode obter os meios de pagamento desejados ao excluir boleto da chamada ao método payment, inserindo o parâmetro `"payment_type_id" = credit_card` como filtro, por exemplo.
 
-> Você pode encontrar mais detalhes na [referência da API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payment_methods/_payment_methods/get/).
+> Você pode encontrar mais detalhes na [referência da API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins ou soluções de e-commerce prontas para usar
 

--- a/guides/resources/faqs/payments.pt.md
+++ b/guides/resources/faqs/payments.pt.md
@@ -52,7 +52,7 @@ Isso ocorre porque, de acordo com o valor escolhido, você pode visualizar algun
 
 ## Como gerar a segunda via do boleto
 
-Para gerar uma segunda via do boleto será necessário [utilizar o método GET da API de Payment](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments_id/get) passando o ID do pagamento e a Access Token do vendedor.
+Para gerar uma segunda via do boleto será necessário [utilizar o método GET da API de Payment](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments_id/get) passando o ID do pagamento e a Access Token do vendedor.
 
 A consulta será da seguinte forma:
 
@@ -72,7 +72,7 @@ Dependendo do seu tipo de checkout e integração o processo pode ser diferente.
 
 A remoção é realizada diretamente no seu frontend. Você pode obter os meios de pagamento desejados ao excluir boleto da chamada ao método payment, inserindo o parâmetro `"payment_type_id" = credit_card` como filtro, por exemplo.
 
-> Você pode encontrar mais detalhes na [referência da API](https://www.mercadopago.FAKER][URL][DOMAIN]/developers/pt/reference/payment_methods/_payment_methods/get).
+> Você pode encontrar mais detalhes na [referência da API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins ou soluções de e-commerce prontas para usar
 

--- a/guides/resources/faqs/payments.pt.md
+++ b/guides/resources/faqs/payments.pt.md
@@ -52,7 +52,7 @@ Isso ocorre porque, de acordo com o valor escolhido, você pode visualizar algun
 
 ## Como gerar a segunda via do boleto
 
-Para gerar uma segunda via do boleto será necessário [utilizar o método GET da API de Payment](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments_id/get) passando o ID do pagamento e a Access Token do vendedor.
+Para gerar uma segunda via do boleto será necessário [utilizar o método GET da API de Payment](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments_id/get) passando o ID do pagamento e a Access Token do vendedor.
 
 A consulta será da seguinte forma:
 
@@ -72,7 +72,7 @@ Dependendo do seu tipo de checkout e integração o processo pode ser diferente.
 
 A remoção é realizada diretamente no seu frontend. Você pode obter os meios de pagamento desejados ao excluir boleto da chamada ao método payment, inserindo o parâmetro `"payment_type_id" = credit_card` como filtro, por exemplo.
 
-> Você pode encontrar mais detalhes na [referência da API](https://www.mercadopago.[FAKER][URL][DOMAIN]/developers/pt/reference/payment_methods/_payment_methods/get).
+> Você pode encontrar mais detalhes na [referência da API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins ou soluções de e-commerce prontas para usar
 

--- a/guides/resources/faqs/payments.pt.md
+++ b/guides/resources/faqs/payments.pt.md
@@ -52,7 +52,7 @@ Isso ocorre porque, de acordo com o valor escolhido, você pode visualizar algun
 
 ## Como gerar a segunda via do boleto
 
-Para gerar uma segunda via do boleto será necessário [utilizar o método GET da API de Payment](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payments/_payments_id/get) passando o ID do pagamento e a Access Token do vendedor.
+Para gerar uma segunda via do boleto será necessário [utilizar o método GET da API de Payment](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments_id/get) passando o ID do pagamento e a Access Token do vendedor.
 
 A consulta será da seguinte forma:
 
@@ -72,7 +72,7 @@ Dependendo do seu tipo de checkout e integração o processo pode ser diferente.
 
 A remoção é realizada diretamente no seu frontend. Você pode obter os meios de pagamento desejados ao excluir boleto da chamada ao método payment, inserindo o parâmetro `"payment_type_id" = credit_card` como filtro, por exemplo.
 
-> Você pode encontrar mais detalhes na [referência da API](https://www.mercadopago[FAKER[URL][DOMAIN]/developers/pt/reference/payment_methods/_payment_methods/get).
+> Você pode encontrar mais detalhes na [referência da API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payment_methods/_payment_methods/get).
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plugins ou soluções de e-commerce prontas para usar
 

--- a/guides/resources/localization/identification-types.en.md
+++ b/guides/resources/localization/identification-types.en.md
@@ -52,7 +52,7 @@ curl -X GET \
 ```
 ]]]
 
-The results included in this response will coincide with the country associated with your Mercado Pago account. For more information about this feature and its attributes, go to  [API reference](https://www.mercadopago.com.ar/developers/en/reference/identification_types/_identification_types/get).
+The results included in this response will coincide with the country associated with your Mercado Pago account. For more information about this feature and its attributes, go to  [API reference](https://www.mercadopago.com.ar/developers/en/reference/identification_types/_identification_typesget).
 
 ## Identification types by country
 

--- a/guides/resources/localization/identification-types.en.md
+++ b/guides/resources/localization/identification-types.en.md
@@ -52,7 +52,7 @@ curl -X GET \
 ```
 ]]]
 
-The results included in this response will coincide with the country associated with your Mercado Pago account. For more information about this feature and its attributes, go to  [API reference](https://www.mercadopago.com.ar/developers/en/reference/identification_types/_identification_typesget).
+The results included in this response will coincide with the country associated with your Mercado Pago account. For more information about this feature and its attributes, go to  [API reference](https://www.mercadopago.com.ar/developers/en/reference/identification_types/_identification_types/get).
 
 ## Identification types by country
 

--- a/guides/resources/localization/identification-types.es.md
+++ b/guides/resources/localization/identification-types.es.md
@@ -50,7 +50,7 @@ curl -X GET \
 ```
 ]]]
 
-Los resultados incluídos en esta respuesta coincidirán con el país asociado a tu cuenta de Mercado Pago. Puedes obtener más información sobre este recurso y sus atributos en la [Referencia de API](https://www.mercadopago.com.ar/developers/es/reference/identification_types/_identification_types/get).
+Los resultados incluídos en esta respuesta coincidirán con el país asociado a tu cuenta de Mercado Pago. Puedes obtener más información sobre este recurso y sus atributos en la [Referencia de API](https://www.mercadopago.com.ar/developers/es/reference/identification_types/_identification_typesget).
 
 ## Tipos de documento por país
 

--- a/guides/resources/localization/identification-types.es.md
+++ b/guides/resources/localization/identification-types.es.md
@@ -50,7 +50,7 @@ curl -X GET \
 ```
 ]]]
 
-Los resultados incluídos en esta respuesta coincidirán con el país asociado a tu cuenta de Mercado Pago. Puedes obtener más información sobre este recurso y sus atributos en la [Referencia de API](https://www.mercadopago.com.ar/developers/es/reference/identification_types/_identification_typesget).
+Los resultados incluídos en esta respuesta coincidirán con el país asociado a tu cuenta de Mercado Pago. Puedes obtener más información sobre este recurso y sus atributos en la [Referencia de API](https://www.mercadopago.com.ar/developers/es/reference/identification_types/_identification_types/get).
 
 ## Tipos de documento por país
 

--- a/guides/resources/localization/identification-types.pt.md
+++ b/guides/resources/localization/identification-types.pt.md
@@ -54,7 +54,7 @@ curl -X GET \
 ]]]
 
 
-Os resultados incluídos nesta resposta coincidirão com o país associado à sua conta Mercado Pago. Você poderá obter mais informações sobre este recurso e seus atributos em [Referência da API](https://www.mercadopago.com.br/developers/pt/reference/payment_methods/_payment_methods/get/).
+Os resultados incluídos nesta resposta coincidirão com o país associado à sua conta Mercado Pago. Você poderá obter mais informações sobre este recurso e seus atributos em [Referência da API](https://www.mercadopago.com.br/developers/pt/reference/payment_methods/_payment_methods/get).
 
 ## Tipos de documentos por país
 

--- a/guides/resources/localization/migrating-v0-v1.en.md
+++ b/guides/resources/localization/migrating-v0-v1.en.md
@@ -27,9 +27,9 @@ La siguiente tabla contiene a los recursos migrados y sus equivalentes.
 | Devoluciones | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
 | Actualización de pago | `PUT` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
 | Actualización de pago | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
-| Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
-| Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
-| Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
+| Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
+| Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
+| Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
 | Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
 | Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
 

--- a/guides/resources/localization/migrating-v0-v1.en.md
+++ b/guides/resources/localization/migrating-v0-v1.en.md
@@ -24,14 +24,14 @@ La siguiente tabla contiene a los recursos migrados y sus equivalentes.
 | Uso | Método | URI del recurso deprecado | URI del recurso equivalente | Referencia |
 | --- | --- | --- | --- | --- |
 | Devoluciones | `POST` | /collections/$payment_id/refunds | /v1/payments/$payment_id/refunds |- |
-| Devoluciones | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put/) |
-| Actualización de pago | `PUT` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put/) |
-| Actualización de pago | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put/) |
-| Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
-| Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
-| Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
-| Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get)|
-| Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get)|
+| Devoluciones | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
+| Actualización de pago | `PUT` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
+| Actualización de pago | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
+| Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
+| Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
+| Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
+| Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
+| Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
 
 ### Versiones migradas de las herramientas de Mercado Pago
 

--- a/guides/resources/localization/migrating-v0-v1.en.md
+++ b/guides/resources/localization/migrating-v0-v1.en.md
@@ -30,8 +30,8 @@ La siguiente tabla contiene a los recursos migrados y sus equivalentes.
 | Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
 | Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
 | Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
-| Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
-| Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
+| Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get)|
+| Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get)|
 
 ### Versiones migradas de las herramientas de Mercado Pago
 

--- a/guides/resources/localization/migrating-v0-v1.es.md
+++ b/guides/resources/localization/migrating-v0-v1.es.md
@@ -62,14 +62,14 @@ A continuación vas a poder encontrar los recursos migrados y sus equivalentes.
 | Uso | Método | URI del recurso deprecado | URI del recurso equivalente | Referencia |
 | --- | --- | --- | --- | --- |
 | Devoluciones | `POST` | /collections/$payment_id/refunds | /v1/payments/$payment_id/refunds | -|
-| Devoluciones | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put/) |
-| Actualización de pago | `PUT` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put/) |
-| Actualización de pago | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put/) |
-| Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
-| Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
-| Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
-| Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get)|
-| Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get)|
+| Devoluciones | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
+| Actualización de pago | `PUT` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
+| Actualización de pago | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
+| Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
+| Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
+| Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
+| Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
+| Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
 
 ##Versiones válidas de las herramientas para la nueva versión 
 

--- a/guides/resources/localization/migrating-v0-v1.es.md
+++ b/guides/resources/localization/migrating-v0-v1.es.md
@@ -68,8 +68,8 @@ A continuación vas a poder encontrar los recursos migrados y sus equivalentes.
 | Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
 | Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
 | Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
-| Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
-| Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
+| Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get)|
+| Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_search/get)|
 
 ##Versiones válidas de las herramientas para la nueva versión 
 

--- a/guides/resources/localization/migrating-v0-v1.es.md
+++ b/guides/resources/localization/migrating-v0-v1.es.md
@@ -65,9 +65,9 @@ A continuación vas a poder encontrar los recursos migrados y sus equivalentes.
 | Devoluciones | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
 | Actualización de pago | `PUT` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
 | Actualización de pago | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/put) |
-| Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
-| Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
-| Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_idget) |
+| Pagos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
+| Pagos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
+| Notificación de pagos | `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_id/get) |
 | Búsqueda de pagos | `GET` | /payments/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
 | Búsqueda de pagos | `GET` | /collections/search | /v1/payments/search | [visita](https://www.mercadopago.com.ar/developers/es/reference/payments/_payments_searchget)|
 

--- a/guides/resources/localization/migrating-v0-v1.pt.md
+++ b/guides/resources/localization/migrating-v0-v1.pt.md
@@ -39,8 +39,8 @@ A seguir, você encontrará os recursos migrados e seus equivalentes.
 | Pagamentos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) |
 | Pagamentos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) |
 | Notificação de pagamentos| `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) |
-| Busca de pagamentos | `GET` | /payments/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_searchget)|
-| Busca de pagamentos | `GET` | /collections/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_searchget)|
+| Busca de pagamentos | `GET` | /payments/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get)|
+| Busca de pagamentos | `GET` | /collections/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get)|
 
 ## Versões válidas das ferramentas para a nova versão 
 

--- a/guides/resources/localization/migrating-v0-v1.pt.md
+++ b/guides/resources/localization/migrating-v0-v1.pt.md
@@ -36,9 +36,9 @@ A seguir, você encontrará os recursos migrados e seus equivalentes.
 | Devoluções | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/put)	 |
 | Atualização de pagamento | `PUT` | /payments/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/put) |
 | Atualização de pagamento | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/put) |
-| Pagamentos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_idget) |
-| Pagamentos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_idget) |
-| Notificação de pagamentos| `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_idget) |
+| Pagamentos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) |
+| Pagamentos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) |
+| Notificação de pagamentos| `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) |
 | Busca de pagamentos | `GET` | /payments/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_searchget)|
 | Busca de pagamentos | `GET` | /collections/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_searchget)|
 

--- a/guides/resources/localization/migrating-v0-v1.pt.md
+++ b/guides/resources/localization/migrating-v0-v1.pt.md
@@ -33,14 +33,14 @@ A seguir, você encontrará os recursos migrados e seus equivalentes.
 | Uso | Método | URI do Recurso deprecado | URI do Recurso equivalente | Referência |
 | --- | --- | --- | --- | --- |
 | Devoluções | `POST` | /collections/$payment_id/refunds | /v1/payments/$payment_id/refunds |- |
-| Devoluções | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/put/)	 |
-| Atualização de pagamento | `PUT` | /payments/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/put/) |
-| Atualização de pagamento | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/put/) |
-| Pagamentos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) |
-| Pagamentos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) |
-| Notificação de pagamentos| `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/get) |
-| Busca de pagamentos | `GET` | /payments/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get)|
-| Busca de pagamentos | `GET` | /collections/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_search/get)|
+| Devoluções | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/put)	 |
+| Atualização de pagamento | `PUT` | /payments/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/put) |
+| Atualização de pagamento | `PUT` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_id/put) |
+| Pagamentos | `GET` | /payments/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_idget) |
+| Pagamentos | `GET` | /collections/$payment_id | /v1/payments/$payment_id/ | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_idget) |
+| Notificação de pagamentos| `GET` | /collections/notifications/$payment_id | /v1/payments/$payment_id/ |[acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_idget) |
+| Busca de pagamentos | `GET` | /payments/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_searchget)|
+| Busca de pagamentos | `GET` | /collections/search | /v1/payments/search | [acesse](https://www.mercadopago.com.br/developers/pt/reference/payments/_payments_searchget)|
 
 ## Versões válidas das ferramentas para a nova versão 
 

--- a/guides/resources/localization/payment-methods.en.md
+++ b/guides/resources/localization/payment-methods.en.md
@@ -89,7 +89,7 @@ curl -X GET \
 		...
 	]
 
-The results included in this response will coincide with the country associated with your Mercado Pago account. For more information about this feature and its attributes, go to  [API reference](https://www.mercadopago.com.ar/developers/en/reference/payment_methods/_payment_methods/get/).
+The results included in this response will coincide with the country associated with your Mercado Pago account. For more information about this feature and its attributes, go to  [API reference](https://www.mercadopago.com.ar/developers/en/reference/payment_methods/_payment_methods/get).
 
 ## Payment methods by country
 

--- a/guides/resources/localization/payment-methods.es.md
+++ b/guides/resources/localization/payment-methods.es.md
@@ -89,7 +89,7 @@ curl -X GET \
 		...
 	]
 
-Los resultados incluídos en esta respuesta coincidirán con el país asociado a tu cuenta de Mercado Pago. Puedes obtener más información sobre este recurso y sus atributos en la [Referencia de API](https://www.mercadopago.com.ar/developers/es/reference/payment_methods/_payment_methods/get/).
+Los resultados incluídos en esta respuesta coincidirán con el país asociado a tu cuenta de Mercado Pago. Puedes obtener más información sobre este recurso y sus atributos en la [Referencia de API](https://www.mercadopago.com.ar/developers/es/reference/payment_methods/_payment_methods/get).
 
 ## Medios de pago por país
 

--- a/guides/resources/localization/payment-methods.pt.md
+++ b/guides/resources/localization/payment-methods.pt.md
@@ -70,7 +70,7 @@ curl -X GET \
 	]
 ```
 
-Os resultados incluídos nesta resposta coincidirão com o país associado à sua conta Mercado Pago. Você poderá obter mais informações sobre este recurso e seus atributos na [Referência da API](https://www.mercadopago.com.br/developers/pt/reference/payment_methods/_payment_methods/get/).
+Os resultados incluídos nesta resposta coincidirão com o país associado à sua conta Mercado Pago. Você poderá obter mais informações sobre este recurso e seus atributos na [Referência da API](https://www.mercadopago.com.br/developers/pt/reference/payment_methods/_payment_methods/get).
 
 ## Meios de pagamento por país
 


### PR DESCRIPTION
Se actualizan todos los links de APIReference para evitar la barra al final de la URL y mejorar el SEO de nuestro sitio