### PR TITLE
Cambio links en html con tag <a> a links en formato Markdown

### DIFF
--- a/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.en.md
@@ -86,7 +86,7 @@ Answer will be `HTTP 204 No Content`.
 
 Implement IPN `merchant_order` with an order search by `external_reference` as a contingency method.
 
-<a href="https://www.mercadopago.com.ar/developers/en/guides/notifications/ipn/" target="_blank"> Receive IPN notifications </a>
+[Receive IPN notifications](https://www.mercadopago.com.ar/developers/en/guides/notifications/ipn)
 
 ---
 ### Next steps

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.es.md
@@ -85,7 +85,7 @@ Las notificaciones IPN (Instant Payment Notification) son la **forma automática
 
 Implementa IPN de `merchant_order` junto con una búsqueda de la orden por `external_reference` como método de contigencia.
 
-<a href="https://www.mercadopago.com.ar/developers/es/guides/notifications/ipn/" target="_blank">Recibir notificaciones IPN</a>
+[Recibir notificaciones IPN](https://www.mercadopago.com.ar/developers/es/guides/notifications/ipn)
 
 ---
 ### Próximos pasos

--- a/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
+++ b/guides/in-person-payments/qr-code/qr-attended-part-b.pt.md
@@ -82,7 +82,7 @@ As [notificações IPN](https://www.mercadopago.com.br/developers/pt/guides/noti
 
 Implementa IPN de `merchant_order` junto com uma busca do pedido por `external_reference` como método de contingência.
 
-<a href="https://www.mercadopago.com.ar/developers/pt/guides/notifications/ipn/" target="_blank"> Receber notificações IPN </a>
+[Receber notificações IPN](https://www.mercadopago.com.ar/developers/pt/guides/notifications/ipn)
 
 ---
 ### Próximos passos

--- a/guides/online-payments/checkout-api/previous-requirements.en.md
+++ b/guides/online-payments/checkout-api/previous-requirements.en.md
@@ -44,7 +44,7 @@ Install an [official SDK](https://www.mercadopago[FAKER][URL][DOMAIN]/developers
 [[[
 ```php
 ===
-<a href="https://getcomposer.org/download" target="_blank"> Install Composer</a> to use the SDK.
+[Install Composer](https://getcomposer.org/download) to use the SDK.
 
 Then run the following code on the command line:
 ===
@@ -52,13 +52,13 @@ php composer.phar require "mercadopago/dx-php:dev-master"
 ```
 ```node
 ===
-To install the SDK you must execute the following code on the command line of your terminal using <a href="https://www.npmjs.com/get-npm" target="_blank">npm</a>:
+To install the SDK you must execute the following code on the command line of your terminal using [npm](https://www.npmjs.com/get-npm):
 ===
 npm install mercadopago
 ```
 ```java
 ===
-To install the SDK in your <a href="http://maven.apache.org/install.html" target="_blank"> Maven </a> project, add the following dependency in your pom.xml file and then run ´maven install´.
+To install the SDK in your [Maven](http://maven.apache.org/install.html) project, add the following dependency in your pom.xml file and then run ´maven install´.
 ===
 <dependency>
             <groupId> com.mercadopago </groupId>
@@ -68,17 +68,17 @@ To install the SDK in your <a href="http://maven.apache.org/install.html" target
 ```
 ```ruby
 ===
-The Mercado Pago SDK is available as a <a href="https://rubygems.org/gems/mercadopago-sdk" target="_blank"> gema</a>, to install it you must execute the following code on the command line:
+The Mercado Pago SDK is available as a [gema](https://rubygems.org/gems/mercadopago-sdk), to install it you must execute the following code on the command line:
 ===
 gem install mercadopago-sdk
 ```
 ```csharp
 ===
 ----[mlb]----
-Use <a href="https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> to install the Mercado Pago SDK .NET.
+Use [NuGet](https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools) to install the Mercado Pago SDK .NET.
 ------------
 ----[mla, mco, mlu, mlc, mlm]----
-Use <a href="https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> to install the Mercado Pago SDK .NET.
+Use [NuGet](https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools) to install the Mercado Pago SDK .NET.
 ------------
 To do this, run the following command in the NuGet Package Manager console:
 ===

--- a/guides/online-payments/checkout-api/previous-requirements.en.md
+++ b/guides/online-payments/checkout-api/previous-requirements.en.md
@@ -68,7 +68,7 @@ To install the SDK in your [Maven](http://maven.apache.org/install.html) project
 ```
 ```ruby
 ===
-The Mercado Pago SDK is available as a [gema](https://rubygems.org/gems/mercadopago-sdk), to install it you must execute the following code on the command line:
+The Mercado Pago SDK is available as a [gem](https://rubygems.org/gems/mercadopago-sdk), to install it you must execute the following code on the command line:
 ===
 gem install mercadopago-sdk
 ```

--- a/guides/online-payments/checkout-api/previous-requirements.es.md
+++ b/guides/online-payments/checkout-api/previous-requirements.es.md
@@ -43,7 +43,7 @@ Instala un [SDKs oficial](https://www.mercadopago[FAKER][URL][DOMAIN]/developers
 [[[
 ```php
 ===
-<a href="https://getcomposer.org/download" target="_blank"> Instala Composer</a> para usar el SDK.
+[Instala Composer](https://getcomposer.org/download) para usar el SDK.
 
 Luego ejecuta el siguiente código en la línea de comandos:
 ===
@@ -51,13 +51,13 @@ php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===
-Para instalar el SDK debes ejecutar el siguiente código en la línea de comandos de tu terminal usando <a href="https://www.npmjs.com/get-npm" target="_blank">npm</a>:
+Para instalar el SDK debes ejecutar el siguiente código en la línea de comandos de tu terminal usando [npm](https://www.npmjs.com/get-npm):
 ===
 npm install mercadopago
 ```
 ```java
 ===
-Para instalar el SDK en tu proyecto <a href="http://maven.apache.org/install.html" target="_blank"> Maven </a> agrega la siguiente dependencia en tu archivo pom.xml y luego ejecuta 'maven install'.
+Para instalar el SDK en tu proyecto [Maven](http://maven.apache.org/install.html) agrega la siguiente dependencia en tu archivo pom.xml y luego ejecuta 'maven install'.
 ===
 <dependency>
             <groupId> com.mercadopago </groupId>
@@ -67,17 +67,17 @@ Para instalar el SDK en tu proyecto <a href="http://maven.apache.org/install.htm
 ```
 ```ruby
 ===
-El SDK de Mercado Pago está disponible como <a href="https://rubygems.org/gems/mercadopago-sdk" target="_blank"> gema</a>, para instalarla debes ejecutar el siguiente código en la línea de comandos:
+El SDK de Mercado Pago está disponible como [gema](https://rubygems.org/gems/mercadopago-sdk), para instalarla debes ejecutar el siguiente código en la línea de comandos:
 ===
 gem install mercadopago-sdk
 ```
 ```csharp
 ===
 ----[mlb]----
-Usa <a href="https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> para instalar el SDK .NET de Mercado Pago.
+Usa [NuGet](https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools) para instalar el SDK .NET de Mercado Pago.
 ------------
 ----[mla, mlm, mco, mlc, mlu]----
-Usa <a href="https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> para instalar el SDK .NET de Mercado Pago.
+Usa [NuGet](https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools) para instalar el SDK .NET de Mercado Pago.
 ------------
 Para hacerlo ejecuta el siguiente comando en la consola del NuGet Package Manager:
 ===

--- a/guides/online-payments/checkout-api/previous-requirements.pt.md
+++ b/guides/online-payments/checkout-api/previous-requirements.pt.md
@@ -44,7 +44,7 @@ Instale o [SDKs oficial](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/
 [[[
 ```php
 ===
-<a href="https://getcomposer.org/download" target="_blank"> Instale Composer</a> para usar o SDK.
+[Instale Composer](https://getcomposer.org/download) para usar o SDK.
 
 Execute o seguinte código na sua linha de comando:
 ===
@@ -52,13 +52,13 @@ php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===
-Para instalar o SDK execute o seguinte código via linha de comandos do seu terminal usando <a href="https://www.npmjs.com/get-npm" target="_blank">npm</a>:
+Para instalar o SDK execute o seguinte código via linha de comandos do seu terminal usando [npm](https://www.npmjs.com/get-npm):
 ===
 npm install mercadopago
 ```
 ```java
 ===
-Para instalar o SDK no seu projeto <a href="http://maven.apache.org/install.html" target="_blank"> Maven </a> adicione a seguinte dependência no seu arquivo pom.xml e em seguida execute 'maven install'.
+Para instalar o SDK no seu projeto [Maven](http://maven.apache.org/install.html) adicione a seguinte dependência no seu arquivo pom.xml e em seguida execute 'maven install'.
 ===
 <dependency>
             <groupId> com.mercadopago </groupId>
@@ -68,17 +68,17 @@ Para instalar o SDK no seu projeto <a href="http://maven.apache.org/install.html
 ```
 ```ruby
 ===
-O SDK de Mercado Pago está disponível como <a href="https://rubygems.org/gems/mercadopago-sdk" target="_blank"> gema</a>, para instá-la execute o seguinte código na sua linha de comandos:
+O SDK de Mercado Pago está disponível como [gema](https://rubygems.org/gems/mercadopago-sdk), para instá-la execute o seguinte código na sua linha de comandos:
 ===
 gem install mercadopago-sdk
 ```
 ```csharp
 ===
 ----[mlb]----
-Use <a href="https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> para instalar o SDK .NET de Mercado Pago.
+Use [NuGet](https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools) para instalar o SDK .NET de Mercado Pago.
 ------------
 ----[mla, mlm, mco, mlc, mlu]----
-Use <a href="https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> para instalar el SDK .NET de Mercado Pago.
+Use [NuGet](https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools) para instalar el SDK .NET de Mercado Pago.
 ------------
 Execute o seguinte comando no seu console do NuGet Package Manager:
 ===

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
@@ -539,14 +539,14 @@ Finally, you always need to be notified of new payments and status updates.  For
 >
 > Checkout API
 >
-> Use our <a href="http://github.com/mercadopago/card-payment-sample" target="_blank">complete integration examples</a> on GitHub in PHP or NodeJS to download instantly.
+> Use our [complete integration examples](http://github.com/mercadopago/card-payment-sample) on GitHub in PHP or NodeJS to download instantly.
 
 <span></span>
 > GIT
 >
 > Payment form
 >
-> If you want to deploy other technology in your server, you can <a href="https://github.com/mercadopago/card-payment-sample/tree/master/client" target="_blank">download a complete payment form sample</a> from GitHub.
+> If you want to deploy other technology in your server, you can [download a complete payment form sample](https://github.com/mercadopago/card-payment-sample/tree/master/client) from GitHub.
 
 ---
 ### Next steps

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
@@ -556,14 +556,14 @@ Por último, es importante que estés siempre informado sobre la creación de nu
 > Checkout API
 ------------
 >
-> Te dejamos <a href="http://github.com/mercadopago/card-payment-sample" target="_blank">ejemplos completos de integración</a> en GitHub para PHP o NodeJS para que puedas descargar al instante.
+> Te dejamos [ejemplos completos de integración](http://github.com/mercadopago/card-payment-sample) en GitHub para PHP o NodeJS para que puedas descargar al instante.
 
 <span></span>
 > GIT
 >
 > Formulario de pago
 >
-> Si quieres implementar tu servidor con alguna otra tecnología, te dejamos un <a href="https://github.com/mercadopago/card-payment-sample/tree/master/client" target="_blank">ejemplo completo del formulario de pago</a> en GitHub para que puedas descargar.
+> Si quieres implementar tu servidor con alguna otra tecnología, te dejamos un [ejemplo completo del formulario de pago](https://github.com/mercadopago/card-payment-sample/tree/master/client) en GitHub para que puedas descargar.
 
 ---
 ### Próximos pasos

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
@@ -563,14 +563,14 @@ Por último, é importante que esteja sempre informado sobre a criação nos nov
 > Checkout API
 ------------
 >
-> Disponibilizamos <a href="http://github.com/mercadopago/card-payment-sample" target="_blank">exemplos completos de integração</a> no GitHub para PHP ou NodeJS para que você possa fazer o download imediatamente.
+> Disponibilizamos [exemplos completos de integração](http://github.com/mercadopago/card-payment-sample) no GitHub para PHP ou NodeJS para que você possa fazer o download imediatamente.
 
 <span></span>
 > GIT
 >
 > Formulário de pagamento
 >
-> Se você deseja implementar seu servidor com alguma outra tecnologia, te deixamos um <a href="https://github.com/mercadopago/card-payment-sample/tree/master/client" target="_blank">exemplo completo do formulário de pagamento </a> no GitHub para que possa baixar.
+> Se você deseja implementar seu servidor com alguma outra tecnologia, te deixamos um [exemplo completo do formulário de pagamento ](https://github.com/mercadopago/card-payment-sample/tree/master/client) no GitHub para que possa baixar.
 
 ---
 ### Próximos passos

--- a/guides/online-payments/checkout-api/testing.en.md
+++ b/guides/online-payments/checkout-api/testing.en.md
@@ -154,7 +154,7 @@ To **test different payment results,** complete the information you want in the 
 
 ## Start receiving payments
 
-To start charging, you need to meet the [production environment requirements](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/checkout-api/goto-production/), and must <a href="[FAKER][CREDENTIALS][URL]" target="_blank">activate your credentials</a>.
+To start charging, you need to meet the [production environment requirements](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/checkout-api/goto-production), and must [activate your credentials]([FAKER][CREDENTIALS][URL]).
 
 Before activating them, verify that the credentials in your integration are those of the account that receives the money from the sales.<br/>
 

--- a/guides/online-payments/checkout-api/testing.es.md
+++ b/guides/online-payments/checkout-api/testing.es.md
@@ -154,7 +154,7 @@ Para **probar distintos resultados de pago**, completa el dato que quieras en el
 
 ## Comenzar a recibir pagos
 
-Para empezar a cobrar, debes cumplir los [requisitos para ir a producción](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/goto-production) y [ activar tus credenciales]([FAKER][CREDENTIALS][URL]).
+Para empezar a cobrar, debes cumplir los [requisitos para ir a producción](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/goto-production) y [activar tus credenciales]([FAKER][CREDENTIALS][URL]).
 
 Antes de activarlas, verifica que las credenciales en tu integración sean las de la cuenta que reciba el dinero de las ventas.<br/>
 

--- a/guides/online-payments/checkout-api/testing.es.md
+++ b/guides/online-payments/checkout-api/testing.es.md
@@ -154,7 +154,7 @@ Para **probar distintos resultados de pago**, completa el dato que quieras en el
 
 ## Comenzar a recibir pagos
 
-Para empezar a cobrar, debes cumplir los [requisitos para ir a producción](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/goto-production/) y <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> activar tus credenciales</a>.
+Para empezar a cobrar, debes cumplir los [requisitos para ir a producción](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/goto-production) y [ activar tus credenciales]([FAKER][CREDENTIALS][URL]).
 
 Antes de activarlas, verifica que las credenciales en tu integración sean las de la cuenta que reciba el dinero de las ventas.<br/>
 

--- a/guides/online-payments/checkout-api/testing.pt.md
+++ b/guides/online-payments/checkout-api/testing.pt.md
@@ -153,7 +153,7 @@ Para **testar resultados diferentes de pagamento**, complete o dado que queira n
 
 ## Começar a receber pagamentos
 
-Para começar a cobrar, você deve cumprir os [requisitos para ir a produção](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/goto-production/) e <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> ativar suas credenciais</a>.
+Para começar a cobrar, você deve cumprir os [requisitos para ir a produção](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/goto-production) e [ ativar suas credenciais]([FAKER][CREDENTIALS][URL]).
 
 Antes de ativá-las, certifique-se de que as credenciais na sua integração sejam as da conta que recebe o dinheiro das vendas.<br/>
 

--- a/guides/online-payments/checkout-api/testing.pt.md
+++ b/guides/online-payments/checkout-api/testing.pt.md
@@ -153,7 +153,7 @@ Para **testar resultados diferentes de pagamento**, complete o dado que queira n
 
 ## Começar a receber pagamentos
 
-Para começar a cobrar, você deve cumprir os [requisitos para ir a produção](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/goto-production) e [ ativar suas credenciais]([FAKER][CREDENTIALS][URL]).
+Para começar a cobrar, você deve cumprir os [requisitos para ir a produção](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/goto-production) e [ativar suas credenciais]([FAKER][CREDENTIALS][URL]).
 
 Antes de ativá-las, certifique-se de que as credenciais na sua integração sejam as da conta que recebe o dinheiro das vendas.<br/>
 

--- a/guides/online-payments/checkout-api/wallet-integration.en.md
+++ b/guides/online-payments/checkout-api/wallet-integration.en.md
@@ -18,10 +18,10 @@ This means that your customers have more ways to pay you and can access better b
   They also have their **addresses saved**, which simplifies the whole information entering process.
   * **With balance available in Mercado Pago** they have the money ready to be used on the spot, in just 1 click.
 ----[mla]----
-* Your clients can pay you in up to 12 installments without using a credit card, being financed by <a href="https://www.mercadolibre.com.ar/mercado-credito/meses-sin-tarjeta/" target="_blank"> Mercado Crédito</a>.
+* Your clients can pay you in up to 12 installments without using a credit card, being financed by [Mercado Crédito](https://www.mercadolibre.com.ar/mercado-credito/meses-sin-tarjeta/).
 ------------
 ----[mlb]----
-* Your clients can pay you in up to 12 installments without using a credit card, being financed by <a href="https://www.mercadolibre.com.br/mercado-credito/meses-sin-tarjeta/" target="_blank"> Mercado Crédito</a>.
+* Your clients can pay you in up to 12 installments without using a credit card, being financed by [Mercado Crédito](https://www.mercadolibre.com.br/mercado-credito/meses-sin-tarjeta/).
 ------------
 * Your checkout conversion improves by offering more dynamic and easy-to-use payment methods.
 * Improve approval of your payments with less risk of fraud.

--- a/guides/online-payments/checkout-api/wallet-integration.es.md
+++ b/guides/online-payments/checkout-api/wallet-integration.es.md
@@ -13,10 +13,10 @@ Esto significa que tus clientes tienen más formas de pagarte y pueden acceder a
   También tienen sus **direcciones guardadas**, lo que simplifica todo el proceso de carga.
   * **Con dinero disponible en Mercado Pago** tienen su dinero listo para ser usado en el momento, en tan solo 1 click.
 ----[mla]----
-* Tus clientes pueden pagarte en hasta 12 cuotas sin usar tarjeta de crédito, siendo financiados por <a href="https://www.mercadolibre.com.ar/mercado-credito/meses-sin-tarjeta/" target="_blank"> Mercado Crédito</a>.
+* Tus clientes pueden pagarte en hasta 12 cuotas sin usar tarjeta de crédito, siendo financiados por [Mercado Crédito](https://www.mercadolibre.com.ar/mercado-credito/meses-sin-tarjeta/).
 ------------
 ----[mlb]----
-* Tus clientes pueden pagarte en hasta 12 cuotas sin usar tarjeta de crédito, siendo financiados por <a href="https://www.mercadolibre.com.br/mercado-credito/meses-sin-tarjeta/" target="_blank"> Mercado Crédito</a>.
+* Tus clientes pueden pagarte en hasta 12 cuotas sin usar tarjeta de crédito, siendo financiados por [Mercado Crédito](https://www.mercadolibre.com.br/mercado-credito/meses-sin-tarjeta/).
 ------------
 * La conversión de tu Checkout mejora al ofrecer medios de pago más dinámicos y fáciles de usar.
 * Mejora la aprobación de tus pagos con menor riesgo de fraude.

--- a/guides/online-payments/checkout-api/wallet-integration.pt.md
+++ b/guides/online-payments/checkout-api/wallet-integration.pt.md
@@ -13,10 +13,10 @@ Isto significa que seus clientes têm mais formas de te pagar e podem ter acesso
   Eles também têm seus endereços salvos, o que simplifica todo o processo de preenchimento.
   * **Com saldo disponível no Mercado Pago**, o dinheiro está pronto para ser usado na hora, em 1 clique.
 ----[mla]----
-* Seus clientes podem pagar em até 12 vezes no boleto, com parcelamento financiado pelo <a href="https://www.mercadolibre.com.ar/mercado-credito/meses-sin-tarjeta/" target="_blank"> Mercado Crédito</a>.
+* Seus clientes podem pagar em até 12 vezes no boleto, com parcelamento financiado pelo [Mercado Crédito](https://www.mercadolibre.com.ar/mercado-credito/meses-sin-tarjeta/).
 ------------
 ----[mlb]----
-* Seus clientes podem pagar em até 12 vezes no boleto, com parcelamento financiado pelo <a href="https://www.mercadolibre.com.br/mercado-credito/meses-sin-tarjeta/" target="_blank"> Mercado Crédito</a>.
+* Seus clientes podem pagar em até 12 vezes no boleto, com parcelamento financiado pelo [Mercado Crédito](https://www.mercadolibre.com.br/mercado-credito/meses-sin-tarjeta/).
 ------------
 * A conversão do seu Checkout melhora ao oferecer meios de pagamento mais dinâmicos e fáceis de usar.
 * Melhora a aprovação dos seus pagamentos com menos risco de fraude.

--- a/guides/online-payments/checkout-pro/advanced-integration.en.md
+++ b/guides/online-payments/checkout-pro/advanced-integration.en.md
@@ -5,7 +5,7 @@
 IPN (Instant Payment Notification) notifications are the **automatic form of notice of the creation of new payments and updates of their status.** For example if they were approved, rejected or if they are pending.
 They allow you to manage your stock and keep your system in sync.
 
-<a href="https://www.mercadopago.com.ar/developers/en/guides/notifications/ipn/" target="_blank">Receive IPN notifications</a>
+[Receive IPN notifications](https://www.mercadopago.com.ar/developers/en/guides/notifications/ipn)
 
 ## Additional information for the preference
 
@@ -318,21 +318,21 @@ Preference preference = new Preference();
 
 A payment can be rejected because the issuer for the selected method detected a problem or because of non-compliance with security requirements.
 
-Avoid rejected payments with our recommendations and <a href="https://www.mercadopago.com.ar/developers/en/guides/manage-account/account/payment-rejections" target="_blank">improve the approval process</a>.
+Avoid rejected payments with our recommendations and [improve the approval process](https://www.mercadopago.com.ar/developers/en/guides/manage-account/account/payment-rejections).
 
 ## Cancellations and Returns
 
 Cancellations are made when the cash payment was not completed before the expiration date and the seller decides to cancel it.
 And the returns happen when the payment was made but the seller decides to cancel it totally or partially.
 
-You can find all the information in the <a href="https://www.mercadopago.com.ar/developers/en/guides/manage-account/account/cancellations-and-refunds" target="_blank"> Returns and Cancellations section</a>.
+You can find all the information in the [Returns and Cancellations section](https://www.mercadopago.com.ar/developers/en/guides/manage-account/account/cancellations-and-refunds).
 
 ## Manage Chargebacks
 
 A _chargeback_ occurs when the buyer contacts the entity that issued the card and communicates that they do not recognize the payment.
 This means that the seller's money for that payment will be withheld from their Mercado Pago account until it is settled.
 
-<a href="https://www.mercadopago.com.ar/developers/en/guides/manage-account/account/chargebacks/" target="_blank"> Manage Chargebacks</a>
+[Manage Chargebacks](https://www.mercadopago.com.ar/developers/en/guides/manage-account/account/chargebacks)
 
 ---
 

--- a/guides/online-payments/checkout-pro/advanced-integration.es.md
+++ b/guides/online-payments/checkout-pro/advanced-integration.es.md
@@ -5,7 +5,7 @@
 Las notificaciones IPN (Instant Payment Notification) son la **forma automática de aviso de la creación de nuevos pagos y las actualizaciones de sus estados.** Por ejemplo si fueron aprobados, rechazados o si se encuentran pendientes.
 Te permiten administrar tu stock y mantener tu sistema sincronizado.
 
-<a href="https://www.mercadopago.com.ar/developers/es/guides/notifications/ipn/" target="_blank">Recibir notificaciones IPN</a>
+[Recibir notificaciones IPN](https://www.mercadopago.com.ar/developers/es/guides/notifications/ipn)
 
 ## Información adicional para la preferencia
 
@@ -320,21 +320,21 @@ Preference preference = new Preference();
 
 Un pago puede ser rechazado porque el emisor del medio de pago detecta un problema o porque no se cumple con los requisitos de seguridad necesarios.
 
-Evita pagos rechazados con nuestras recomendaciones y <a href="https://www.mercadopago.com.ar/developers/es/guides/manage-account/account/payment-rejections" target="_blank">mejora la aprobación de tus pagos</a>.
+Evita pagos rechazados con nuestras recomendaciones y [mejora la aprobación de tus pagos](https://www.mercadopago.com.ar/developers/es/guides/manage-account/account/payment-rejections).
 
 ## Cancelaciones y devoluciones
 
 Las cancelaciones se efectúan cuando el pago en efectivo no se concretó antes de la fecha de vencimiento y el vendedor decide cancelarlo.
 Y las devoluciones suceden cuando el pago se realizó pero el vendedor decide anularlo total o parcialmente.
 
-Puedes encontrar toda la información en la <a href="https://www.mercadopago.com.ar/developers/es/guides/manage-account/account/cancellations-and-refunds" target="_blank"> sección Devoluciones y cancelaciones</a>.
+Puedes encontrar toda la información en la [sección Devoluciones y cancelaciones](https://www.mercadopago.com.ar/developers/es/guides/manage-account/account/cancellations-and-refunds).
 
 ## Gestiona contracargos
 
 Se produce un contracargo o _chargeback_ cuando el comprador se comunica con la entidad que emitió su tarjeta y desconoce el pago.
 Esto quiere decir que el dinero del vendedor por ese pago será retenido de su cuenta de Mercado Pago hasta que se solucione.
 
-<a href="https://www.mercadopago.com.ar/developers/es/guides/manage-account/account/chargebacks/" target="_blank"> Gestionar contracargos</a>
+[Gestionar contracargos](https://www.mercadopago.com.ar/developers/es/guides/manage-account/account/chargebacks/)
 
 ---
 

--- a/guides/online-payments/checkout-pro/advanced-integration.pt.md
+++ b/guides/online-payments/checkout-pro/advanced-integration.pt.md
@@ -5,7 +5,7 @@
  As notificações IPN (Instant Payment Notification) são a **forma automática de aviso da criação de novos pagamentos e as atualizações de seus status.** Por exemplo se foram aprovados, recusados ou se estão pendentes.
 Permitem que você administre seu estoque e mantenha seu sistema sincronizado.
 
-<a href="https://www.mercadopago.com.br/developers/pt/guides/notifications/ipn/" target="_blank">Receber notificações IPN</a>
+[Receber notificações IPN](https://www.mercadopago.com.br/developers/pt/guides/notifications/ipn/)
 
 ## Informações adicionais para a preferência
 
@@ -317,21 +317,21 @@ Preference preference = new Preference();
 
 Um pagamento pode ser recusado porque o emissor do meio de pagamento detecta um problema ou porque não preenche os requisitos de segurança necessários.
 
-Evite pagamentos recusados com nossas recomendações e <a href="https://www.mercadopago.com.ar/developers/pt/guides/manage-account/account/payment-rejections" target="_blank">melhore a aprovação de seus pagamentos</a>.
+Evite pagamentos recusados com nossas recomendações e [melhore a aprovação de seus pagamentos](https://www.mercadopago.com.ar/developers/pt/guides/manage-account/account/payment-rejections).
 
 ## Cancelamentos e estornos
 
 Os cancelamentos são feitos quando o pagamento não foi concluído antes da data de vencimento e o vendedor decide cancelá-lo.
 As devoluções acontecem quando o pagamento foi feito, mas o vendedor decide estorná-lo, total ou parcialmente.
 
-Você pode encontrar todas as informações na <a href="https://www.mercadopago.com.br/developers/pt/guides/manage-account/account/cancellations-and-refunds" target="_blank"> seção de Devoluções e cancelamentos</a>.
+Você pode encontrar todas as informações na [ seção de Devoluções e cancelamentos](https://www.mercadopago.com.br/developers/pt/guides/manage-account/account/cancellations-and-refunds).
 
 ## Gerencie contestações
 
 Uma contestação ou chargeback acontece quando o comprador entra em contato com a entidade emissora do cartão e desconhece o pagamento.
 Isso significa que o dinheiro do vendedor, por esse pagamento, será retido da sua conta do Mercado Pago até que seja solucionada.
 
-<a href="https://www.mercadopago.com.br/developers/pt/guides/manage-account/account/chargebacks/" target="_blank"> Gerenciar contestações</a>
+[ Gerenciar contestações](https://www.mercadopago.com.br/developers/pt/guides/manage-account/account/chargebacks/)
 
 ---
 

--- a/guides/online-payments/checkout-pro/configurations.en.md
+++ b/guides/online-payments/checkout-pro/configurations.en.md
@@ -170,8 +170,8 @@ You can also set a payment method to appear by default or define the maximum num
 | Attribute | Description |
 | --- | --- |
 | `payment_methods` | Class that describes the attributes and methods of payment methods. |
-| `excluded_payment_methods` | Method that excludes by specific <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/resources/localization/payment-methods/#bookmark_payment_methods_by_country" target="_blank">payment methods</a>: Visa, Mastercard or American Express, among others. |
-| `excluded_payment_types` | Method that excludes by type of <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/resources/localization/payment-methods/#bookmark_payment_methods_by_country" target="_blank">payment method</a>: cash, credit or debit cards. |
+| `excluded_payment_methods` | Method that excludes by specific [payment methods](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/resources/localization/payment-methods#bookmark_payment_methods_by_country): Visa, Mastercard or American Express, among others. |
+| `excluded_payment_types` | Method that excludes by type of [payment method](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/resources/localization/payment-methods#bookmark_payment_methods_by_country): cash, credit or debit cards. |
 | `installments` | Method that defines the amount of maximum number of installments to offer. |
 | `purpose` | When the "wallet purchase" value is indicated, Checkout will accept payments exclusively from Mercado Pago registered users, with card and account balance. |
 
@@ -874,7 +874,7 @@ curl -X POST \
 ![Pago 2 tarjetas](/images/web-payment-checkout/pay_2_tarjetas.png)
 
 You can enable the option to offer to pay with two credit cards from the Mercado Pago account.
-To activate the payment option, go to your <a href="https://www.mercadopago.com.ar/settings/my-business" target="_blank">business options</a> and choose the option _Receive payments with 2 credit cards_.
+To activate the payment option, go to your [business options](https://www.mercadopago.com.ar/settings/my-business) and choose the option _Receive payments with 2 credit cards_.
 
 ![Config pago 2 tarjetas](/images/web-payment-checkout/config_pago_dos_tarjetas.gif)
 

--- a/guides/online-payments/checkout-pro/configurations.es.md
+++ b/guides/online-payments/checkout-pro/configurations.es.md
@@ -176,8 +176,8 @@ También se puede definir un medio de pago para que aparezca por defecto o la ca
 | Atributo | Descripción |
 | --- | --- |
 | `payment_methods` | Clase que describe los atributos y métodos de medios de pago. |
-| `excluded_payment_methods` | Método que excluye por <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/localization/payment-methods/#bookmark_medios_de_pago_por_país" target="_blank">medios de pago</a> específicos: Visa, Mastercard o American Express, entre otras. |
-| `excluded_payment_types` | Método que excluye por tipo de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/localization/payment-methods/#bookmark_medios_de_pago_por_país" target="_blank">medios de pago</a>: efectivo, tarjetas de crédito o débito. |
+| `excluded_payment_methods` | Método que excluye por [medios de pago](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/localization/payment-methods#bookmark_medios_de_pago_por_país) específicos: Visa, Mastercard o American Express, entre otras. |
+| `excluded_payment_types` | Método que excluye por tipo de [medios de pago](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/localization/payment-methods#bookmark_medios_de_pago_por_país): efectivo, tarjetas de crédito o débito. |
 | `installments` | Método que define la cantidad de cuotas máximas a ofrecer. |
 | `purpose` | Cuando se indique el valor "wallet_purchase", el Checkout aceptará pagos exclusivamente de usuarios registrados en Mercado Pago, con tarjeta y dinero en cuenta. |
 
@@ -187,8 +187,8 @@ También se puede definir un medio de pago para que aparezca por defecto o la ca
 | Atributo | Descripción |
 | --- | --- |
 | `payment_methods` | Clase que describe los atributos y métodos de medios de pago. |
-| `excluded_payment_methods` | Método que excluye por <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/localization/payment-methods/#bookmark_medios_de_pago_por_país" target="_blank">medios de pago</a>  específicos: Visa, Mastercard o American Express, entre otras. |
-| `excluded_payment_types` | Método que excluye por tipo de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/localization/payment-methods/#bookmark_medios_de_pago_por_país" target="_blank">medios de pago</a> : efectivo, tarjetas de crédito o débito. |
+| `excluded_payment_methods` | Método que excluye por [medios de pago](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/localization/payment-methods#bookmark_medios_de_pago_por_país)  específicos: Visa, Mastercard o American Express, entre otras. |
+| `excluded_payment_types` | Método que excluye por tipo de [medios de pago](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/localization/payment-methods#bookmark_medios_de_pago_por_país) : efectivo, tarjetas de crédito o débito. |
 | `installments` | Método que define la cantidad de mensualidades máximas a ofrecer. |
 | `purpose` | Cuando se indique el valor "wallet_purchase", el Checkout aceptará pagos exclusivamente de usuarios registrados en Mercado Pago, con tarjeta y dinero en cuenta.|
 
@@ -919,7 +919,7 @@ curl -X POST \
 ![Pago 2 tarjetas](/images/web-payment-checkout/pay_2_tarjetas.png)
 
 Se puede habilitar la opción de ofrecer pagar con dos tarjetas de crédito desde la cuenta de Mercado Pago.
-Para activar la opción de pago, ve a tus <a href="https://www.mercadopago.com.ar/settings/my-business" target="_blank"> opciones de negocio</a> y elige la opción _Recibir pagos con 2 tarjetas de crédito_.
+Para activar la opción de pago, ve a tus [opciones de negocio](https://www.mercadopago.com.ar/settings/my-business) y elige la opción _Recibir pagos con 2 tarjetas de crédito_.
 
 ![Config pago 2 tarjetas](/images/web-payment-checkout/config_pago_dos_tarjetas.gif)
 

--- a/guides/online-payments/checkout-pro/configurations.pt.md
+++ b/guides/online-payments/checkout-pro/configurations.pt.md
@@ -168,8 +168,8 @@ Você também pode definir um meio de pagamento para que apareça por padrão ou
 | Atributo | Descrição |
 | --- | --- |
 | `payment_methods` | Classe que descreve os atributos e métodos de meios de pagamento. |
-| `excluded_payment_methods` | Método que exclui por <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/resources/localization/payment-methods/#bookmark_meios_de_pagamento_por_país" target="_blank">meios de pagamento</a> específicos: Visa, Mastercard o American Express, entre outros. |
-| `excluded_payment_types` | Método que exclui por tipo de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/resources/localization/payment-methods/#bookmark_meios_de_pagamento_por_país" target="_blank">meio de pagamento</a>: cartão de crédito ou ticket (boleto ou pagamento em lotérica). |
+| `excluded_payment_methods` | Método que exclui por [meios de pagamento](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/resources/localization/payment-methods#bookmark_meios_de_pagamento_por_país) específicos: Visa, Mastercard o American Express, entre outros. |
+| `excluded_payment_types` | Método que exclui por tipo de [meios de pagamento](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/resources/localization/payment-methods#bookmark_meios_de_pagamento_por_país): cartão de crédito ou ticket (boleto ou pagamento em lotérica). |
 | `installments` | Método que define o número máximo de parcelas a oferecer. |
 | `purpose` | Quando for indicado o valor "wallet_purchase", o Checkout aceitará pagamentos exclusivamente de usuários cadastrados no Mercado Pago, com cartão e saldo em conta. |
 
@@ -898,7 +898,7 @@ curl -X POST \
 
 ![Pago 2 tarjetas](/images/web-payment-checkout/pay_2_tarjetas_br.png)
 
-Você pode ativar a opção de oferecer pagamento com dois cartões de crédito da conta do Mercado Pago. Para ativar a opção de pagamento, acesse as <a href="https://www.mercadopago.com.ar/settings/my-business" target="_blank">opcões de negócio</a> e selecione a opção _Receber pagamentos com 2 cartões de crédito_.
+Você pode ativar a opção de oferecer pagamento com dois cartões de crédito da conta do Mercado Pago. Para ativar a opção de pagamento, acesse as [opcões de negócio](https://www.mercadopago.com.ar/settings/my-business) e selecione a opção _Receber pagamentos com 2 cartões de crédito_.
 
 
 ![Config pago 2 tarjetas](/images/web-payment-checkout/config_pago_dos_tarjetas_br.gif)

--- a/guides/online-payments/checkout-pro/integration.en.md
+++ b/guides/online-payments/checkout-pro/integration.en.md
@@ -22,7 +22,7 @@ Installing the Checkout Pro consists of two steps:
 
 Write the following code consisting of three parts:
 
-1.1 Add the <a href="https://www.mercadopago.com.br/developers/en/guides/online-payments/checkout-pro/previous-requirements#bookmark_pré-requisitos" target="_blank"> Mercado Pago SDK</a> in your project:
+1.1 Add the [Mercado Pago SDK](https://www.mercadopago.com.br/developers/en/guides/online-payments/checkout-pro/previous-requirements#bookmark_pré-requisitos) in your project:
 
 [[[
 ```php
@@ -49,7 +49,7 @@ require 'mercadopago.rb'
 ```
 ]]]
 
-<br/><br/>1.2 Add the <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credentials</a> to enable the use of the Mercado Pago SDK:<br/>
+<br/><br/>1.2 Add the [credentials]([FAKER][CREDENTIALS][URL]) to enable the use of the Mercado Pago SDK:<br/>
 
 [[[
 ```php

--- a/guides/online-payments/checkout-pro/integration.es.md
+++ b/guides/online-payments/checkout-pro/integration.es.md
@@ -22,7 +22,7 @@ Instalar el Checkout Pro consta de dos pasos:
 
 Escribe el siguiente código que consta de tres partes:
 
-1.1 Suma la <a href="https://www.mercadopago.com.ar/developers/es/guides/online-payments/checkout-pro/previous-requirements#bookmark_requisitos_previos" target="_blank"> SDK de Mercado Pago</a> en tu proyecto:
+1.1 Suma la [SDK de Mercado Pago](https://www.mercadopago.com.ar/developers/es/guides/online-payments/checkout-pro/previous-requirements#bookmark_requisitos_previos) en tu proyecto:
 
 [[[
 ```php
@@ -49,7 +49,7 @@ require 'mercadopago.rb'
 ```
 ]]]
 
-<br/><br/>1.2 Agrega las <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciales</a> para habilitar el uso de la SDK de Mercado Pago:<br/>
+<br/><br/>1.2 Agrega las [credenciales]([FAKER][CREDENTIALS][URL]) para habilitar el uso de la SDK de Mercado Pago:<br/>
 
 [[[
 ```php

--- a/guides/online-payments/checkout-pro/integration.pt.md
+++ b/guides/online-payments/checkout-pro/integration.pt.md
@@ -22,7 +22,7 @@ Instalar o Checkout Pro requer duas etapas:
 
 Insira o seguinte código que consta de três partes:
 
-1.1 Adicione o <a href="https://www.mercadopago.com.br/developers/pt/guides/online-payments/checkout-pro/previous-requirements#bookmark_pré-requisitos" target="_blank"> SDK do Mercado Pago</a> no seu projeto:
+1.1 Adicione o [SDK do Mercado Pago](https://www.mercadopago.com.br/developers/pt/guides/online-payments/checkout-pro/previous-requirements#bookmark_pré-requisitos) no seu projeto:
 
 [[[
 ```php
@@ -49,7 +49,7 @@ require 'mercadopago.rb'
 ```
 ]]]
 
-<br/><br/>1.2 Adicione as <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciais</a> para habilitar o uso do SDK do Mercado Pago:<br/>
+<br/><br/>1.2 Adicione as [credenciais]([FAKER][CREDENTIALS][URL]) para habilitar o uso do SDK do Mercado Pago:<br/>
 
 [[[
 ```php

--- a/guides/online-payments/checkout-pro/introduction.en.md
+++ b/guides/online-payments/checkout-pro/introduction.en.md
@@ -12,25 +12,25 @@ Checkout Pro is an integration that allows you to **charge your customers throug
 ## Checkout Pro offers:
 
 ----[mla]----
-* The most popular <a href="https://www.mercadopago.com.ar/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank">payment methods</a> in the country.
+* The most popular [payment methods](https://www.mercadopago.com.ar/ayuda/medios-de-pago-cuotas-promociones_264) in the country.
 ------------
 ----[mlm]----
-*  The most popular <a href="https://www.mercadopago.com.mx/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank">payment methods</a> in the country.
+*  The most popular [payment methods](https://www.mercadopago.com.mx/ayuda/medios-de-pago-cuotas-promociones_264) in the country.
 ------------
 ----[mlc]----
-* The most popular <a href="https://www.mercadopago.cl/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank">payment methods</a> in the country.
+* The most popular [payment methods](https://www.mercadopago.cl/ayuda/medios-de-pago-cuotas-promociones_264) in the country.
 ------------
 ----[mlu]----
-* The most popular <a href="https://www.mercadopago.com.uy/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank">payment methods</a> in the country.
+* The most popular [payment methods](https://www.mercadopago.com.uy/ayuda/medios-de-pago-cuotas-promociones_264) in the country.
 ------------
 ----[mco]----
-* The most popular <a href="https://www.mercadopago.com.co/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank">payment methods</a> in the country.
+* The most popular [payment methods](https://www.mercadopago.com.co/ayuda/medios-de-pago-cuotas-promociones_264) in the country.
 ------------
 ----[mlb]----
-* The most popular <a href="https://www.mercadopago.com.br/ajuda/meios-de-pagamento-parcelamento_265" target="_blank">payment methods</a> in the country.
+* The most popular [payment methods](https://www.mercadopago.com.br/ajuda/meios-de-pagamento-parcelamento_265) in the country.
 ------------
 ----[mpe]----
-* The most popular <a href="https://www.mercadopago.com.pe/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank">payment methods</a> in the country.
+* The most popular [payment methods](https://www.mercadopago.com.pe/ayuda/medios-de-pago-cuotas-promociones_264) in the country.
 ------------
 
 * A shopping experience on your site that's accessible across devices.

--- a/guides/online-payments/checkout-pro/introduction.es.md
+++ b/guides/online-payments/checkout-pro/introduction.es.md
@@ -12,25 +12,25 @@ Checkout Pro es la integración que **te permite cobrar a través de nuestro for
 ## Checkout Pro ofrece:
 
 ----[mla]----
-* Pagar con los principales <a href="https://www.mercadopago.com.ar/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> medios de pago</a> del país.
+* Pagar con los principales [medios de pago](https://www.mercadopago.com.ar/ayuda/medios-de-pago-cuotas-promociones_264) del país.
 ------------
 ----[mlm]----
-* Pagar con los principales <a href="https://www.mercadopago.com.mx/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> medios de pago</a> del país.
+* Pagar con los principales [medios de pago](https://www.mercadopago.com.mx/ayuda/medios-de-pago-cuotas-promociones_264) del país.
 ------------
 ----[mlu]----
-* Pagar con los principales <a href="https://www.mercadopago.com.uy/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> medios de pago</a> del país.
+* Pagar con los principales [medios de pago](https://www.mercadopago.com.uy/ayuda/medios-de-pago-cuotas-promociones_264) del país.
 ------------
 ----[mlc]----
-* Pagar con los principales <a href="https://www.mercadopago.cl/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> medios de pago</a> del país.
+* Pagar con los principales [medios de pago](https://www.mercadopago.cl/ayuda/medios-de-pago-cuotas-promociones_264) del país.
 ------------
 ----[mco]----
-* Pagar con los principales <a href="https://www.mercadopago.com.co/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> medios de pago</a> del país.
+* Pagar con los principales [medios de pago](https://www.mercadopago.com.co/ayuda/medios-de-pago-cuotas-promociones_264) del país.
 ------------
 ----[mlb]----
-* Pagar con los principales <a href="https://www.mercadopago.com.br/ajuda/meios-de-pagamento-parcelamento_265" target="_blank"> medios de pago</a> del país.
+* Pagar con los principales [medios de pago](https://www.mercadopago.com.br/ajuda/meios-de-pagamento-parcelamento_265) del país.
 ------------
 ----[mpe]----
-* Pagar con los principales <a href="https://www.mercadopago.com.pe/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> medios de pago</a> del país.
+* Pagar con los principales [medios de pago](https://www.mercadopago.com.pe/ayuda/medios-de-pago-cuotas-promociones_264) del país.
 ------------
 * Una **experiencia de compra adaptada** y accesible desde cualquier celular o computadora.
 * **Compras en un click.** Al pagar con una cuenta de Mercado Pago, se recuerdan los datos y tarjetas de los compradores, por lo que permite pagos ingresando solo el código de seguridad o dinero en cuenta.

--- a/guides/online-payments/checkout-pro/introduction.pt.md
+++ b/guides/online-payments/checkout-pro/introduction.pt.md
@@ -8,25 +8,25 @@ O Checkout Pro é a integração que **te permite cobrar através do nosso formu
 ## O Checkout Pro oferece:
 
 ----[mla]----
-* Pagar com os principais  <a href="https://www.mercadopago.com.ar/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> meios de pagamento</a> do país.
+* Pagar com os principais [meios de pagamento](https://www.mercadopago.com.ar/ayuda/medios-de-pago-cuotas-promociones_264) do país.
 ------------
 ----[mlb]----
-* Pagar com os principais  <a href="https://www.mercadopago.com.br/ajuda/meios-de-pagamento-parcelamento_265" target="_blank"> meios de pagamento</a> do país.
+* Pagar com os principais [meios de pagamento](https://www.mercadopago.com.br/ajuda/meios-de-pagamento-parcelamento_265) do país.
 ------------
 ----[mlu]----
-* Pagar com os principais  <a href="https://www.mercadopago.com.uy/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> meios de pagamento</a> do país.
+* Pagar com os principais [meios de pagamento](https://www.mercadopago.com.uy/ayuda/medios-de-pago-cuotas-promociones_264) do país.
 ------------
 ----[mlc]----
-* Pagar com os principais  <a href="https://www.mercadopago.cl/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> meios de pagamento</a> do país.
+* Pagar com os principais [meios de pagamento](https://www.mercadopago.cl/ayuda/medios-de-pago-cuotas-promociones_264) do país.
 ------------
 ----[mco]----
-* Pagar com os principais  <a href="https://www.mercadopago.com.co/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> meios de pagamento</a> do país.
+* Pagar com os principais [meios de pagamento](https://www.mercadopago.com.co/ayuda/medios-de-pago-cuotas-promociones_264) do país.
 ------------
 ----[mlm]----
-* Pagar com os principais  <a href="https://www.mercadopago.com.mx/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> meios de pagamento</a> do país.
+* Pagar com os principais [meios de pagamento](https://www.mercadopago.com.mx/ayuda/medios-de-pago-cuotas-promociones_264) do país.
 ------------
 ----[mpe]----
-* Pagar com os principais  <a href="https://www.mercadopago.com.pe/ayuda/medios-de-pago-cuotas-promociones_264" target="_blank"> meios de pagamento</a> do país.
+* Pagar com os principais [meios de pagamento](https://www.mercadopago.com.pe/ayuda/medios-de-pago-cuotas-promociones_264) do país.
 ------------
 * Uma **experiência de compra adaptada** e acessível de qualquer celular ou computador no seu site.
 * **Compras em um clique.** Ao pagar com uma conta do Mercado Pago, os dados e cartões dos compradores são salvos, o que lhes permite pagar informando apenas o código de segurança ou dinheiro na conta.

--- a/guides/online-payments/checkout-pro/previous-requirements.en.md
+++ b/guides/online-payments/checkout-pro/previous-requirements.en.md
@@ -8,10 +8,10 @@ We know some terms are new. Before getting started, we'll give you a hand.
 | Term | Description |
 | --- | --- |
 | _Preference_ | It is the **information of the product or service that you want to offer.** Among the most important attributes of a preference are defined: the description, the amount and the items. When generating it, you get the URL to start the payment flow. |
-| _Credentials_ | Your credentials are the **keys we provide so you can configure your integrations.**<br/>There are two types:<br/><br/>**Public Key**. Public key of the application to know, for example, the payment methods and encrypt card details. You must use it only for your integrations.<br/>**Access Token**. Private key of the application to generate payments. You must use it only for your integrations.<br/><br/>To find them, go to your <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credentials </a> and select the productive ones.<br/><br/> |
+| _Credentials_ | Your credentials are the **keys we provide so you can configure your integrations.**<br/>There are two types:<br/><br/>**Public Key**. Public key of the application to know, for example, the payment methods and encrypt card details. You must use it only for your integrations.<br/>**Access Token**. Private key of the application to generate payments. You must use it only for your integrations.<br/><br/>To find them, go to your [credentials]([FAKER][CREDENTIALS][URL]) and select the productive ones.<br/><br/> |
 | _Initial Point (init_point)_ | **It is the URL obtained at the time of generating the preference** and that starts the payment flow of the Checkout Pro. |
 | _Ítem_ | It refers to the product or service you want to offer. It can be one or a list. |
-| _Application_ | The applications are used to process the seller's payments. **Each application identifies a particular integration**, since each one has its own <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credentials</a>. One Mercado Pago account can have multiple applications.<br/><br/>You can find the information of each one in Credentials. Upon entering, one will be created automatically or you can <a href="https://applications.mercadopago.com/" target="_blank"> create an application</a> every time you need one. |
+| _Application_ | The applications are used to process the seller's payments. **Each application identifies a particular integration**, since each one has its own [credentials]([FAKER][CREDENTIALS][URL]). One Mercado Pago account can have multiple applications.<br/><br/>You can find the information of each one in Credentials. Upon entering, one will be created automatically or you can [create an application](https://applications.mercadopago.com) every time you need one. |
 
 ## Previous requirements
 
@@ -19,27 +19,7 @@ To continue, check the necessary prerequisites:
 
 ### 1. Access to the Mercado Pago or Mercado Libre account
 In order to start the integration, it is necessary to **have a Mercado Pago or Mercado Libre account.**.
-----[mla]----
-If you don't have one yet, you can <a href="https://www.mercadopago.com.ar/" target="_blank"> create a Mercado Pago account</a> whenever you want.
-------------
-----[mlm]----
-If you don't have one yet, you can <a href="https://www.mercadopago.com.mx/" target="_blank"> create a Mercado Pago account</a> whenever you want.
-------------
-----[mlu]----
-If you don't have one yet, you can <a href="https://www.mercadopago.com.uy/" target="_blank"> create a Mercado Pago account</a> whenever you want.
-------------
-----[mlc]----
-If you don't have one yet, you can <a href="https://www.mercadopago.cl/" target="_blank"> create a Mercado Pago account</a> whenever you want.
-------------
-----[mco]----
-If you don't have one yet, you can <a href="https://www.mercadopago.com.co/" target="_blank"> create a Mercado Pago account</a> whenever you want.
-------------
-----[mlb]----
-If you don't have one yet, you can <a href="https://www.mercadopago.com.br/" target="_blank"> create a Mercado Pago account</a> whenever you want.
-------------
-----[mpe]----
-If you don't have one yet, you can <a href="https://www.mercadopago.com.pe/" target="_blank"> create a Mercado Pago account</a> whenever you want.
-------------
+If you don't have one yet, you can [create a Mercado Pago account](https://www.mercadopago[FAKER][URL][DOMAIN]) whenever you want.
 
 ### 2. Installations of Mercado Pago SDK
 **Install the official SDK** to simplify your interaction with our APIs.
@@ -47,7 +27,7 @@ If you don't have one yet, you can <a href="https://www.mercadopago.com.pe/" tar
 [[[
 ```php
 ===
-<a href="https://getcomposer.org/download" target="_blank"> Install Composer</a> to use the SDK.
+[Install Composer](https://getcomposer.org/download) to use the SDK.
 
 Then run the following code on the command line:
 ===
@@ -55,13 +35,13 @@ php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===
-To install the SDK you must execute the following code on the command line of your terminal using <a href="https://www.npmjs.com/get-npm" target="_blank">npm</a>:
+To install the SDK you must execute the following code on the command line of your terminal using [npm](https://www.npmjs.com/get-npm):
 ===
 npm install mercadopago
 ```
 ```java
 ===
-To install the SDK in your <a href="http://maven.apache.org/install.html" target="_blank"> Maven </a> project, add the following dependency in your pom.xml file and then run ´maven install´.
+To install the SDK in your [Maven](http://maven.apache.org/install.html) project, add the following dependency in your pom.xml file and then run ´maven install´.
 ===
 <dependency>
             <groupId> com.mercadopago </groupId>
@@ -71,17 +51,17 @@ To install the SDK in your <a href="http://maven.apache.org/install.html" target
 ```
 ```ruby
 ===
-The Mercado Pago SDK is available as a <a href="https://rubygems.org/gems/mercadopago-sdk" target="_blank"> gema</a>, to install it you must execute the following code on the command line:
+The Mercado Pago SDK is available as a [gema](https://rubygems.org/gems/mercadopago-sdk), to install it you must execute the following code on the command line:
 ===
 gem install mercadopago-sdk
 ```
 ```csharp
 ===
 ----[mlb]----
-Use <a href="https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> to install the Mercado Pago SDK .NET.
+Use [NuGet](https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools) to install the Mercado Pago SDK .NET.
 ------------
 ----[mla, mco, mlu, mlc, mlm, mpe]----
-Use <a href="https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> to install the Mercado Pago SDK .NET.
+Use [NuGet](https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools) to install the Mercado Pago SDK .NET.
 ------------
 To do this, run the following command in the NuGet Package Manager console:
 ===

--- a/guides/online-payments/checkout-pro/previous-requirements.es.md
+++ b/guides/online-payments/checkout-pro/previous-requirements.es.md
@@ -8,10 +8,10 @@ Sabemos que algunos términos son nuevos. Antes de empezar, te los dejamos a man
 | Término | Descripción |
 | --- | --- |
 | _Preferencia (preference)_ | Es la **información del producto o servicio que se quiere ofrecer.** Entre los atributos más importantes de una preferencia se definen: la descripción, el monto y los items. Al generarla se obtiene la URL para iniciar el flujo de pago. |
-| | _Credenciales (credentials)_ | Tus credenciales son las **claves que te proporcionamos para que puedas configurar tus integraciones.**<br/><br/>**Public key**. Clave pública de la aplicación para conocer, por ejemplo, los medios de pago y cifrar datos de tarjeta. Debes usarla solo para tus integraciones.<br/>**Access token**. Clave privada de la aplicación para generar pagos. Debes usarla solo para tus integraciones.<br/><br/>Para poder encontrarlas, ve a tus <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciales </a> y selecciona las productivas.<br/><br/> |
+| | _Credenciales (credentials)_ | Tus credenciales son las **claves que te proporcionamos para que puedas configurar tus integraciones.**<br/><br/>**Public key**. Clave pública de la aplicación para conocer, por ejemplo, los medios de pago y cifrar datos de tarjeta. Debes usarla solo para tus integraciones.<br/>**Access token**. Clave privada de la aplicación para generar pagos. Debes usarla solo para tus integraciones.<br/><br/>Para poder encontrarlas, ve a tus [ credenciales ]([FAKER][CREDENTIALS][URL]) y selecciona las productivas.<br/><br/> |
 | _Punto de inicio (init_point)_ | **Es la URL que se obtiene al momento de generar la preferencia** y que da inicio al flujo de pago del Checkout Pro. |
 | _Ítem (ítem)_ | Hace referencia al producto o servicio que se quiere ofrecer. Puede ser uno o una lista. |
-| _Aplicación (application)_ | Las aplicaciones sirven para procesar los pagos del vendedor. **Cada aplicación identifica a una integración en particular**, ya que cada una tiene sus <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciales </a>propias. Una cuenta de Mercado Pago puede tener múltiples aplicaciones.<br/><br/>Puedes encontrar la información de cada una en credenciales. Al ingresar, se creará una automáticamente o puedes <a href="https://applications.mercadopago.com/" target="_blank"> crear una aplicación</a> cada vez que lo necesites. |
+| _Aplicación (application)_ | Las aplicaciones sirven para procesar los pagos del vendedor. **Cada aplicación identifica a una integración en particular**, ya que cada una tiene sus [credenciales]([FAKER][CREDENTIALS][URL]) propias. Una cuenta de Mercado Pago puede tener múltiples aplicaciones.<br/><br/>Puedes encontrar la información de cada una en credenciales. Al ingresar, se creará una automáticamente o puedes [crear una aplicación](https://applications.mercadopago.com) cada vez que lo necesites. |
 
 ## Requisitos previos
 
@@ -19,27 +19,7 @@ Para continuar, verifica los requisitos previos necesarios:
 
 ### 1. Acceso a cuenta de Mercado Pago o Mercado Libre
 Para poder comenzar la integración, es necesario **contar con una cuenta de Mercado Pago o Mercado Libre**.
-----[mla]----
-Si aún no tienes una, puedes <a href="https://www.mercadopago.com.ar/" target="_blank"> crear una cuenta de Mercado Pago</a> cuando quieras.
-------------
-----[mlm]----
-Si aún no tienes una, puedes <a href="https://www.mercadopago.com.mx/" target="_blank"> crear una cuenta de Mercado Pago</a> cuando quieras.
-------------
-----[mlb]----
-Si aún no tienes una, puedes <a href="https://www.mercadopago.com.br/" target="_blank"> crear una cuenta de Mercado Pago</a> cuando quieras.
-------------
-----[mlu]----
-Si aún no tienes una, puedes <a href="https://www.mercadopago.com.uy/" target="_blank"> crear una cuenta de Mercado Pago</a> cuando quieras.
-------------
-----[mlc]----
-Si aún no tienes una, puedes <a href="https://www.mercadopago.cl/" target="_blank"> crear una cuenta de Mercado Pago</a> cuando quieras.
-------------
-----[mco]----
-Si aún no tienes una, puedes <a href="https://www.mercadopago.com.co/" target="_blank"> crear una cuenta de Mercado Pago</a> cuando quieras.
-------------
-----[mpe]----
-Si aún no tienes una, puedes <a href="https://www.mercadopago.com.pe/" target="_blank"> crear una cuenta de Mercado Pago</a> cuando quieras.
-------------
+Si aún no tienes una, puedes [crear una cuenta de Mercado Pago](https://www.mercadopago[FAKER][URL][DOMAIN]) cuando quieras.
 
 ### 2. Instalación de SDK de Mercado Pago
 **Instala el SDK oficial** para simplificar tu interacción con nuestras APIs.
@@ -47,7 +27,7 @@ Si aún no tienes una, puedes <a href="https://www.mercadopago.com.pe/" target="
 [[[
 ```php
 ===
-<a href="https://getcomposer.org/download" target="_blank"> Instala Composer</a> para usar el SDK.
+[Instala Composer](https://getcomposer.org/download) para usar el SDK.
 
 Luego ejecuta el siguiente código en la línea de comandos:
 ===
@@ -55,13 +35,13 @@ php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===
-Para instalar el SDK debes ejecutar el siguiente código en la línea de comandos de tu terminal usando <a href="https://www.npmjs.com/get-npm" target="_blank">npm</a>:
+Para instalar el SDK debes ejecutar el siguiente código en la línea de comandos de tu terminal usando [npm](https://www.npmjs.com/get-npm):
 ===
 npm install mercadopago
 ```
 ```java
 ===
-Para instalar el SDK en tu proyecto <a href="http://maven.apache.org/install.html" target="_blank"> Maven </a> agrega la siguiente dependencia en tu archivo pom.xml y luego ejecuta 'maven install'.
+Para instalar el SDK en tu proyecto [Maven](http://maven.apache.org/install.html) agrega la siguiente dependencia en tu archivo pom.xml y luego ejecuta 'maven install'.
 ===
 <dependency>
             <groupId> com.mercadopago </groupId>
@@ -71,17 +51,17 @@ Para instalar el SDK en tu proyecto <a href="http://maven.apache.org/install.htm
 ```
 ```ruby
 ===
-El SDK de Mercado Pago está disponible como <a href="https://rubygems.org/gems/mercadopago-sdk" target="_blank"> gema</a>, para instalarla debes ejecutar el siguiente código en la línea de comandos:
+El SDK de Mercado Pago está disponible como [gema](https://rubygems.org/gems/mercadopago-sdk), para instalarla debes ejecutar el siguiente código en la línea de comandos:
 ===
 gem install mercadopago-sdk
 ```
 ```csharp
 ===
 ----[mlb]----
-Usa <a href="https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> para instalar el SDK .NET de Mercado Pago.
+Usa [NuGet](https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools) para instalar el SDK .NET de Mercado Pago.
 ------------
 ----[mla, mlm, mco, mlc, mlu, mpe]----
-Usa <a href="https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> para instalar el SDK .NET de Mercado Pago.
+Usa [NuGet](https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools) para instalar el SDK .NET de Mercado Pago.
 ------------
 Para hacerlo ejecuta el siguiente comando en la consola del NuGet Package Manager:
 ===

--- a/guides/online-payments/checkout-pro/previous-requirements.pt.md
+++ b/guides/online-payments/checkout-pro/previous-requirements.pt.md
@@ -8,10 +8,10 @@ Sabemos que alguns termos são novos. Antes de começar, os deixamos à mão.
 | Termo | Descrição |
 | --- | --- |
 | _Preferência (preference)_ | São as **informações do produto ou serviço que você quer oferecer.** Entre os atributos mais importantes de uma preferência são definidos: a descrição, o valor e os itens. Ao gerá-lo, você obtém uma URL para iniciar o fluxo de pagamento. |
-| _Credenciais (credentials)_ | Suas credenciais são as **chaves que te informamos para que você possa configurar suas integrações.**<br/>Existem dois tipos:<br/><br/>**Public key**. Chave pública da aplicação para saber, por exemplo, os meios de pagamento e criptografar os dados do cartão. Você deve usá-las somente para as suas integrações.<br/>**Access token**. Chave privada da aplicação para gerar pagamentos. Você deve usá-la somente para suas integrações.<br/><br/>Para poder encontrá-las, confira suas <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciais </a> e selecione as produtivas.<br/><br/> |
+| _Credenciais (credentials)_ | Suas credenciais são as **chaves que te informamos para que você possa configurar suas integrações.**<br/>Existem dois tipos:<br/><br/>**Public key**. Chave pública da aplicação para saber, por exemplo, os meios de pagamento e criptografar os dados do cartão. Você deve usá-las somente para as suas integrações.<br/>**Access token**. Chave privada da aplicação para gerar pagamentos. Você deve usá-la somente para suas integrações.<br/><br/>Para poder encontrá-las, confira suas [credenciais]([FAKER][CREDENTIALS][URL]) e selecione as produtivas.<br/><br/> |
 | _Ponto de inicio (init_point)_ | É a **URL obtida na hora de gerar a preferência** e que dá início ao fluxo de pagamento do Checkout Pro. |
 | _Ítem (ítem)_ | Faz referência ao produto ou serviço que se quer oferecer. Pode ser um ou uma lista. |
-| _Aplicação (application)_ | As aplicações são usadas para processar os pagamentos do vendedor. **Cada aplicação identifica uma integração específica**, pois cada uma possui suas próprias<a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciais </a>. Uma conta do Mercado Pago pode ter diversas aplicações.<br/><br/>Você pode encontrar as informações de cada uma em credenciais. Ao entrar, um será criado automaticamente ou você poderá <a href="https://applications.mercadopago.com/" target="_blank"> criar uma aplicação</a> sempre que precisar. |
+| _Aplicação (application)_ | As aplicações são usadas para processar os pagamentos do vendedor. **Cada aplicação identifica uma integração específica**, pois cada uma possui suas próprias [credenciais]([FAKER][CREDENTIALS][URL]). Uma conta do Mercado Pago pode ter diversas aplicações.<br/><br/>Você pode encontrar as informações de cada uma em credenciais. Ao entrar, um será criado automaticamente ou você poderá [criar uma aplicação](https://applications.mercadopago.com) sempre que precisar. |
 
 ## Pré-requisitos
 
@@ -19,27 +19,7 @@ Para continuar, confira os pré-requisitos:
 
 ### 1. Acesso à conta do Mercado Pago ou do Mercado Livre
 Para poder começar a integração, é necessário **contar com uma conta do Mercado Pago ou do Mercado Livre.**
-----[mla]----
-Caso você ainda não tenha uma, pode <a href="https://www.mercadopago.com.ar/" target="_blank"> criar uma conta do Mercado Pago</a> quando quiser.
-------------
-----[mlm]----
-Caso você ainda não tenha uma, pode <a href="https://www.mercadopago.com.mx/" target="_blank"> criar uma conta do Mercado Pago</a> quando quiser.
-------------
-----[mlu]----
-Caso você ainda não tenha uma, pode <a href="https://www.mercadopago.com.uy/" target="_blank"> criar uma conta do Mercado Pago</a> quando quiser.
-------------
-----[mco]----
-Caso você ainda não tenha uma, pode <a href="https://www.mercadopago.com.co/" target="_blank"> criar uma conta do Mercado Pago</a> quando quiser.
-------------
-----[mlc]----
-Caso você ainda não tenha uma, pode <a href="https://www.mercadopago.cl/" target="_blank"> criar uma conta do Mercado Pago</a> quando quiser.
-------------
-----[mlb]----
-Caso você ainda não tenha uma, pode <a href="https://www.mercadopago.com.br/" target="_blank"> criar uma conta do Mercado Pago</a> quando quiser.
-------------
-----[mpe]----
-Caso você ainda não tenha uma, pode <a href="https://www.mercadopago.com.pe/" target="_blank"> criar uma conta do Mercado Pago</a> quando quiser.
-------------
+Caso você ainda não tenha uma, pode [criar uma conta do Mercado Pago](https://www.mercadopago[FAKER][URL][DOMAIN]) quando quiser.
 
 ### 2.  Instalação do SDK do Mercado Pago
 **Instale o SDK oficial** para simplificar sua integração com as nossas APIs.
@@ -47,20 +27,20 @@ Caso você ainda não tenha uma, pode <a href="https://www.mercadopago.com.pe/" 
 [[[
 ```php
 ===
-<a href="https://getcomposer.org/download" target="_blank"> Instale o Composer </a> para usar o SDK.
+[Instale o Composer](https://getcomposer.org/download) para usar o SDK.
 Em seguida, execute o seguinte código na linha de comandos:
 ===
 php composer.phar require "mercadopago/dx-php"
 ```
 ```node
 ===
-Para instalar o SDK, você deve executar o seguinte código na linha de comandos do seu terminal usando <a href="https://www.npmjs.com/get-npm" target="_blank">npm</a>:
+Para instalar o SDK, você deve executar o seguinte código na linha de comandos do seu terminal usando [npm](https://www.npmjs.com/get-npm):
 ===
 npm install mercadopago
 ```
 ```java
 ===
-Para instalar o SDK no seu projeto<a href="http://maven.apache.org/install.html" target="_blank"> Maven </a> adicione a seguinte dependência no seu arquivo pom.xml e execute o 'maven install'.
+Para instalar o SDK no seu projeto [Maven](http://maven.apache.org/install.html) adicione a seguinte dependência no seu arquivo pom.xml e execute o 'maven install'.
 ===
 <dependency>
             <groupId> com.mercadopago </groupId>
@@ -70,17 +50,17 @@ Para instalar o SDK no seu projeto<a href="http://maven.apache.org/install.html"
 ```
 ```ruby
 ===
-O SDK do Mercado Pago está disponível como <a href="https://rubygems.org/gems/mercadopago-sdk" target="_blank"> gema</a>, para instalá-la, você deve executar o seguinte código na linha de comandos:
+O SDK do Mercado Pago está disponível como [gema](https://rubygems.org/gems/mercadopago-sdk), para instalá-la, você deve executar o seguinte código na linha de comandos:
 ===
 gem install mercadopago-sdk
 ```
 ```csharp
 ===
 ----[mla, mco, mlu, mlc, mlm, mpe]----
-Use o  <a href="https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> para instalar o SDK .NET do Mercado Pago.
+Use o [NuGet](https://docs.microsoft.com/es-es/nuget/install-nuget-client-tools) para instalar o SDK .NET do Mercado Pago.
 ------------
 ----[mlb]----
-Use o  <a href="https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools" target="_blank"> NuGet</a> para instalar o SDK .NET do Mercado Pago.
+Use o [NuGet](https://docs.microsoft.com/pt-pt/nuget/install-nuget-client-tools) para instalar o SDK .NET do Mercado Pago.
 ------------
 Para isso, execute o seguinte comando no console do NuGet Package Manager:
 ===

--- a/guides/online-payments/checkout-pro/shipments.en.md
+++ b/guides/online-payments/checkout-pro/shipments.en.md
@@ -13,7 +13,7 @@ Integrate Mercado Envíos to receive payment for your products and manage their 
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Activate Mercado Envíos
 
-From the seller's account, go to the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping" target="_blank">Your Business > Settings</a> section and activate the Mercado Envíos option.
+From the seller's account, go to the [Settings](https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping) section and activate the Mercado Envíos option.
 
 We will use the address you upload to show the delivery points close to where the seller will be able to take the packages, and calculate the shipping costs.
 
@@ -142,7 +142,7 @@ By default, you'll have shipping configured at the buyer's expense. If you want,
 
 ----[mla]----
 The shipping cost will be debited from the seller’s account when the payment is received. 
-You can offer different shipping methods by changing the ID. Check the available <a href="https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true" target="_blank">id shipping methods</a> to know which ones to add.
+You can offer different shipping methods by changing the ID. Check the available [id shipping methods](https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true) to know which ones to add.
 
 For example, in the following code is added the `ID 73328` which refers to a normal home delivery of OCA and the `ID 504945` for normal home delivery of Adreani. 
 
@@ -221,7 +221,7 @@ preference.Shipments = shipments;
 ----[mlm]----
 
 The shipping cost will be debited from the seller’s account when the payment is received. 
-You can offer different shipping methods by changing the ID. Check the available <a href="https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true" target="_blank">id shipping methods</a> to know which ones to add.
+You can offer different shipping methods by changing the ID. Check the available [id shipping methods](https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true) to know which ones to add.
 
 For example, in the following code is added the `ID 509247` which refers to a standard delivery to home and the `ID 509245` for priority delivery to a post office.
 
@@ -300,7 +300,7 @@ preference.Shipments = shipments;
 ----[mlb]----
 
 The shipping cost will be debited from the seller’s account when the payment is received. 
-You can offer different shipping methods by changing the ID. Check the available <a href="https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true" target="_blank">id shipping methods</a> to know which ones to add.
+You can offer different shipping methods by changing the ID. Check the available [id shipping methods](https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true) to know which ones to add.
 
 For example, in the following code, the `ID 505345` is added, referring to a normal Mercado Envíos shipping address and the `ID 100009` for normal Post Office shipping.
 
@@ -452,13 +452,13 @@ preference.Shipments = shipments;
 
 **Done! Mercado Envíos is already integrated.** 
 
-Once you receive an order, you only need to ----[mla, mlm]---- <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603" target="_blank">prepare and ship the package</a>. ------------ ----[mlb]---- <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_1603" target="_blank"> prepare and ship the package</a>. ------------
+Once you receive an order, you only need to ----[mla, mlm]---- [prepare and ship the package](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603). ------------
 
 > NOTE
 >
 > Label Management
 >
-> When an order is made, you will receive an e-mail with a button to print the label you must attach to the package. You will also be able to view the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/activities?type=facet_type_collection&status=facet_shipping_me_all" target="_blank">payments to be printed</a> from the Mercado Pago account that received the order.
+> When an order is made, you will receive an e-mail with a button to print the label you must attach to the package. You will also be able to view the [payments to be printed](https://www.mercadopago[FAKER][URL][DOMAIN]/activities?type=facet_type_collection&status=facet_shipping_me_all) from the Mercado Pago account that received the order.
 
 
 ## Example of a complete preference

--- a/guides/online-payments/checkout-pro/shipments.en.md
+++ b/guides/online-payments/checkout-pro/shipments.en.md
@@ -13,7 +13,7 @@ Integrate Mercado Envíos to receive payment for your products and manage their 
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Activate Mercado Envíos
 
-From the seller's account, go to the [Settings](https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping) section and activate the Mercado Envíos option.
+From the seller's account, go to the [Your Business > Settings](https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping) section and activate the Mercado Envíos option.
 
 We will use the address you upload to show the delivery points close to where the seller will be able to take the packages, and calculate the shipping costs.
 
@@ -452,7 +452,7 @@ preference.Shipments = shipments;
 
 **Done! Mercado Envíos is already integrated.** 
 
-Once you receive an order, you only need to ----[mla, mlm]---- [prepare and ship the package](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603). ------------
+Once you receive an order, you only need to ----[mla, mlm]---- [prepare and ship the package](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603). ------------ ----[mlb]---- [prepare and ship the package](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_1603) ------------
 
 > NOTE
 >

--- a/guides/online-payments/checkout-pro/shipments.es.md
+++ b/guides/online-payments/checkout-pro/shipments.es.md
@@ -14,7 +14,7 @@ Integra Mercado Envíos para recibir el pago de tus productos y gestionar su env
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Activa Mercado Envíos
 
-Desde la cuenta del vendedor, ingresa a la sección de [Configuración](https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping) y activa la opción de Mercado Envíos.
+Desde la cuenta del vendedor, ingresa a la sección de [Tu negocio > Configuración](https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping) y activa la opción de Mercado Envíos.
 
 Usaremos el domicilio que cargues para mostrar los puntos de despacho cercanos a los que el vendedor podrá llevar los paquetes, y calcular los costos de envío.
 
@@ -458,7 +458,7 @@ preference.Shipments = shipments;
 
 **¡Y listo! Mercado Envíos ya se encuentra integrado.** 
 
-Una vez que se reciba una venta, solo hay que ----[mla, mlm]---- [preparar el paquete y enviarlo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603). ------------
+Una vez que se reciba una venta, solo hay que ----[mla, mlm]---- [preparar el paquete y enviarlo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603). ------------ ----[mlb]---- [preparar el paquete y enviarlo](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_1603). ------------
 
 > NOTE
 >

--- a/guides/online-payments/checkout-pro/shipments.es.md
+++ b/guides/online-payments/checkout-pro/shipments.es.md
@@ -14,7 +14,7 @@ Integra Mercado Envíos para recibir el pago de tus productos y gestionar su env
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Activa Mercado Envíos
 
-Desde la cuenta del vendedor, ingresa a la sección de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping" target="_blank">Tu negocio > Configuración</a> y activa la opción de Mercado Envíos.
+Desde la cuenta del vendedor, ingresa a la sección de [Configuración](https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping) y activa la opción de Mercado Envíos.
 
 Usaremos el domicilio que cargues para mostrar los puntos de despacho cercanos a los que el vendedor podrá llevar los paquetes, y calcular los costos de envío.
 
@@ -146,7 +146,7 @@ Por defecto, tendrás configurado el envío a cargo del comprador. Si quieres, p
 ----[mla]----
 El costo del envío será debitado de la cuenta del vendedor cuando reciba un pago. 
 
-Puedes ofrecer distintos métodos de envíos modificando el ID. Consulta los <a href="https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true" target="_blank">id de medios de envío</a> envíos disponibles para saber cuáles agregar. 
+Puedes ofrecer distintos métodos de envíos modificando el ID. Consulta los [id de medios de envío](https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true) envíos disponibles para saber cuáles agregar. 
 
 Por ejemplo, en el siguiente código se encuentra sumado el `ID 73328` que refiere a un envío normal a domicilio de OCA y el `ID 504945` para envío normal a domicilio de Adreani. 
 
@@ -226,7 +226,7 @@ preference.Shipments = shipments;
 
 El costo del envío será debitado de la cuenta del vendedor cuando reciba un pago. 
 
-Puedes ofrecer distintos métodos de envío modificando el ID. Consulta los <a href="https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true" target="_blank">id de medios de envío</a> disponibles para saber cuáles agregar. 
+Puedes ofrecer distintos métodos de envío modificando el ID. Consulta los [id de medios de envío](https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true) disponibles para saber cuáles agregar. 
 
 Por ejemplo, en el siguiente código se encuentra sumado el `ID 509247` que refiere a un envío estándar a domicilio y el `ID 509245` para envío prioritario a sucursal de correo. 
 
@@ -306,7 +306,7 @@ preference.Shipments = shipments;
 
 El costo del envío será debitado de la cuenta del vendedor cuando reciba un pago. 
 
-Puedes ofrecer distintos métodos de envío modificando el ID. Consulta los <a href="https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true" target="_blank">id de medios de envío</a> disponibles para saber cuáles agregar. 
+Puedes ofrecer distintos métodos de envío modificando el ID. Consulta los [id de medios de envío](https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true) disponibles para saber cuáles agregar. 
 
 Por ejemplo, en el siguiente código se encuentra sumado el `ID 505345` que refiere a un envío estándar a domicilio y el `ID 100009` para envío prioritario a sucursal de correo. 
 
@@ -458,13 +458,13 @@ preference.Shipments = shipments;
 
 **¡Y listo! Mercado Envíos ya se encuentra integrado.** 
 
-Una vez que se reciba una venta, solo hay que ----[mla, mlm]---- <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603" target="_blank">preparar el paquete y enviarlo</a>. ------------ ----[mlb]---- <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_1603" target="_blank">preparar el paquete y enviarlo</a>. ------------
+Una vez que se reciba una venta, solo hay que ----[mla, mlm]---- [preparar el paquete y enviarlo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603). ------------
 
 > NOTE
 >
 > Gestión de etiquetas
 >
-> Cuando se efectúe una venta, te va a llegar un e-mail con un botón para imprimir la etiqueta que tendrás que pegar en el paquete. También podrás ver los <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/activities?type=facet_type_collection&status=facet_shipping_me_all" target="_blank">pagos pendientes de impresión</a> desde la cuenta de Mercado Pago que recibió la venta.
+> Cuando se efectúe una venta, te va a llegar un e-mail con un botón para imprimir la etiqueta que tendrás que pegar en el paquete. También podrás ver los [pagos pendientes de impresión](https://www.mercadopago[FAKER][URL][DOMAIN]/activities?type=facet_type_collection&status=facet_shipping_me_all) desde la cuenta de Mercado Pago que recibió la venta.
 
 
 ## Ejemplo de una preferencia completa

--- a/guides/online-payments/checkout-pro/shipments.pt.md
+++ b/guides/online-payments/checkout-pro/shipments.pt.md
@@ -16,7 +16,7 @@ Integre o Mercado Envios para receber o pagamento dos seus produtos e gerenciar 
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Ative o Mercado Envios
 
-Pela conta do vendedor, entre na seção do [Configurações](https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping) e ative a opção do Mercado Envios.
+Pela conta do vendedor, entre na seção do [Seu negócio > Configurações](https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping) e ative a opção do Mercado Envios.
 
 Usaremos o endereço cadastrado para mostrar os pontos de envio próximos para onde o vendedor poderá levar os pacotes e calcular os custos de envio.
 
@@ -470,7 +470,7 @@ preference.Shipments = shipments;
 
 **Pronto! O Mercado Envios já está integrado.** 
 
-Quando receber uma venda, basta ----[mla, mlm]---- [preparar o pacote e enviá-lo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603). ------------
+Quando receber uma venda, basta ----[mla, mlm]---- [preparar o pacote e enviá-lo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603). ------------ ----[mlb]---- [preparar o pacote e enviá-lo](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_1603). ------------
 
 > NOTE
 >

--- a/guides/online-payments/checkout-pro/shipments.pt.md
+++ b/guides/online-payments/checkout-pro/shipments.pt.md
@@ -16,7 +16,7 @@ Integre o Mercado Envios para receber o pagamento dos seus produtos e gerenciar 
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Ative o Mercado Envios
 
-Pela conta do vendedor, entre na seção do <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping" target="_blank">Seu negócio > Configurações</a> e ative a opção do Mercado Envios.
+Pela conta do vendedor, entre na seção do [Configurações](https://www.mercadopago[FAKER][URL][DOMAIN]/business#shipping) e ative a opção do Mercado Envios.
 
 Usaremos o endereço cadastrado para mostrar os pontos de envio próximos para onde o vendedor poderá levar os pacotes e calcular os custos de envio.
 
@@ -151,8 +151,7 @@ Por padrão, você terá configurado o envio por conta do comprador. Se quiser, 
 ----[mlb]----
 O custo do envio será debitado da conta do vendedor quando receber um pagamento. 
 
-Você pode oferecer diferentes formas de envio alterando o ID. Confira os
- <a href="https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true" target="_blank">ID de formas de envio</a> disponíveis para saber quais adicionar.
+Você pode oferecer diferentes formas de envio alterando o ID. Confira os [ID de formas de envio](https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true) disponíveis para saber quais adicionar.
 
 Por exemplo, no código a seguir, o `ID 505345` se encontra adicionado, referente a um envio normal em domicílio de Mercado Envios e o `ID 100009` para envio normal de Correios.
 
@@ -233,8 +232,7 @@ preference.Shipments = shipments;
 ----[mla]----
 O custo do envio será debitado da conta do vendedor quando receber um pagamento. 
 
-Você pode oferecer diferentes formas de envio alterando o ID. Confira os
- <a href="https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true" target="_blank">ID de formas de envio</a> disponíveis para saber quais adicionar.
+Você pode oferecer diferentes formas de envio alterando o ID. Confira os [ID de formas de envio](https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true) disponíveis para saber quais adicionar.
 
 Por exemplo, no código a seguir, o `ID 73328` se encontra adicionado, referente a um envio normal de OCA e o `ID 504945` para envio normal de Andreani.
 
@@ -316,8 +314,7 @@ preference.Shipments = shipments;
 
 O custo do envio será debitado da conta do vendedor quando receber um pagamento. 
 
-Você pode oferecer diferentes formas de envio alterando o ID. Confira os
- <a href="https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true" target="_blank">ID de formas de envio</a> disponíveis para saber quais adicionar.
+Você pode oferecer diferentes formas de envio alterando o ID. Confira os [ID de formas de envio](https://api.mercadolibre.com/shipping_methods/search?site_id=[FAKER][GLOBALIZE][UPPER_SITE_ID]&shipping_mode=me2&allow_free_shipping=true) disponíveis para saber quais adicionar.
 
 Por exemplo, no código a seguir, o `ID 509247` se encontra adicionado, referente a um envio normal em domicílio e o `ID 509245` para envio prioritário para uma agência dos correios.
 
@@ -473,13 +470,13 @@ preference.Shipments = shipments;
 
 **Pronto! O Mercado Envios já está integrado.** 
 
-Quando receber uma venda, basta ----[mla, mlm]---- <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603" target="_blank">preparar o pacote e enviá-lo</a>. ------------ ----[mlb]---- <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_1603" target="_blank">preparar o pacote e enviá-lo</a>. ------------
+Quando receber uma venda, basta ----[mla, mlm]---- [preparar o pacote e enviá-lo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_1603). ------------
 
 > NOTE
 >
 > Gestão de etiquetas
 >
-> Quando uma venda é feita, você receberá um e-mail com um botão para imprimir a etiqueta que será anexada no pacote. Você também pode ver os <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/activities?type=facet_type_collection&status=facet_shipping_me_all" target="_blank">pagamentos pendentes de impressão</a> pela conta Mercado Pago que recebeu a venda..
+> Quando uma venda é feita, você receberá um e-mail com um botão para imprimir a etiqueta que será anexada no pacote. Você também pode ver os [pagamentos pendentes de impressão](https://www.mercadopago[FAKER][URL][DOMAIN]/activities?type=facet_type_collection&status=facet_shipping_me_all) pela conta Mercado Pago que recebeu a venda..
 
 
 ## Exemplo de uma preferência completa

--- a/guides/online-payments/checkout-pro/test-integration.en.md
+++ b/guides/online-payments/checkout-pro/test-integration.en.md
@@ -53,7 +53,7 @@ curl -X POST \
 
 ### 1. Configure the checkout with the information of your selling user
 
-Generate a preference with the <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credentials</a> of the test user that you want to use as a seller.
+Generate a preference with the [credentials]([FAKER][CREDENTIALS][URL]) of the test user that you want to use as a seller.
 
 ### 2. Make a payment with your buyer user
 
@@ -156,7 +156,7 @@ To **test different payment results,** complete the information you want in the 
 
 ## Start receiving payments
 
-To start charging, you must <a href="[FAKER][CREDENTIALS][URL]" target="_blank">activate your credentials</a>.
+To start charging, you must [activate your credentials]([FAKER][CREDENTIALS][URL]).
 
 To activate them, verify that the credentials in your integration are those of the account that receives the money from the sales.<br/>
 

--- a/guides/online-payments/checkout-pro/test-integration.es.md
+++ b/guides/online-payments/checkout-pro/test-integration.es.md
@@ -55,7 +55,7 @@ curl -X POST \
 
 ### 1. Configura el checkout con los datos de tu usuario vendedor
 
-Genera una preferencia con las <a href="[FAKER][CREDENTIALS][URL]" target="_blank">credenciales</a> del usuario de prueba que quieras usar como vendedor.
+Genera una preferencia con las [credenciales]([FAKER][CREDENTIALS][URL]) del usuario de prueba que quieras usar como vendedor.
 
 ### 2. Realiza un pago con tu usuario comprador
 
@@ -157,7 +157,7 @@ Para **probar distintos resultados de pago**, completa el dato que quieras en el
 
 ## Comenzar a recibir pagos
 
-Para empezar a cobrar, debes <a href="[FAKER][CREDENTIALS][URL]" target="_blank">activar tus credenciales</a>.
+Para empezar a cobrar, debes [activar tus credenciales]([FAKER][CREDENTIALS][URL]).
 
 Al activarlas, verifica que las credenciales en tu integración sean las de la cuenta que reciba el dinero de las ventas.<br/>
 

--- a/guides/online-payments/checkout-pro/test-integration.pt.md
+++ b/guides/online-payments/checkout-pro/test-integration.pt.md
@@ -55,7 +55,7 @@ curl -X POST \
 
 ### 1. Configure o checkout com os dados do seu usuário vendedor
 
-Gere uma preferência com as <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciais</a> do usuário de teste que quiser usar como vendedor.
+Gere uma preferência com as [credenciais]([FAKER][CREDENTIALS][URL]) do usuário de teste que quiser usar como vendedor.
 
 ### 2. Faça um pagamento de teste com seu usuário comprador
 
@@ -158,7 +158,7 @@ Para **testar diferentes resultados de pagamento**, preencha o dado que quiser n
 
 ## Começar a receber pagamentos
 
-Para começar a cobrar, você deve <a href="[FAKER][CREDENTIALS][URL]" target="_blank">ativar suas credenciais</a>.
+Para começar a cobrar, você deve [ativar suas credenciais]([FAKER][CREDENTIALS][URL]).
 
 Para ativá-las, certifique-se de que as credenciais na sua integração sejam as da conta que recebe o dinheiro das vendas.<br/>
 

--- a/guides/online-payments/marketplace/checkout-api/introduction.en.md
+++ b/guides/online-payments/marketplace/checkout-api/introduction.en.md
@@ -24,7 +24,7 @@ After creating the application, you only need to take the second and third steps
 
 ### Credentials
 
-Your <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credentials </a> are the **keys we provide so you can configure your integrations.**. 
+Your [credentials]([FAKER][CREDENTIALS][URL]) are the **keys we provide so you can configure your integrations.**. 
 
 * The public key, or **Public Key**, is used to access the resources that your frontend needs. You will be able to collect credit card data and convert it into a representative token that you can safely store on your servers to create a payment.
 

--- a/guides/online-payments/marketplace/checkout-api/introduction.es.md
+++ b/guides/online-payments/marketplace/checkout-api/introduction.es.md
@@ -24,7 +24,7 @@ Después de crear la aplicación, sólo es necesario ejecutar el segundo y terce
 
 ## Credenciales
 
-Las <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciales </a> son las **claves que te proporcionamos para que puedas configurar tu integración**. Para este caso, vas a utilizar una clave pública y otra privada.
+Las [credenciales]([FAKER][CREDENTIALS][URL]) son las **claves que te proporcionamos para que puedas configurar tu integración**. Para este caso, vas a utilizar una clave pública y otra privada.
 
 * La clave pública, o **Public key**, te sirve para acceder a los recursos que necesita tu frontend. Vas a poder recolectar los datos de las tarjetas de crédito y convertirlos en un token representativo que puedes guardar de forma segura en tus servidores para crear un pago.
 

--- a/guides/online-payments/marketplace/checkout-pro/introduction.en.md
+++ b/guides/online-payments/marketplace/checkout-pro/introduction.en.md
@@ -24,7 +24,7 @@ After creating the application, you only need to take the second and third steps
 
 ### Credentials
 
-Your <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credentials </a> are the **keys we provide so you can configure your integrations.**. 
+Your [credentials]([FAKER][CREDENTIALS][URL]) are the **keys we provide so you can configure your integrations.**. 
 
 * The public key, or Public Key, is used to access the resources that your frontend needs. You will be able to collect credit card data and convert it into a representative token that you can safely store on your servers to create a payment.
 

--- a/guides/online-payments/marketplace/checkout-pro/introduction.es.md
+++ b/guides/online-payments/marketplace/checkout-pro/introduction.es.md
@@ -26,7 +26,7 @@ Después de crear la aplicación, sólo es necesario ejecutar el segundo y terce
 
 ## Credenciales
 
-Las <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciales </a> son las **claves que te proporcionamos para que puedas configurar tu integración**. Para este caso, vas a utilizar una clave pública y otra privada.
+Las [credenciales]([FAKER][CREDENTIALS][URL]) son las **claves que te proporcionamos para que puedas configurar tu integración**. Para este caso, vas a utilizar una clave pública y otra privada.
 
 * La clave pública, o Public key, te sirve para acceder a los recursos que necesita tu frontend. Vas a poder recolectar los datos de las tarjetas de crédito y convertirlos en un token representativo que puedes guardar de forma segura en tus servidores para crear un pago.
 

--- a/guides/online-payments/mobile-checkout/latest/introduction.en.md
+++ b/guides/online-payments/mobile-checkout/latest/introduction.en.md
@@ -27,7 +27,7 @@ Offer the best payment experience to your users, on Android or iOS.
 ### It is very easy to integrate the checkout:
 
 1. Include the SDK in your project.
-2. Enter your <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credentials</a> and create the payment preference.
+2. Enter your [credentials]([FAKER][CREDENTIALS][URL]) and create the payment preference.
 3. Start the payment process with a button on your application.
 4. Get to know when a payment is made with the notifications we send you.
 

--- a/guides/online-payments/mobile-checkout/latest/introduction.es.md
+++ b/guides/online-payments/mobile-checkout/latest/introduction.es.md
@@ -27,7 +27,7 @@ Ofrece a tus usuarios la mejor experiencia de pago, tanto en Android como en iOS
 ### Integrar el checkout es muy fácil:
 
 1. Incluye el SDK en tu proyecto.
-2. Coloca tus <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciales </a> y crea la preferencia de pagos.
+2. Coloca tus [credenciales]([FAKER][CREDENTIALS][URL]) y crea la preferencia de pagos.
 3. Inicia el proceso de pago desde un botón en tu aplicación.
 4. Enterate del pago escuchando las notificaciones que te enviamos.
 

--- a/guides/online-payments/mobile-checkout/latest/introduction.pt.md
+++ b/guides/online-payments/mobile-checkout/latest/introduction.pt.md
@@ -28,7 +28,7 @@ Ofereça aos seus usuários a melhor experiência de pagamento, tanto no Android
 ### Integrar o checkout é muito fácil:
 
 1. Inclua o SDK em seu projeto.
-2. Insira suas <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciais </a> e crie a preferência de pagamentos.
+2. Insira suas [credenciais]([FAKER][CREDENTIALS][URL]) e crie a preferência de pagamentos.
 3. Inicie o processo de pagamento a partir de um botão em sua aplicação.
 4. Receba as notificações de pagamento que lhe enviamos.
 

--- a/guides/online-payments/mobile-checkout/latest/receive-payments.en.md
+++ b/guides/online-payments/mobile-checkout/latest/receive-payments.en.md
@@ -436,7 +436,7 @@ To learn more about it, go to [Notifications.](https://www.mercadopago.com.ar/de
 
 A payment can be rejected because the issuer for the selected method detected a problem or because of non-compliance with security requirements.
 
-Avoid rejected payments with our recommendations and <a href="https://www.mercadopago.com.ar/developers/en/guides/manage-account/account/payment-rejections" target="_blank">improve the approval process</a>.
+Avoid rejected payments with our recommendations and [improve the approval process](https://www.mercadopago.com.ar/developers/en/guides/manage-account/account/payment-rejections).
 
 ### Test the integration
 

--- a/guides/online-payments/mobile-checkout/latest/receive-payments.es.md
+++ b/guides/online-payments/mobile-checkout/latest/receive-payments.es.md
@@ -437,7 +437,7 @@ Visita la sección [Notificaciones](https://www.mercadopago.com.ar/developers/es
 
 Un pago puede ser rechazado porque el emisor del medio de pago detecta un problema o porque no se cumple con los requisitos de seguridad necesarios.
 
-Evita pagos rechazados con nuestras recomendaciones y <a href="https://www.mercadopago.com.ar/developers/es/guides/manage-account/account/payment-rejections" target="_blank">mejora la aprobación de tus pagos</a>.
+Evita pagos rechazados con nuestras recomendaciones y [mejora la aprobación de tus pagos](https://www.mercadopago.com.ar/developers/es/guides/manage-account/account/payment-rejections).
 
 ### Prueba la integración
 

--- a/guides/online-payments/mobile-checkout/latest/receive-payments.pt.md
+++ b/guides/online-payments/mobile-checkout/latest/receive-payments.pt.md
@@ -438,7 +438,7 @@ Para mais informações, consulte a seção de [Notificações](https://www.merc
 
 Um pagamento pode ser recusado porque o emissor do meio de pagamento detecta um problema ou porque não preenche os requisitos de segurança necessários.
 
-Evite pagamentos recusados com nossas recomendações e <a href="https://www.mercadopago.com.ar/developers/pt/guides/manage-account/account/payment-rejections" target="_blank">melhore a aprovação de seus pagamentos</a>.
+Evite pagamentos recusados com nossas recomendações e [melhore a aprovação de seus pagamentos](https://www.mercadopago.com.ar/developers/pt/guides/manage-account/account/payment-rejections).
 
 ### Teste a integração
 

--- a/guides/online-payments/subscriptions/advanced-integration.en.md
+++ b/guides/online-payments/subscriptions/advanced-integration.en.md
@@ -7,7 +7,7 @@ sites_supported:
 
 # Subscription updates
 
-To update, pause, cancel or reactivate a subscription already created, you need to use the `preapproval_id` that returns after the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/subscriptions/introduction/" target="_blank">creation</a>. 
+To update, pause, cancel or reactivate a subscription already created, you need to use the `preapproval_id` that returns after the [creation](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/subscriptions/introduction). 
 
 ## Search for a subscription
 
@@ -110,7 +110,7 @@ With the subscription `application_id` you want to update, make the following ca
 ```
 ]]]
 
->To get more information about the available fields, view the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API references</a>.
+>To get more information about the available fields, view the [API references](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.es.md
+++ b/guides/online-payments/subscriptions/advanced-integration.es.md
@@ -7,7 +7,7 @@ sites_supported:
 
 # Actualización de suscripciones
 
-Para actualizar, pausar, cancelar o reactivar una suscripción ya creada, es necesario usar el `preapproval_id` que retorna luego de la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/subscriptions/introduction/" target="_blank">creación</a>.
+Para actualizar, pausar, cancelar o reactivar una suscripción ya creada, es necesario usar el `preapproval_id` que retorna luego de la [creación](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/subscriptions/introduction).
 
 ## Búsqueda de una suscripción
 
@@ -110,7 +110,7 @@ Con el `application_id` de la suscripción que quieras actualizar, realiza la si
 ```
 ]]]
 
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API</a>.
+>Puedes obtener más información sobre los campos en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 
 ------------

--- a/guides/online-payments/subscriptions/advanced-integration.pt.md
+++ b/guides/online-payments/subscriptions/advanced-integration.pt.md
@@ -7,7 +7,7 @@ sites_supported:
 
 # Atualização de assinaturas
 
-Para atualizar, pausar, cancelar ou reativar uma assinatura já criada, é necessário usar o `preapproval_id` que retorna após a <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/online-payments/subscriptions/introduction/" target="_blank">criação</a>. 
+Para atualizar, pausar, cancelar ou reativar uma assinatura já criada, é necessário usar o `preapproval_id` que retorna após a [criação](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/online-payments/subscriptions/introduction). 
 
 ## Busca de uma assinatura
 
@@ -108,7 +108,7 @@ Com o `application_id` da assinatura que quiser atualizar, faça a seguinte cham
 ```
 ]]]
 
->Para saber mais sobre os campos disponíveis, confira as <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referências de API</a>.
+>Para saber mais sobre os campos disponíveis, confira as [Referências de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 
 ------------

--- a/guides/online-payments/subscriptions/integration.en.md
+++ b/guides/online-payments/subscriptions/integration.en.md
@@ -19,7 +19,7 @@ There are two ways to integrate subscriptions:
 > 
 > Key concepts
 > 
-> Do you have questions about what a plan or other concept is? Keep the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/subscriptions/introduction" target="_blank">key concepts</a> handy to review them when needed.
+> Do you have questions about what a plan or other concept is? Keep the [key concepts](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/subscriptions/introduction) handy to review them when needed.
 
 
 ## Subscriptions with an associated plan
@@ -128,7 +128,7 @@ Once you have generated your plan and obtained your `preapproval_plan_id`, creat
 > 
 > Important
 > 
-> ¿Do you have questions about how to create the payment token? Find all the information in the section of <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/checkout-api/receiving-payment-by-card#bookmark_card_data_capture" target="_blank">Capture data from the card</a>.
+> ¿Do you have questions about how to create the payment token? Find all the information in the section of [Capture data from the card](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/online-payments/checkout-api/receiving-payment-by-card#bookmark_card_data_capture).
 
 #### Response 
 `HTTP Status 200 OK`
@@ -157,7 +157,7 @@ Once you have generated your plan and obtained your `preapproval_plan_id`, creat
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API Reference</a>.
+>You can get more information about the fields in the [API Reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 Done! You have already created a subscription with an associated plan.
 
@@ -283,7 +283,7 @@ In order to subscribe, the card data must be uploaded with our form. Only the li
 }
 ```
 
-> You can get more information about the fields in the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/" target="_blank">API reference</a>.
+> You can get more information about the fields in the [API reference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference).
 
 
 Attributes

--- a/guides/online-payments/subscriptions/integration.es.md
+++ b/guides/online-payments/subscriptions/integration.es.md
@@ -19,7 +19,7 @@ Hay dos formas de integrar suscripciones:
 > 
 > Conceptos claves
 > 
-> ¿Tienes dudas sobre qué es un plan u otro concepto? Ten a mano los <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/subscriptions/introduction" target="_blank">conceptos claves</a> para revisarlos cuando los necesites.
+> ¿Tienes dudas sobre qué es un plan u otro concepto? Ten a mano los [conceptos claves](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/subscriptions/introduction) para revisarlos cuando los necesites.
 
 
 ## Suscripciones con un plan asociado
@@ -128,7 +128,7 @@ Una vez generado tu plan y obtenido tu `preapproval_plan_id`, crea la suscripci�
 > 
 > Importante
 > 
-> ¿Tienes dudas sobre cómo crear el token de pago? Encuentra toda la información en la sección de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/receiving-payment-by-card#bookmark_captura_los_datos_de_la_tarjeta" target="_blank">Capturar datos de la tarjeta</a>.
+> ¿Tienes dudas sobre cómo crear el token de pago? Encuentra toda la información en la sección de [Capturar datos de la tarjeta](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/online-payments/checkout-api/receiving-payment-by-card#bookmark_captura_los_datos_de_la_tarjeta).
 
 #### Respuesta 
 `HTTP Status 200 OK`
@@ -157,7 +157,7 @@ Una vez generado tu plan y obtenido tu `preapproval_plan_id`, crea la suscripci�
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API</a>.
+>Puedes obtener más información sobre los campos en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 ¡Y listo! Ya creaste una suscripción con un plan asociado.
 
@@ -283,7 +283,7 @@ Para poder adherirse, la carga de los datos de la tarjeta se debe realizar con n
 }
 ```
 
-> Puedes obtener más información sobre los campos en la <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/" target="_blank">Referencia de API</a>.
+> Puedes obtener más información sobre los campos en la [Referencia de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference).
 
 
 Atributos

--- a/guides/online-payments/subscriptions/integration.pt.md
+++ b/guides/online-payments/subscriptions/integration.pt.md
@@ -19,7 +19,7 @@ Há duas formas de integrar assinaturas:
 > 
 > Conceitos-chave
 > 
-> Dúvidas sobre o que é um plano ou outro conceito? Tenha em mãos os <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/online-payments/subscriptions/introduction" target="_blank">conceitos-chave</a> para revisá-los quando necessário.
+> Dúvidas sobre o que é um plano ou outro conceito? Tenha em mãos os [conceitos-chave](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/online-payments/subscriptions/introduction) para revisá-los quando necessário.
 
 
 ## Assinaturas com um plano associado
@@ -128,7 +128,7 @@ Uma vez que você tenha gerado seu plano e obtido seu `preapproval_plan_id`, cri
 > 
 > Importante
 > 
-> Dúvidas sobre como criar o token de pagamento? Encontre todas as informações na seção de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/online-payments/checkout-api/receiving-payment-by-card#bookmark_capture_os_dados_de_cart_o" target="_blank">Capturar dados do cartão</a>.
+> Dúvidas sobre como criar o token de pagamento? Encontre todas as informações na seção de [Capturar dados do cartão](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/online-payments/checkout-api/receiving-payment-by-card#bookmark_capture_os_dados_de_cart_o).
 
 #### Resposta 
 `HTTP Status 200 OK`
@@ -157,7 +157,7 @@ Uma vez que você tenha gerado seu plano e obtido seu `preapproval_plan_id`, cri
         "end_date": "2021-07-02T11:59:52.581-04:00"
 }
 ```
->Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API</a>.
+>Você pode obter mais informações sobre os campos na [Referência de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 Prono! Você criou uma assinatura com um plano associado.
 
@@ -283,7 +283,7 @@ Para o cadastro, os detalhes do cartão devem ser informados usando nosso formul
 }
 ```
 
-> Você pode obter mais informações sobre os campos na <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/" target="_blank">Referência de API</a>.
+> Você pode obter mais informações sobre os campos na [Referência de API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference).
 
 
 Atributos

--- a/guides/online-payments/subscriptions/introduction.en.md
+++ b/guides/online-payments/subscriptions/introduction.en.md
@@ -19,7 +19,7 @@ There are two roles involved:
 > 
 > Do you want to create subscriptions quickly and easily?
 > 
-> Enter the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/subscription-plans" target="_blank">Subscriptions</a> section on your Mercado Pago account panel, set the data you need and that's it!
+> Enter the [Subscriptions](https://www.mercadopago[FAKER][URL][DOMAIN]/subscription-plans) section on your Mercado Pago account panel, set the data you need and that's it!
 
 
 ## Key concepts

--- a/guides/online-payments/subscriptions/introduction.es.md
+++ b/guides/online-payments/subscriptions/introduction.es.md
@@ -19,7 +19,7 @@ Existen dos roles involucrados:
 > 
 > ¿Quieres crear suscripciones de forma rápida y simple?
 > 
-> Ingresa en la sección de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/subscription-plans" target="_blank">Suscripciones</a> en el panel de tu cuenta de Mercado Pago, configura tus datos ¡y listo!
+> Ingresa en la sección de [Suscripciones](https://www.mercadopago[FAKER][URL][DOMAIN]/subscription-plans) en el panel de tu cuenta de Mercado Pago, configura tus datos ¡y listo!
 
 
 ## Conceptos claves

--- a/guides/online-payments/subscriptions/introduction.pt.md
+++ b/guides/online-payments/subscriptions/introduction.pt.md
@@ -19,7 +19,7 @@ Há duas funções envolvidas:
 > 
 > Você quer criar assinaturas de forma rápida e fácil?
 > 
-> Entre na seção de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/subscription-plans" target="_blank">Assinaturas</a> no painel da sua conta Mercado Pago, configure os dados que precisar e pronto!
+> Entre na seção de [Assinaturas](https://www.mercadopago[FAKER][URL][DOMAIN]/subscription-plans) no painel da sua conta Mercado Pago, configure os dados que precisar e pronto!
 
 
 ## Conceitos-chave

--- a/guides/online-payments/subscriptions/previous-requirements.en.md
+++ b/guides/online-payments/subscriptions/previous-requirements.en.md
@@ -29,20 +29,20 @@ Please note that the minimum amount allowed to create a subscription is $ 10 and
 ### Access to the Mercado Pago or Mercado Libre account
 In order to start the integration, it is necessary to have a Mercado Pago or Mercado Libre account.
 
-If you don't have one yet, you can <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/" target="_blank">create a account</a> whenever you want.
+If you don't have one yet, you can [create a account](https://www.mercadopago[FAKER][URL][DOMAIN]) whenever you want.
 
 ### Keep your credentials handy
 
 The credentials are the keys that we provide you with, so that you can configure your integration. For this case, you will use a public key and a private key.
 
-To find them, go to the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/account/credentials/" target="_blank">Credentials</a> section.
+To find them, go to the [Credentials](https://www.mercadopago[FAKER][URL][DOMAIN]/developer/panel/credentials) section.
 
->Do you have questions about credentials? You can check our <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/faqs/credentials/" target="_blank">FAQs</a>.
+>Do you have questions about credentials? You can check our [FAQs](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/faqs/credentials).
 
 
 ### Use our official library
 
-Integrate with our <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/sdks" target="_blank">Mercado Pago SDK Javascript</a> which allows you to create a token with your card details securely and send it to your backend for use in your payments. 
+Integrate with our [Mercado Pago SDK Javascript](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/sdks) which allows you to create a token with your card details securely and send it to your backend for use in your payments. 
 
 
 ------------

--- a/guides/online-payments/subscriptions/previous-requirements.es.md
+++ b/guides/online-payments/subscriptions/previous-requirements.es.md
@@ -29,20 +29,20 @@ Ten en cuenta que el monto mínimo permitido para crear una suscripción es de $
 ### Acceso a cuenta de Mercado Pago o Mercado Libre
 Para poder comenzar la integración, es necesario contar con una cuenta de Mercado Pago o Mercado Libre.
 
-Si aún no tienes una, puedes <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/" target="_blank">crear una cuenta</a> cuando quieras.
+Si aún no tienes una, puedes [crear una cuenta](https://www.mercadopago[FAKER][URL][DOMAIN]) cuando quieras.
 
 ### Ten a mano tus credenciales
 
 Las credenciales son las claves que te proporcionamos para que puedas configurar tu integración. Para este caso, vas a utilizar una clave pública y otra clave privada.
 
-Para poder encontrarlas, ve la sección de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/account/credentials/" target="_blank">Credenciales</a>.
+Para poder encontrarlas, ve la sección de [Credenciales](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials).
 
->¿Tienes dudas sobre credenciales? Puedes consultar nuestras <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/faqs/credentials/" target="_blank">preguntas frecuentes</a>.
+>¿Tienes dudas sobre credenciales? Puedes consultar nuestras [preguntas frecuentes](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/resources/faqs/credentials).
 
 
 ### Usa nuestras librerías oficiales
 
-Intégrate con nuestra <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/sdks" target="_blank">SDK Javascript de Mercado Pago</a>  que te permite crear un token de pago y enviar los datos de las tarjetas a tu backend de forma segura. 
+Intégrate con nuestra [SDK Javascript de Mercado Pago](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/sdks)  que te permite crear un token de pago y enviar los datos de las tarjetas a tu backend de forma segura. 
 
 
 ------------

--- a/guides/online-payments/subscriptions/previous-requirements.pt.md
+++ b/guides/online-payments/subscriptions/previous-requirements.pt.md
@@ -29,20 +29,20 @@ Observe que o valor mínimo permitido para criar uma assinatura é de $ 10 e o m
 ### Acesso à conta Mercado Pago ou Mercado Livre
 Para poder começar a integração, é necessário ter uma conta Mercado Pago ou Mercado Livre.
 
-Se você ainda não tem uma, pode <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/" target="_blank">criar uma conta</a> quando quiser.
+Se você ainda não tem uma, pode [criar uma conta](https://www.mercadopago[FAKER][URL][DOMAIN]) quando quiser.
 
 ### Tenha suas credenciais à mão
 
 As credenciais são as chaves que fornecemos para que você possa configurar sua integração. Para este caso, você usará uma chave pública e uma chave privada.
 
-Para poder encontrá-las, confira a seção de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/account/credentials/" target="_blank">Credenciais</a>.
+Para poder encontrá-las, confira a seção de [Credenciais](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials).
 
->Dúvidas sobre credenciais? Você pode conferir nossas <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/resources/faqs/credentials/" target="_blank">perguntas frequentes</a>.
+>Dúvidas sobre credenciais? Você pode conferir nossas [perguntas frequentes](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/resources/faqs/credentials).
 
 
 ### Utilize nossa biblioteca oficial
 
-Integre com nosso <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/sdks" target="_blank">SDK Javascript do Mercado Pago</a> que te permite criar um token com os dados do cartão de forma segura e enviá-lo ao seu backend para usá-lo nos seus pagamentos.
+Integre com nosso [SDK Javascript do Mercado Pago](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/sdks) que te permite criar um token com os dados do cartão de forma segura e enviá-lo ao seu backend para usá-lo nos seus pagamentos.
 
 
 ------------

--- a/guides/online-payments/subscriptions/testing.en.md
+++ b/guides/online-payments/subscriptions/testing.en.md
@@ -53,7 +53,7 @@ Run the following curl to generate a test user:
 
 #### 1. Set the subscription with the data of your seller user
 
-Use the <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/account/credentials" target="_blank">test public key</a> of your seller user at the time of creating the subscription you want to test.<br>
+Use the [test public key](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials) of your seller user at the time of creating the subscription you want to test.<br>
 
 #### 2. Make a payment with your buyer user
 

--- a/guides/online-payments/subscriptions/testing.es.md
+++ b/guides/online-payments/subscriptions/testing.es.md
@@ -53,7 +53,7 @@ Ejecuta el siguiente curl para generar un usuario de prueba:
 
 #### 1. Configura la suscripción con los datos de tu usuario vendedor
 
-Utiliza la  <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/account/credentials" target="_blank">clave pública de prueba</a> de tu usuario vendedor al momento de crear la suscripción que quieras probar.<br>
+Utiliza la  [clave pública de prueba](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials) de tu usuario vendedor al momento de crear la suscripción que quieras probar.<br>
 
 #### 2. Realiza un pago con tu usuario comprador
 

--- a/guides/online-payments/subscriptions/testing.pt.md
+++ b/guides/online-payments/subscriptions/testing.pt.md
@@ -53,7 +53,7 @@ Execute o curl a seguir para gerar um usuário de teste:
 
 #### 1. Configure a assinatura com os dados do seu usuário vendedo
 
-Use a <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/account/credentials" target="_blank">chave pública de teste</a> do seu usuário vendedor na hora de criar a assinatura que quiser testar.<br>
+Use a [chave pública de teste](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials) do seu usuário vendedor na hora de criar a assinatura que quiser testar.<br>
 
 #### 2. Faça um pagamento com seu usuário comprador
 

--- a/guides/plugins/unofficial/vtex.pt.md
+++ b/guides/plugins/unofficial/vtex.pt.md
@@ -203,7 +203,7 @@ Os dados mais significativos são os seguintes:
 
 Quando confrontado com uma rejeição, é muito importante rever o `status_detail` que especifica o motivo do mesmo.
 
-Para mais informações acesse o link <a href="https://www.mercadopago.com.br/developers/pt/guides/online-payments/checkout-api/handling-responses/" target="_blank">Resultados da criação de uma cobrança</a>.
+Para mais informações acesse o link [Resultados da criação de uma cobrança](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/online-payments/checkout-api/handling-responses).
 
 ## Erros comuns
 
@@ -220,7 +220,7 @@ Os erros mais comuns são os seguintes:
 >
 > Importante
 >
-> Antes de iniciar sua operação em produção, você deve <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials" target="_blank">ativar suas credenciais</a>. Caso já tenha realizado este passo o link não será apresentado.
+> Antes de iniciar sua operação em produção, você deve [ativar suas credenciais](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/credentials). Caso já tenha realizado este passo o link não será apresentado.
 
 <!-- -->
 > Para mais informação, visite o site [oficial da VTEX](https://help.vtex.com/) e o [site de status da Vtex](https://status.vtex.com/).

--- a/guides/plugins/woocommerce/integration.en.md
+++ b/guides/plugins/woocommerce/integration.en.md
@@ -12,7 +12,7 @@ Connect a Mercado Pago account to the module to capture your sales charges in Wo
 Once the module is installed, follow these steps to integrate:
 
 1. Create a [seller account](https://www.mercadopago.com.ar/registration-company?confirmation_url=https%3A%2F%2Fwww.mercadopago.com.ar%2Fcomo-cobrar)  in Mercado Pago if you don’t have one yet.
-2. Obtain the Access Token and Public Key <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credencials </a> and paste them into the Production and Testing fields that you will find in the module configuration.
+2. Obtain the Access Token and Public Key [credencials]([FAKER][CREDENTIALS][URL]) and paste them into the Production and Testing fields that you will find in the module configuration.
 3. Approve the account to [go to Production](https://www.mercadopago.com.ar/developers/en/guides/online-payments/checkout-api/goto-production/) and receive money from your sales in Mercado Pago.
 
 Done! With this you can capture the payments you receive in WooCommerce with your Mercado Pago account.

--- a/guides/plugins/woocommerce/integration.es.md
+++ b/guides/plugins/woocommerce/integration.es.md
@@ -12,7 +12,7 @@ Conecta una cuenta de Mercado Pago al módulo para capturar los cobros de tus ve
 Una vez instalado el módulo, sigue estos pasos para integrar:
 
 1. Crea una [cuenta vendedor](https://www.mercadopago.com.ar/registration-company?confirmation_url=https%3A%2F%2Fwww.mercadopago.com.ar%2Fcomo-cobrar) en Mercado Pago si todavía no tienes una.
-2. Obtén el par de <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciales </a> Access Token y Public Key y pégalas en los campos de Producción y Pruebas que encontrarás en la configuración del módulo.
+2. Obtén el par de [credenciales]([FAKER][CREDENTIALS][URL]) Access Token y Public Key y pégalas en los campos de Producción y Pruebas que encontrarás en la configuración del módulo.
 3. Homologa la cuenta para [ir a Producción](https://www.mercadopago.com.ar/developers/es/guides/online-payments/checkout-api/goto-production/) y recibir el dinero de tus ventas en Mercado Pago.
 
 > Encuentra toda la información sobre tus credenciales en nuestras [preguntas frecuentes](https://www.mercadopago.com.ar/developers/es/guides/resources/faqs/credentials/). 

--- a/guides/plugins/woocommerce/integration.pt.md
+++ b/guides/plugins/woocommerce/integration.pt.md
@@ -12,7 +12,7 @@ Conecte uma conta do Mercado Pago ao módulo para capturar os recebimentos das s
 Quando o módulo estiver instalado, siga estas etapas para integrá-lo:
 
 1. Crie uma [conta de vendedor](https://www.mercadopago.com.br/registration-company?confirmation_url=https%3A%2F%2Fwww.mercadopago.com.br%2Fcomo-cobrar) no Mercado Pago caso ainda não tenha uma.
-2. Obtenha suas <a href="[FAKER][CREDENTIALS][URL]" target="_blank"> credenciais </a> Access Token e Public Key e cole-as nos campos de Produção e Testes que estarão na configuração do módulo.
+2. Obtenha suas [credenciais]([FAKER][CREDENTIALS][URL]) Access Token e Public Key e cole-as nos campos de Produção e Testes que estarão na configuração do módulo.
 3. Homologue a conta para [ir à Produção](https://www.mercadopago.com.br/developers/pt/guides/online-payments/checkout-api/goto-production/) e receber o dinheiro das suas vendas no Mercado Pago.
 
 > Encontre toda a informação sobre suas credenciais em nossas [perguntas frequentes](https://www.mercadopago.com.br/developers/pt/guides/resources/faqs/credentials/).

--- a/guides/resources/faqs/payments.en.md
+++ b/guides/resources/faqs/payments.en.md
@@ -36,7 +36,7 @@ Currently, Mercado Pago only allows payments in the local currency. That is, the
 
 Mercado Pago has an amount validation when offering the available payment methods.
 
-If the amount does not comply with the requirements for <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_620" target="_blank">minimum and maximum amounts</a> for the payment method, our checkout will request the log in into the Mercado Pago account, since the only option available to use will be the money available in the account. For this reason, your clients won’t be able to pay as guests.
+If the amount does not comply with the requirements for [minimum and maximum amounts](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_620) for the payment method, our checkout will request the log in into the Mercado Pago account, since the only option available to use will be the money available in the account. For this reason, your clients won’t be able to pay as guests.
 
 Because of this, according to the amount selected, you can only see some payment methods, the ones which are not shown do not comply with the necessary requirements. In other words, the available payment methods will be shown based on the value of the product and the minimum and maximum allowed.
 ------------
@@ -46,7 +46,7 @@ Because of this, according to the amount selected, you can only see some payment
 
 Mercado Pago has an amount validation when offering the available payment methods.
 
-If the amount does not comply with the requirements for <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_620" target="_blank">minimum and maximum amounts</a> for the payment method, our checkout will request the log in into the Mercado Pago account, since the only option available to use will be the money available in the account. For this reason, your clients won’t be able to pay as guests.
+If the amount does not comply with the requirements for [minimum and maximum amounts](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_620) for the payment method, our checkout will request the log in into the Mercado Pago account, since the only option available to use will be the money available in the account. For this reason, your clients won’t be able to pay as guests.
 
 Because of this, according to the amount selected, you can only see some payment methods, the ones which are not shown do not comply with the necessary requirements. In other words, the available payment methods will be shown based on the value of the product and the minimum and maximum allowed.
 ------------
@@ -99,18 +99,18 @@ It is important to add to your integration all the necessary information to [imp
 
 ----[mla, mco, mlu, mpe, mlc, mlm]----
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A payment has been rejected
-If you are having trouble with a payment, you can contact us through Help > Collections > I have a problem with a collection > <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/charges" target="_blank">Solve a problem with a collection</a>.
+If you are having trouble with a payment, you can contact us through Help > Collections > I have a problem with a collection > [Solve a problem with a collection](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/charges).
 ------------
 
 ----[mlb]----
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A payment has been rejected
-If you are having trouble with a payment, you can contact us through Help > Collections > I have a problem with a collection > <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/charges" target="_blank">Solve a problem with a collection</a>.
+If you are having trouble with a payment, you can contact us through Help > Collections > I have a problem with a collection > [Solve a problem with a collection](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/charges).
 ------------
 
 ----[mla, mco, mlu, mpe, mlc, mlm]----
-> If you still need help, please contact us through <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda" target="_blank">Help</a>.
+> If you still need help, please contact us through [Help](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda).
 ------------
 
 ----[mlb]----
-> If you still need help, please contact us through <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda" target="_blank">Help</a>.
+> If you still need help, please contact us through [Help](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda).
 ------------

--- a/guides/resources/faqs/payments.es.md
+++ b/guides/resources/faqs/payments.es.md
@@ -36,7 +36,7 @@ Por el momento, Mercado Pago permite pagos solamente en moneda local. Es decir, 
 
 Mercado Pago cuenta con una validación de montos al momento de ofrecer los medios de pago disponibles.
 
-En el caso de que el monto no cumpla con las condiciones de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_620" target="_blank">montos mínimos y máximos</a> del medio de pago, nuestro checkout solicitará el inicio sesión a la cuenta de Mercado Pago, ya que la única opción disponible para usar será dinero en cuenta. Por esto, tus clientes no podrán pagar como invitados.
+En el caso de que el monto no cumpla con las condiciones de [montos mínimos y máximos](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_620) del medio de pago, nuestro checkout solicitará el inicio sesión a la cuenta de Mercado Pago, ya que la única opción disponible para usar será dinero en cuenta. Por esto, tus clientes no podrán pagar como invitados.
 
 Esto genera que, según el monto elegido, puedas visualizar algunos medios de pagos y otros no debido a que no cumple con los requisitos necesarios. Es decir, en base al valor del producto y del mínimo o máximo permitido, se mostrarán los medios de pagos disponibles.
 ------------
@@ -46,7 +46,7 @@ Esto genera que, según el monto elegido, puedas visualizar algunos medios de pa
 
 Mercado Pago cuenta con una validación de montos al momento de ofrecer los medios de pago disponibles.
 
-En el caso de que el monto no cumpla con las condiciones de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_324" target="_blank">montos mínimos y máximos</a> del medio de pago, nuestro checkout solicitará el inicio sesión a la cuenta de Mercado Pago, ya que la única opción disponible para usar será dinero en cuenta. Por esto, tus clientes no podrán pagar como invitados.
+En el caso de que el monto no cumpla con las condiciones de [montos mínimos y máximos](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_324) del medio de pago, nuestro checkout solicitará el inicio sesión a la cuenta de Mercado Pago, ya que la única opción disponible para usar será dinero en cuenta. Por esto, tus clientes no podrán pagar como invitados.
 
 Esto genera que, según el monto elegido, puedas visualizar algunos medios de pagos y otros no debido a que no cumple con los requisitos necesarios. Es decir, en base al valor del producto y del mínimo o máximo permitido, se mostrarán los medios de pagos disponibles.
 
@@ -97,19 +97,19 @@ Es importante que sumes en tu integración toda la información necesaria para [
 
 ----[mla, mco, mlu, mpe, mlc, mlm]----
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Me rechazaron un pago
-Si tienes problemas con un pago, puedes contactarte a través de Ayuda > Cobros > Tengo un problema con un cobro > <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/charges" target="_blank">Resolver un problema con un cobro</a>.
+Si tienes problemas con un pago, puedes contactarte a través de Ayuda > Cobros > Tengo un problema con un cobro > [Resolver un problema con un cobro](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/charges).
 ------------
 
 ----[mlb]----
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Me rechazaron un pago
-Si tienes problemas con un pago, puedes contactarte a través de Ayuda > Cobros > Tengo un problema con un cobro > <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/charges" target="_blank">Resolver un problema con un cobro</a>.
+Si tienes problemas con un pago, puedes contactarte a través de Ayuda > Cobros > Tengo un problema con un cobro > [Resolver un problema con un cobro](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/charges).
 ------------
 
 ----[mla, mco, mlu, mpe, mlc, mlm]----
-> Si sigues necesitando ayuda, te recomendamos que nos contactes a través de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda" target="_blank">Ayuda</a>.
+> Si sigues necesitando ayuda, te recomendamos que nos contactes a través de [Ayuda](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda).
 ------------
 
 ----[mlb]----
-> Si sigues necesitando ayuda, te recomendamos que nos contactes a través de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda" target="_blank">Ayuda</a>.
+> Si sigues necesitando ayuda, te recomendamos que nos contactes a través de [Ayuda](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda).
 ------------
 

--- a/guides/resources/faqs/payments.pt.md
+++ b/guides/resources/faqs/payments.pt.md
@@ -36,7 +36,7 @@ No momento, o Mercado Pago permite pagamentos somente em moeda local. Ou seja, u
 
 O Mercado Pago conta com uma validação de valores no momento de oferecer os meios de pagamento disponíveis.
 
-No caso em que o valor não cumpra com as condições de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_620" target="_blank">valores mínimos e máximos</a> do meio de pagamento, nosso checkout solicitará iniciar uma seção na conta do Mercado Pago, já que a única opção disponível para usar será dinheiro em conta. Por isso, seus clientes não poderão pagar como convidados.
+No caso em que o valor não cumpra com as condições de [valores mínimos e máximos](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/_620) do meio de pagamento, nosso checkout solicitará iniciar uma seção na conta do Mercado Pago, já que a única opção disponível para usar será dinheiro em conta. Por isso, seus clientes não poderão pagar como convidados.
 
 Isso ocorre porque, de acordo com o valor escolhido, você pode visualizar alguns meios de pagamentos e outros não devido a não cumprir com os requisitos necessários. Ou seja, com base no valor do produto e do mínimo ou máximo permitido, serão mostrados os meios de pagamentos disponíveis.
 ------------
@@ -46,7 +46,7 @@ Isso ocorre porque, de acordo com o valor escolhido, você pode visualizar algun
 
 O Mercado Pago conta com uma validação de valores no momento de oferecer os meios de pagamento disponíveis.
 
-No caso em que o valor não cumpra com as condições de <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_324" target="_blank">valores mínimos e máximos</a> do meio de pagamento, nosso checkout solicitará iniciar uma seção na conta do Mercado Pago, já que a única opção disponível para usar será dinheiro em conta. Por isso, seus clientes não poderão pagar como convidados.
+No caso em que o valor não cumpra com as condições de [valores mínimos e máximos](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/_324) do meio de pagamento, nosso checkout solicitará iniciar uma seção na conta do Mercado Pago, já que a única opção disponível para usar será dinheiro em conta. Por isso, seus clientes não poderão pagar como convidados.
 
 Isso ocorre porque, de acordo com o valor escolhido, você pode visualizar alguns meios de pagamentos e outros não devido a não cumprir com os requisitos necessários. Ou seja, com base no valor do produto e do mínimo ou máximo permitido, serão mostrados os meios de pagamentos disponíveis.
 
@@ -96,9 +96,9 @@ Verifique se a identidade da conta vendedor está validada no painel do Mercado 
 É importante que acrescente em sua integração toda a informação necessária para [melhorar a aprovação de seus pagamentos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/manage-account/account/payment-rejections/#bookmark_recomendações_para_melhorar_sua_aprovação).
 
 ----[mla, mco, mlu, mpe, mlc, mlm]----
-> Se você ainda precisar de ajuda, recomendamos que entre em contato através da <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/charges" target="_blank">Ajuda</a>.
+> Se você ainda precisar de ajuda, recomendamos que entre em contato através da [Ajuda](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/charges).
 ------------
 
 ----[mlb]----
-> Se você ainda precisar de ajuda, recomendamos que entre em contato através da <a href="https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/charges" target="_blank">Ajuda</a>.
+> Se você ainda precisar de ajuda, recomendamos que entre em contato através da [Ajuda](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/charges).
 ------------


### PR DESCRIPTION
- Se deja de utilizar HTML para crear links que se abran en otra página
- Como regla, a partir de ahora el devsite abrirá sólo los links que no sean /developers/(es|pt|en)/guides en otra pestaña