### PR TITLE
Fix link SDK Java at changelog

### DIFF
--- a/guides/resources/changelog/current-year.pt.md
+++ b/guides/resources/changelog/current-year.pt.md
@@ -37,7 +37,7 @@ Lançamos uma nova versão do SDK Java 1.9.0.
 >
 > GitHub
 >
-> Confira no GitHub o detalhe das [últimas atualizações produtivas](https://github.com/mercadopago/java/releases/tag/1.9.0).
+> Confira no GitHub o detalhe das [últimas atualizações produtivas](https://github.com/mercadopago/sdk-java/releases/tag/1.9.0).
 
 > CHANGELOG
 >


### PR DESCRIPTION
## Description
Corrigimos o link a release do SDK de java que estava quebrado na documentação em PT

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #<issue>

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
