### PR TITLE
Fix VTEX h4

### DIFF
--- a/guides/plugins/unofficial/vtex.es.md
+++ b/guides/plugins/unofficial/vtex.es.md
@@ -100,6 +100,7 @@ Para poder utilizar este tipo de checkout se tienen que configurar los medios de
 
 
 <br>
+
 #### Condición de pagos para tarjeta de crédito
 
 Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
@@ -123,6 +124,7 @@ Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para tarjeta de débito
 
 Para crear una condición de pagos con tarjeta de débito, sigue estos pasos:
@@ -137,6 +139,7 @@ Para crear una condición de pagos con tarjeta de débito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para medios de pago en efectivo
 
 Para crear una condición de pago con medios de pago en efectivo, sigue estos pasos:
@@ -296,6 +299,7 @@ Para poder utilizar este tipo de checkout se tienen que configurar los medios de
 
 
 <br>
+
 #### Condición de pagos para tarjeta de crédito
 
 Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
@@ -319,6 +323,7 @@ Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para tarjeta de débito
 
 Para crear una condición de pagos con tarjeta de débito, sigue estos pasos:
@@ -333,6 +338,7 @@ Para crear una condición de pagos con tarjeta de débito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para medios de pago en efectivo
 
 Para crear una condición de pago con medios de pago en efectivo, sigue estos pasos:
@@ -455,6 +461,7 @@ Para poder utilizar este tipo de checkout se tienen que configurar los medios de
 
 
 <br>
+
 #### Condición de pagos para tarjeta de crédito
 
 Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
@@ -478,6 +485,7 @@ Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para medios de pago por transferencia bancaria
 
 Para crear una condición de pago con WebPay, sigue estos pasos: 
@@ -494,6 +502,7 @@ Para crear una condición de pago con WebPay, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para medios de pago en efectivo
 
 Para crear una condición de pago con medios de pago en efectivo, sigue estos pasos: 
@@ -640,6 +649,7 @@ Para poder utilizar este tipo de checkout se tienen que configurar los medios de
 
 
 <br>
+
 #### Condición de pagos para tarjeta de crédito
 
 Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
@@ -664,6 +674,7 @@ Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para tarjeta de débito
 
 Para crear una condición de pagos con tarjeta de débito, sigue estos pasos:
@@ -679,6 +690,7 @@ Para crear una condición de pagos con tarjeta de débito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para medios de pago por transferencia bancaria
 
 Para crear una condición de pago con PSE, sigue estos pasos: 
@@ -695,6 +707,7 @@ Para crear una condición de pago con PSE, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para medios de pago en efectivo
 
 Para crear una condición de pago con medios de pago en efectivo, sigue estos pasos: 
@@ -852,6 +865,7 @@ Para poder utilizar este tipo de checkout se tienen que configurar los medios de
 
 
 <br>
+
 #### Condición de pagos para tarjeta de crédito
 
 Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
@@ -876,6 +890,7 @@ Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para tarjeta de débito
 
 Para crear una condición de pagos con tarjeta de débito, sigue estos pasos:
@@ -890,6 +905,7 @@ Para crear una condición de pagos con tarjeta de débito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para medios de pago en efectivo
 
 Para crear una condición de pago con medios de pago en efectivo, sigue estos pasos: 
@@ -1014,6 +1030,7 @@ Para poder utilizar este tipo de checkout se tienen que configurar los medios de
 
 
 <br>
+
 #### Condición de pagos para tarjeta de crédito
 
 Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
@@ -1037,6 +1054,7 @@ Para crear una condición de pagos con tarjeta de crédito, sigue estos pasos:
 
 
 <br>
+
 #### Condición de pagos para medios de pago en efectivo
 
 Para crear una condición de pago con medios de pago en efectivo, sigue estos pasos: 


### PR DESCRIPTION
## Description
Se arregla los h4 que quedan rotos en la nueva lib cuando no hay breakline entre el <br> y el ####

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #<issue>

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
