### PR TITLE
Adição de respostas/exemplos para algumas API's

### DIFF
--- a/reference/api/cards.yaml
+++ b/reference/api/cards.yaml
@@ -33,33 +33,40 @@ paths:
                     id:
                       type: string
                       description: Card ID.
-                      example: 123123-ABD123DIGKBKI991-123
+                      example: '277090284'
                     date_registered:
                       type: string
-                      description: 
+                      description: null
                     date_created:
                       type: string
                       format: date
                       description: Card's date created.
+                      example: '2018-07-18T13:28:32.000-04:00'
                     date_last_updated:
                       type: string
                       format: date
                       description: Card's last modified date.
+                      example: '2018-08-07T12:21:32.243-04:00'
                     customer_id:
                       type: string
                       description: Customer ID.
+                      example: 329653963-byLEdchVPhPc4H
                     expiration_month:
                       type: number
                       description: Card's expiration month.
+                      example: 11
                     expiration_year:
                       type: number
                       description: Card's expiration year.
+                      example: 2020
                     first_six_digits:
                       type: string
                       description: Card's first six digits.
+                      example: '423564'
                     last_four_digits:
                       type: string
                       description: Card's last four digits.
+                      example: '5682'
                     payment_method:
                       type: object
                       description: Payment method information.
@@ -67,18 +74,23 @@ paths:
                         id:
                           type: string
                           description: Payment method ID.
+                          example: visa
                         name:
                           type: string
                           description: Payment method name.
+                          example: Visa
                         payment_type_id:
                           type: string
                           description: Payment method type.
+                          example: credit_card
                         thumbnail:
                           type: string
                           description: Payment method thumbnail.
+                          example: http://img.mlstatic.com/org-img/MP3/API/logos/visa.gif
                         secure_thumbnail:
                           type: string
                           description: Payment method secure thumbnail.
+                          example: https://www.mercadopago.com/org-img/MP3/API/logos/visa.gif
                     security_code:
                       type: object
                       description: Security code information.
@@ -86,9 +98,11 @@ paths:
                         length:
                           type: number
                           description: Security code's length.
+                          example: 3
                         card_location:
                           type: string
                           description: Security code's card location.
+                          example: back
                     issuer:
                       type: object
                       description: Issuer information.
@@ -96,29 +110,40 @@ paths:
                         id:
                           type: number
                           description: Issuer Id.
+                          example: 25
                         name:
                           type: string
                           description: Issuer name.
+                          example: Visa
                     cardholder:
                       type: object
                       description: Card holder information.
                       properties:
                         name:
-                          type: number
+                          type: string
                           description: Card holder name.
+                          example: APRO
                         identification:
-                          type: number
+                          type: object
                           description: Identification information.
                           properties:
                             number:
-                              type: number
+                              type: string
                               description: Identification number.
+                              example: '19119119100'
                             subtype:
                               type: string
                               description: Identification subtype.
                             type:
                               type: string
                               description: Identification type.
+                              example: CPF
+                    user_id:
+                      type: string
+                      example: '12123adfasdf123u4u'
+                    live_mode:
+                      type: boolean
+                      example: true
         '400':
           description: Error
           content:
@@ -272,8 +297,7 @@ paths:
                         description: thumbnail
                       secure_thumbnail:
                         type: string
-                        example: >-
-                          https://www.mercadopago.com/org-img/MP3/API/logos/visa.gif
+                        example: https://www.mercadopago.com/org-img/MP3/API/logos/visa.gif
                         description: secure_thumbnail
                     description: payment_method
                   security_code:
@@ -322,11 +346,11 @@ paths:
                     description: cardholder
                   date_created:
                     type: string
-                    example: 2019-07-03T21:15:35.000Z
+                    example: '2019-07-03T21:15:35.000Z'
                     description: date_created
                   date_last_updated:
                     type: string
-                    example: 2019-07-03T21:19:18.000Z
+                    example: '2019-07-03T21:19:18.000Z'
                     description: date_last_updated
                   customer_id:
                     type: string
@@ -338,6 +362,7 @@ paths:
                     description: user_id
                   live_mode:
                     type: boolean
+                    example: true
                     description: live_mode
         '400':
           description: Error
@@ -452,32 +477,40 @@ paths:
                   id:
                     type: string
                     description: Card ID.
+                    example: '8987269652'
                   date_registered:
                     type: string
-                    description: 
+                    description: null
                   date_created:
                     type: string
                     format: date
                     description: Card's date created.
+                    example: '2021-03-16T16:08:20.592-04:00'
                   date_last_updated:
                     type: string
                     format: date
                     description: Card's last modified date.
+                    example: '2021-03-16T16:08:20.592-04:00'
                   customer_id:
                     type: string
                     description: Customer ID.
+                    example: 470183340-cpunOI7UsIHlHr
                   expiration_month:
                     type: number
                     description: Card's expiration month.
+                    example: 6
                   expiration_year:
                     type: number
                     description: Card's expiration year.
+                    example: 2023
                   first_six_digits:
                     type: string
                     description: Card's first six digits.
+                    example: '503143'
                   last_four_digits:
                     type: string
                     description: Card's last four digits.
+                    example: '6351'
                   payment_method:
                     type: object
                     description: Payment method information.
@@ -485,18 +518,23 @@ paths:
                       id:
                         type: string
                         description: Payment method ID.
+                        example: master
                       name:
                         type: string
                         description: Payment method name.
+                        example: Mastercard
                       payment_type_id:
                         type: string
                         description: Payment method type.
+                        example: credit_card
                       thumbnail:
                         type: string
                         description: Payment method thumbnail.
+                        example: http://img.mlstatic.com/org-img/MP3/API/logos/master.gif
                       secure_thumbnail:
                         type: string
                         description: Payment method secure thumbnail.
+                        example: https://www.mercadopago.com/org-img/MP3/API/logos/master.gif
                   security_code:
                     type: object
                     description: Security code information.
@@ -504,9 +542,11 @@ paths:
                       length:
                         type: number
                         description: Security code's length.
+                        example: 3
                       card_location:
                         type: string
                         description: Security code's card location.
+                        example: back
                   issuer:
                     type: object
                     description: Issuer information.
@@ -514,29 +554,41 @@ paths:
                       id:
                         type: number
                         description: Issuer Id.
+                        example: 24
                       name:
                         type: string
                         description: Issuer name.
+                        example: Mastercard
                   cardholder:
                     type: object
                     description: Card holder information.
                     properties:
                       name:
-                        type: number
+                        type: string
                         description: Card holder name.
+                        example: APRO
                       identification:
-                        type: number
+                        type: object
                         description: Identification information.
                         properties:
                           number:
-                            type: number
+                            type: string
                             description: Identification number.
+                            example: '19119119100'
                           subtype:
                             type: string
                             description: Identification subtype.
                           type:
                             type: string
                             description: Identification type.
+                            example: CPF
+                  user_id:
+                    type: string
+                    example: '470183340'
+                  live_mode:
+                    type: boolean
+                    example: true
+
         '400':
           description: Error
           content:
@@ -649,6 +701,95 @@ paths:
                   description: Card Token
                   example: 9b2d63e00d66a8c721607214ceda233a
       responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    example: '8987269652'
+                  expiration_month:
+                    type: number
+                    example: 7
+                  expiration_year:
+                    type: number
+                    example: 2023
+                  first_six_digits:
+                    type: string
+                    example: '503143'
+                  last_four_digits:
+                    type: string
+                    example: '6351'
+                  payment_method:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        example: master
+                      name:
+                        type: string
+                        example: Mastercard
+                      payment_type_id:
+                        type: string
+                        example: credit_card
+                      thumbnail:
+                        type: string
+                        example: http://img.mlstatic.com/org-img/MP3/API/logos/master.gif
+                      secure_thumbnail:
+                        type: string
+                        example: https://www.mercadopago.com/org-img/MP3/API/logos/master.gif
+                  security_code:
+                    type: object
+                    properties:
+                      length:
+                        type: number
+                        example: 3
+                      card_location:
+                        type: string
+                        example: back
+                  issuer:
+                    type: object
+                    properties:
+                      id:
+                        type: number
+                        example: 24
+                      name:
+                        type: string
+                        example: Mastercard
+                  cardholder:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        example: APRO
+                      identification:
+                        type: object
+                        properties:
+                          number:
+                            type: string
+                            example: '19119119100'
+                          type:
+                            type: string
+                            example: CPF
+                  date_created:
+                    type: string
+                    example: '2021-03-16T16:08:21.000-04:00'
+                  date_last_updated:
+                    type: string
+                    example: '2021-03-16T16:11:54.294-04:00'
+                  customer_id:
+                    type: string
+                    example: 470183340-cpunOI7UsIHlHr
+                  user_id:
+                    type: string
+                    example: '470183340'
+                  live_mode:
+                    type: boolean
+                    example: true
+        
         '400':
           description: Error
           content:
@@ -751,6 +892,95 @@ paths:
             type: string
             example: 12123adfasdf123u4u
       responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    example: '8987269652'
+                  expiration_month:
+                    type: number
+                    example: 7
+                  expiration_year:
+                    type: number
+                    example: 2023
+                  first_six_digits:
+                    type: string
+                    example: '503143'
+                  last_four_digits:
+                    type: string
+                    example: '6351'
+                  payment_method:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        example: master
+                      name:
+                        type: string
+                        example: Mastercard
+                      payment_type_id:
+                        type: string
+                        example: credit_card
+                      thumbnail:
+                        type: string
+                        example: http://img.mlstatic.com/org-img/MP3/API/logos/master.gif
+                      secure_thumbnail:
+                        type: string
+                        example: https://www.mercadopago.com/org-img/MP3/API/logos/master.gif
+                  security_code:
+                    type: object
+                    properties:
+                      length:
+                        type: number
+                        example: 3
+                      card_location:
+                        type: string
+                        example: back
+                  issuer:
+                    type: object
+                    properties:
+                      id:
+                        type: number
+                        example: 24
+                      name:
+                        type: string
+                        example: Mastercard
+                  cardholder:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        example: APRO
+                      identification:
+                        type: object
+                        properties:
+                          number:
+                            type: string
+                            example: '19119119100'
+                          type:
+                            type: string
+                            example: CPF
+                  date_created:
+                    type: string
+                    example: '2021-03-16T16:08:21.000-04:00'
+                  date_last_updated:
+                    type: string
+                    example: '2021-03-16T16:14:40.962-04:00'
+                  customer_id:
+                    type: string
+                    example: 470183340-cpunOI7UsIHlHr
+                  user_id:
+                    type: string
+                    example: '470183340'
+                  live_mode:
+                    type: boolean
+                    example: true
+
         '400':
           description: Error
           content:

--- a/reference/api/customers.yaml
+++ b/reference/api/customers.yaml
@@ -80,13 +80,11 @@ paths:
                         description: street_name
                       street_number:
                         type: string
-                        properties: null
                         format: nullable
                         description: street_number
                     description: address
                   date_registered:
                     type: string
-                    properties: null
                     format: nullable
                     description: date_registered
                   description:
@@ -99,7 +97,6 @@ paths:
                     description: date_created
                   date_last_updated:
                     type: string
-                    properties: null
                     format: nullable
                     description: date_last_updated
                   metadata:
@@ -111,7 +108,6 @@ paths:
                     description: metadata
                   default_card:
                     type: string
-                    properties: null
                     format: nullable
                     description: default_card
                   default_address:
@@ -497,12 +493,10 @@ paths:
                         description: Street name.
                       street_number:
                         type: string
-                        properties: null
                         description: Street number.
                     description: Default address's information.
                   date_registered:
                     type: string
-                    properties: null
                     format: date
                     description: Customer's registration date.
                   description:
@@ -516,7 +510,6 @@ paths:
                     description: Customer's date created.
                   date_last_updated:
                     type: string
-                    properties: null
                     format: date
                     description: Last modified date.
                   metadata:
@@ -528,7 +521,6 @@ paths:
                     description: Customer's metadata.
                   default_card:
                     type: string
-                    properties: null
                     description: Customer's default card.
                   default_address:
                     type: string

--- a/reference/api/customers.yaml
+++ b/reference/api/customers.yaml
@@ -28,7 +28,7 @@ paths:
                     description: id
                   email:
                     type: string
-                    example: bruno@gmail.com
+                    example: jhon@doe.com
                     description: email
                   first_name:
                     type: string
@@ -89,7 +89,7 @@ paths:
                     description: date_registered
                   description:
                     type: string
-                    example: Lorem Ipsum
+                    example: This is my description
                     description: description
                   date_created:
                     type: string
@@ -240,7 +240,7 @@ paths:
                     description: id
                   email:
                     type: string
-                    example: bruno@gmail.com
+                    example: jhon@doe.com
                     description: email
                   first_name:
                     type: string
@@ -300,7 +300,7 @@ paths:
                     description: date_registered
                   description:
                     type: string
-                    example: Lorem Ipsum
+                    example: This is my description
                     description: description
                   date_created:
                     type: string

--- a/reference/api/customers.yaml
+++ b/reference/api/customers.yaml
@@ -67,6 +67,7 @@ paths:
                     properties:
                       id:
                         type: string
+                        example: '1162600094'
                         format: nullable
                         description: id
                       zip_code:
@@ -79,11 +80,13 @@ paths:
                         description: street_name
                       street_number:
                         type: string
+                        properties: null
                         format: nullable
                         description: street_number
                     description: address
                   date_registered:
                     type: string
+                    properties: null
                     format: nullable
                     description: date_registered
                   description:
@@ -92,21 +95,28 @@ paths:
                     description: description
                   date_created:
                     type: string
-                    example: 2018-02-20T15:36:23.541Z
+                    example: '2018-02-20T15:36:23.541Z'
                     description: date_created
                   date_last_updated:
                     type: string
+                    properties: null
                     format: nullable
                     description: date_last_updated
                   metadata:
                     type: object
+                    properties:
+                      source_sync:
+                        type: string
+                        example: source_ws
                     description: metadata
                   default_card:
                     type: string
+                    properties: null
                     format: nullable
                     description: default_card
                   default_address:
                     type: string
+                    example: '1162600094'
                     format: nullable
                     description: default_address
                   cards:
@@ -121,6 +131,7 @@ paths:
                     description: addresses
                   live_mode:
                     type: boolean
+                    example: true
                     description: live_mode
         '400':
           description: Error
@@ -220,6 +231,113 @@ paths:
       requestBody:
         $ref: '#/schemas/customer'
       responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    example: 000000001-sT93QZFAsfxU9P5
+                    description: id
+                  email:
+                    type: string
+                    example: bruno@gmail.com
+                    description: email
+                  first_name:
+                    type: string
+                    example: Bruce
+                    description: first_name
+                  last_name:
+                    type: string
+                    example: Wayne
+                    description: last_name
+                  phone:
+                    type: object
+                    properties:
+                      area_code:
+                        type: string
+                        example: 23
+                        description: area_code
+                      number:
+                        type: string
+                        example: 12345678
+                        description: number
+                    description: phone
+                  identification:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: DNI
+                        description: type
+                      number:
+                        type: string
+                        example: 12345678
+                        description: number
+                    description: identification
+                  address:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: nullable
+                        description: id
+                      zip_code:
+                        type: string
+                        example: SG1 2AX
+                        description: zip_code
+                      street_name:
+                        type: string
+                        example: Old Knebworth Ln
+                        description: street_name
+                      street_number:
+                        type: string
+                        format: nullable
+                        description: street_number
+                    description: address
+                  date_registered:
+                    type: string
+                    format: nullable
+                    description: date_registered
+                  description:
+                    type: string
+                    example: Lorem Ipsum
+                    description: description
+                  date_created:
+                    type: string
+                    example: 2018-02-20T15:36:23.541Z
+                    description: date_created
+                  date_last_updated:
+                    type: string
+                    format: nullable
+                    description: date_last_updated
+                  metadata:
+                    type: object
+                    description: metadata
+                  default_card:
+                    type: string
+                    format: nullable
+                    description: default_card
+                  default_address:
+                    type: string
+                    format: nullable
+                    description: default_address
+                  cards:
+                    type: array
+                    items:
+                      type: object
+                    description: cards
+                  addresses:
+                    type: array
+                    items:
+                      type: object
+                    description: addresses
+                  live_mode:
+                    type: boolean
+                    description: live_mode
         '400':
           description: Error
           content:
@@ -324,79 +442,100 @@ paths:
                 properties:
                   id:
                     type: string
+                    example: 470183340-cpunOI7UsIHlHr
                     description: Customer ID.
                   email:
                     type: string
+                    example: comprador_mlb01+470183340@asdf12.com.br
                     description: Customer's email.
                   first_name:
                     type: string
+                    example: Customer
                     description: Customer's name.
                   last_name:
                     type: string
+                    example: Tester
                     description: Customer's last name.
                   phone:
                     type: object
-                    description: Customer phone's information.
                     properties:
                       area_code:
                         type: string
+                        example: '11'
                         description: Phone's area code.
                       number:
                         type: string
+                        example: '97654321'
                         description: Phone's number.
+                    description: Customer phone's information.
                   identification:
                     type: object
-                    description: Customer identification's information.
                     properties:
                       type:
                         type: string
+                        example: CPF
                         description: Identification's type.
                       number:
                         type: string
+                        example: '19119119100'
                         description: Identification's number.
-                  default_address:
-                    type: string
-                    description: Customer's default address.
+                    description: Customer identification's information.
                   address:
                     type: object
-                    description: Default address's information.
                     properties:
                       id:
                         type: string
+                        example: '1162600213'
                         description: Address ID.
                       zip_code:
                         type: string
+                        example: '05187010'
                         description: Zip code.
                       street_name:
                         type: string
+                        example: Caetano Poli, 12
                         description: Street name.
                       street_number:
                         type: string
+                        properties: null
                         description: Street number.
+                    description: Default address's information.
                   date_registered:
                     type: string
+                    properties: null
                     format: date
                     description: Customer's registration date.
                   description:
                     type: string
+                    example: Customer Test
                     description: Customer's description.
                   date_created:
                     type: string
+                    example: '2021-03-16T15:45:17.000-04:00'
                     format: date
                     description: Customer's date created.
                   date_last_updated:
                     type: string
+                    properties: null
                     format: date
                     description: Last modified date.
                   metadata:
                     type: object
+                    properties:
+                      source_sync:
+                        type: string
+                        example: source_ws
                     description: Customer's metadata.
                   default_card:
                     type: string
+                    properties: null
                     description: Customer's default card.
+                  default_address:
+                    type: string
+                    example: '1162600213'
+                    description: Customer's default address.
                   cards:
                     type: object
-                    description: Customer's cards.
                     properties:
                       id:
                         type: string
@@ -483,13 +622,14 @@ paths:
                         type: string
                         format: date
                         description: Card's last modified date.
+                    description: Customer's cards.
                   addresses:
                     type: object
-                    description: Customer's addresses.
                     properties:
                       id:
                         type: string
                         description: Address ID.
+                        example: '1162600213'
                       phone:
                         type: string
                         description: Phone number.
@@ -505,12 +645,14 @@ paths:
                       street_name:
                         type: string
                         description: Street name.
+                        example: Caetano Poli, 12
                       street_number:
                         type: number
                         description: Street number.
                       zip_code:
                         type: string
                         description: Postal code of an Address.
+                        example: '05187010'
                       city:
                         type: object
                         description: City information.
@@ -518,9 +660,11 @@ paths:
                           id:
                             type: string
                             description: City ID.
+                            example: BR-SP-44
                           name:
                             type: string
                             description: City name.
+                            example: São Paulo
                       state:
                         type: object
                         description: State information.
@@ -528,9 +672,11 @@ paths:
                           id:
                             type: string
                             description: State ID.
+                            example: BR-SP
                           name:
                             type: string
                             description: State name.
+                            example: São Paulo
                       country:
                         type: object
                         description: Country information.
@@ -538,9 +684,11 @@ paths:
                           id:
                             type: string
                             description: Country ID.
+                            example: BR
                           name:
                             type: string
                             description: Country name.
+                            example: Brasil
                       neighborhood:
                         type: object
                         description: Neighborhood information.
@@ -551,6 +699,7 @@ paths:
                           name:
                             type: string
                             description: Neighborhood name.
+                            example: Jardim Ipanema (Zona Oeste)
                       municipality:
                         type: object
                         description: Municipality information.
@@ -567,11 +716,12 @@ paths:
                       date_created:
                         type: string
                         description: Address date created.
+                        example: '2021-03-16T15:45:17.000-04:00'
+                    description: Customer's addresses.
                   live_mode:
                     type: boolean
-                    description: >-
-                      Whether the customers will be in sandbox or in production
-                      mode.
+                    example: true
+                    description: Whether the customers will be in sandbox or in production mode.
         '400':
           description: Error
           content:
@@ -703,10 +853,12 @@ paths:
                               type: string
                               format: nullable
                               description: id
+                              example: '1162600213'
                             street_name:
                               type: string
                               format: nullable
                               description: street_name
+                              example: Caetano Poli, 12
                             street_number:
                               type: string
                               format: nullable
@@ -715,6 +867,7 @@ paths:
                               type: string
                               format: nullable
                               description: zip_code
+                              example: '05187010'
                           description: address
                         addresses:
                           type: array
@@ -742,6 +895,7 @@ paths:
                           type: string
                           format: nullable
                           description: default_address
+                          example: '1162600213'
                         default_card:
                           type: string
                           example: 1493990563105
@@ -756,8 +910,8 @@ paths:
                           description: email
                         first_name:
                           type: string
-                          format: nullable
                           description: first_name
+                          example: Customer
                         id:
                           type: string
                           example: 123456789-jxOV430go9fx2e
@@ -769,18 +923,22 @@ paths:
                               type: string
                               format: nullable
                               description: number
+                              example: '19119119100'
                             type:
                               type: string
                               format: nullable
                               description: type
+                              example: CPF
                           description: identification
                         last_name:
                           type: string
                           format: nullable
                           description: last_name
+                          example: Tester
                         live_mode:
                           type: boolean
                           description: live_mode
+                          example: true
                         metadata:
                           type: object
                           description: metadata
@@ -791,10 +949,12 @@ paths:
                               type: string
                               format: nullable
                               description: area_code
+                              example: '11'
                             number:
                               type: string
                               format: nullable
                               description: number
+                              example: '987654321'
                           description: phone
                     description: results
         '400':

--- a/reference/api/instore_orders.yaml
+++ b/reference/api/instore_orders.yaml
@@ -155,7 +155,6 @@ paths:
                           properties:
                             id:
                               type: string
-                              example: null
                               description: id
                         description: excluded_payment_methods
                       excluded_payment_types:
@@ -190,15 +189,12 @@ paths:
                     properties:
                       success:
                         type: string
-                        example: null
                         description: success
                       pending:
                         type: string
-                        example: null
                         description: pending
                       failure:
                         type: string
-                        example: null
                         description: failure
                     description: back_urls
                   payer:
@@ -210,18 +206,15 @@ paths:
                         description: id
                       email:
                         type: string
-                        example: null
                         description: email
                       identification:
                         type: object
                         properties:
                           number:
                             type: string
-                            example: null
                             description: number
                           type:
                             type: string
-                            example: null
                             description: type
                         description: identification
                       address:
@@ -232,7 +225,6 @@ paths:
                             description: primary
                           zip:
                             type: string
-                            example: null
                             description: zip
                         description: address
                       phone:
@@ -240,11 +232,9 @@ paths:
                         properties:
                           area_code:
                             type: string
-                            example: null
                             description: area_code
                           number:
                             type: string
-                            example: null
                             description: number
                         description: phone
                     description: payer
@@ -253,7 +243,6 @@ paths:
                     description: expires
                   additional_info:
                     type: string
-                    example: null
                     description: additional_info
                   site_id:
                     type: string

--- a/reference/api/instore_orders_v2.yaml
+++ b/reference/api/instore_orders_v2.yaml
@@ -81,14 +81,66 @@ paths:
                 items:
                   type: object
                   properties:
+                    external_reference:
+                      type: string
+                      example: '12345'
+                    total_amount:
+                      type: number
+                      example: 100
+                    items:
+                      type: array
+                      items:
+                        properties:
+                          type: object
+                          properties:
+                            sku_number:
+                              type: string
+                              example: KS955RUR
+                            category:
+                              type: string
+                              example: COMIDA
+                            title:
+                              type: string
+                              example: Pasta
+                            description:
+                              type: string
+                              example: Compra en Mercado Pago
+                            unit_measure:
+                              type: string
+                              example: unit
+                            quantity:
+                              type: number
+                              example: 5
+                            unit_price:
+                              type: number
+                              example: 20
+                            total_amount:
+                              type: number
+                              example: 100
+                    title:
+                      type: string
+                      example: Compra
+                    description:
+                      type: string
+                      example: Compra en Mercado Pago
+                    sponsor:
+                      type: object
+                      properties:
+                        id:
+                          type: number
+                          example: 329653963
+                    expiration_date:
+                      type: string
+                      example: '2023-08-22T16:34:56.559-04:00'
+                    notification_url:
+                      type: string
+                      example: www.yourserver.com
                     user_id:
                       type: string
                       description: User identifier.
                     external_pos_id:
                       type: string
-                      description: >-
-                        External_id of the point of sale defined by integrator
-                        system.
+                      description: External_id of the point of sale defined by integrator system.
         '400':
           description: Error
           content:

--- a/reference/api/merchant_orders.yaml
+++ b/reference/api/merchant_orders.yaml
@@ -917,15 +917,15 @@ paths:
                           description: operation_type
                         date_approved:
                           type: string
-                          example: 2019-04-02T18:35:35.000Z
+                          example: '2019-04-02T18:35:35.000Z'
                           description: date_approved
                         date_created:
                           type: string
-                          example: 2019-04-02T18:35:34.000Z
+                          example: '2019-04-02T18:35:34.000Z'
                           description: date_created
                         last_modified:
                           type: string
-                          example: 2019-04-02T18:35:35.000Z
+                          example: '2019-04-02T18:35:35.000Z'
                           description: last_modified
                         amount_refunded:
                           type: number
@@ -989,15 +989,15 @@ paths:
                           description: items
                         date_created:
                           type: string
-                          example: 2019-04-02T18:20:46.000Z
+                          example: '2019-04-02T18:20:46.000Z'
                           description: date_created
                         last_modified:
                           type: string
-                          example: 2019-04-12T19:36:48.000Z
+                          example: '2019-04-12T19:36:48.000Z'
                           description: last_modified
                         date_first_printed:
                           type: string
-                          example: 2019-04-02T18:35:40.000Z
+                          example: '2019-04-02T18:35:40.000Z'
                           description: date_first_printed
                         service_id:
                           type: number
@@ -1123,7 +1123,7 @@ paths:
                               properties:
                                 date:
                                   type: string
-                                  example: 2019-04-11T03:00:00.000Z
+                                  example: '2019-04-11T03:00:00.000Z'
                                   description: date
                                 time_from:
                                   type: string
@@ -1156,6 +1156,8 @@ paths:
                               description: speed
                           description: shipping_option
                     description: shipments
+                  payouts:
+                    type: object
                   collector:
                     type: object
                     properties:
@@ -1163,8 +1165,12 @@ paths:
                         type: number
                         example: 999999999
                         description: id
+                      email:
+                        type: string
+                        example: vendedor+329653108@adf12.com.br
                       nickname:
                         type: string
+                        example: TESTRPEHE21Q
                         format: nullable
                         description: nickname
                     description: collector
@@ -1174,18 +1180,20 @@ paths:
                     description: marketplace
                   notification_url:
                     type: string
+                    properties: null
                     format: nullable
                     description: notification_url
                   date_created:
                     type: string
-                    example: 2018-09-14T17:11:31.000Z
+                    example: '2018-09-14T17:11:31.000Z'
                     description: date_created
                   last_updated:
                     type: string
-                    example: 2018-09-14T17:11:43.000Z
+                    example: '2018-09-14T17:11:43.000Z'
                     description: last_updated
                   sponsor_id:
                     type: string
+                    properties: null
                     format: nullable
                     description: sponsor_id
                   shipping_cost:
@@ -1260,6 +1268,7 @@ paths:
                     description: items
                   cancelled:
                     type: boolean
+                    example: false
                     description: cancelled
                   additional_info:
                     type: string
@@ -1267,12 +1276,14 @@ paths:
                     description: additional_info
                   application_id:
                     type: number
+                    properties: null
                     example: 10000000000000000
                     description: application_id
                   order_status:
                     type: string
                     example: paid
                     description: order_status
+
         '400':
           description: Error
           content:
@@ -1545,6 +1556,161 @@ paths:
                         type: string
                         description: Item title.
       responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: number
+                    example: 9999999999
+                    description: id
+                  status:
+                    type: string
+                    example: closed
+                    description: status
+                  external_reference:
+                    type: string
+                    example: default
+                    description: external_reference
+                  preference_id:
+                    type: string
+                    example: Preference identification
+                    description: preference_id
+                  payments:
+                    type: object
+                  shipments:
+                    type: object
+                  payouts:
+                    type: object
+                  collector:
+                    type: object
+                    properties:
+                      id:
+                        type: number
+                        example: 999999999
+                        description: id
+                      email:
+                        type: string
+                        example: ''
+                      nickname:
+                        type: string
+                        example: TESTRPEHE21Q
+                        format: nullable
+                        description: nickname
+                    description: collector
+                  marketplace:
+                    type: string
+                    example: NONE
+                    description: marketplace
+                  notification_url:
+                    type: string
+                    properties: null
+                    format: nullable
+                    description: notification_url
+                  date_created:
+                    type: string
+                    example: '2018-09-14T17:11:31.000Z'
+                    description: date_created
+                  last_updated:
+                    type: string
+                    example: '2018-09-14T17:11:43.000Z'
+                    description: last_updated
+                  sponsor_id:
+                    type: string
+                    properties: null
+                    format: nullable
+                    description: sponsor_id
+                  shipping_cost:
+                    type: number
+                    example: 0
+                    description: shipping_cost
+                  total_amount:
+                    type: number
+                    example: 5
+                    description: total_amount
+                  site_id:
+                    type: string
+                    example: mla
+                    description: site_id
+                  paid_amount:
+                    type: number
+                    example: 5
+                    description: paid_amount
+                  refunded_amount:
+                    type: number
+                    example: 0
+                    description: refunded_amount
+                  payer:
+                    type: object
+                    properties:
+                      id:
+                        type: number
+                        example: 999999999
+                        description: id
+                      email:
+                        type: string
+                        example: null
+                        description: email
+                    description: payer
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          example: item id
+                          description: id
+                        category_id:
+                          type: string
+                          example: item category
+                          description: category_id
+                        currency_id:
+                          type: string
+                          example: $
+                          description: currency_id
+                        description:
+                          type: string
+                          example: item description
+                          description: description
+                        picture_url:
+                          type: string
+                          example: item picture url
+                          description: picture_url
+                        title:
+                          type: string
+                          example: item title
+                          description: title
+                        quantity:
+                          type: number
+                          example: 1
+                          description: quantity
+                        unit_price:
+                          type: number
+                          example: 5
+                          description: unit_price
+                    description: items
+                  cancelled:
+                    type: boolean
+                    example: false
+                    description: cancelled
+                  additional_info:
+                    type: string
+                    example: additional information
+                    description: additional_info
+                  application_id:
+                    type: number
+                    properties: null
+                    example: 10000000000000000
+                    description: application_id
+                  order_status:
+                    type: string
+                    example: payment_required
+                    description: order_status
+
         '400':
           description: Error
           content:

--- a/reference/api/merchant_orders.yaml
+++ b/reference/api/merchant_orders.yaml
@@ -173,7 +173,6 @@ paths:
                         description: id
                       email:
                         type: string
-                        example: null
                         description: email
                     description: payer
                   items:
@@ -750,7 +749,6 @@ paths:
                               description: id
                             email:
                               type: string
-                              example: null
                               description: email
                           description: payer
                         items:
@@ -1223,7 +1221,6 @@ paths:
                         description: id
                       email:
                         type: string
-                        example: null
                         description: email
                     description: payer
                   items:
@@ -1647,7 +1644,6 @@ paths:
                         description: id
                       email:
                         type: string
-                        example: null
                         description: email
                     description: payer
                   items:

--- a/reference/api/merchant_orders.yaml
+++ b/reference/api/merchant_orders.yaml
@@ -1180,7 +1180,6 @@ paths:
                     description: marketplace
                   notification_url:
                     type: string
-                    properties: null
                     format: nullable
                     description: notification_url
                   date_created:
@@ -1193,7 +1192,6 @@ paths:
                     description: last_updated
                   sponsor_id:
                     type: string
-                    properties: null
                     format: nullable
                     description: sponsor_id
                   shipping_cost:
@@ -1276,7 +1274,6 @@ paths:
                     description: additional_info
                   application_id:
                     type: number
-                    properties: null
                     example: 10000000000000000
                     description: application_id
                   order_status:
@@ -1607,7 +1604,6 @@ paths:
                     description: marketplace
                   notification_url:
                     type: string
-                    properties: null
                     format: nullable
                     description: notification_url
                   date_created:
@@ -1620,7 +1616,6 @@ paths:
                     description: last_updated
                   sponsor_id:
                     type: string
-                    properties: null
                     format: nullable
                     description: sponsor_id
                   shipping_cost:
@@ -1703,7 +1698,6 @@ paths:
                     description: additional_info
                   application_id:
                     type: number
-                    properties: null
                     example: 10000000000000000
                     description: application_id
                   order_status:

--- a/reference/api/payment_methods.yaml
+++ b/reference/api/payment_methods.yaml
@@ -24,28 +24,34 @@ paths:
                   properties:
                     id:
                       type: string
+                      example: visa
                       description: Payment method identifier.
                     name:
                       type: string
+                      example: Visa
                       description: Name of the payment method.
                     payment_type_id:
                       type: string
+                      example: credit_card
                       description: Types of payment methods.
                     status:
                       type: string
+                      example: active
                       description: Payment methods status.
                     secure_thumbnail:
                       type: string
+                      example: https://www.mercadopago.com/org-img/MP3/API/logos/visa.gif
                       description: Logo to display on secure sites.
                     thumbnail:
                       type: string
+                      example: http://img.mlstatic.com/org-img/MP3/API/logos/visa.gif
                       description: Logo to show.
                     deferred_capture:
                       type: string
+                      example: supported
                       description: Whether the capture can be delayed or not.
                     settings:
                       type: object
-                      description: Payment method settings.
                       properties:
                         bin:
                           type: object
@@ -53,19 +59,19 @@ paths:
                           properties:
                             pattern:
                               type: string
-                              description: >-
-                                Regular expression representing the accepted
-                                bins.
+                              example: ^(4)
+                              description: Regular expression representing the accepted bins.
                             exclusion_pattern:
                               type: string
-                              description: >-
-                                Regular expression representing the excluded
-                                bins.
+                              description: Regular expression representing the excluded bins.
+                              example: >-
+                                    ^(400163|400176|400178|400185|400199|423808|439267|471233|473200|476332|482481|451416|438935|(40117[8-9])|(45763[1-2])|457393|431274)
                             installments_pattern:
                               type: string
+                              example: ^(?!(417401|453998|426398|462437|451212|456188))
                               description: >-
-                                Regular expression representing bins allowed to
-                                pay with more than one installment.
+                                Regular expression representing bins allowed to pay with more than
+                                one installment.
                         card_number:
                           type: object
                           description: card_number
@@ -73,58 +79,64 @@ paths:
                             length:
                               type: string
                               description: Card number length.
+                              example: 16
                             validation:
                               type: string
+                              example: standard
                               description: >-
-                                Whether the card number can be validated using a
-                                checksum algorithm (usually Luhn)
+                                Whether the card number can be validated using a checksum algorithm
+                                (usually Luhn)
                         security_code:
                           type: object
                           description: security_code
                           properties:
                             mode:
                               type: string
+                              example: mandatory
                               description: Whether the security code is mandatory or not.
                             length:
                               type: number
                               description: Security code length.
+                              example: 3
                             card_location:
                               type: string
+                              example: back
                               description: >-
-                                Whether the security code is located in the back
-                                or in the front of the card.
+                                Whether the security code is located in the back or in the front of
+                                the card.
+                      description: Payment method settings.
                     additional_info_needed:
                       type: array
-                      description: >-
-                        List of additional information that must be supplied by
-                        the payer.
+                      description: List of additional information that must be supplied by the payer.
                     min_allowed_amount:
                       type: number
-                      description: >-
-                        Minimum amount that can be processed with this payment
-                        method.
+                      example: 0.5
+                      description: Minimum amount that can be processed with this payment method.
                     max_allowed_amount:
                       type: number
-                      description: >-
-                        Maximum amount that can be processed with this payment
-                        method.
+                      example: 60000
+                      description: Maximum amount that can be processed with this payment method.
                     accreditation_time:
                       type: number
-                      description: >-
-                        How many time in minutes could happen until processing
-                        of the payment.
+                      example: 2880
+                      description: How many time in minutes could happen until processing of the payment.
                     financial_institutions:
                       type: object
-                      description: Finantial institution processing this payment method.
                       properties:
                         id:
                           type: number
-                          description: >-
-                            External financial institution identifier (e.g.:
-                            company id for atm)
+                          description: 'External financial institution identifier (e.g.: company id for atm)'
                         description:
                           type: string
                           description: Descriptive finantial institution name.
+                      description: Finantial institution processing this payment method.
+                    processing_modes:
+                      type: object
+                      properties:
+                        '0':
+                          type: string
+                          example: aggregator
+
         '400':
           description: Error
           content:

--- a/reference/api/payments.yaml
+++ b/reference/api/payments.yaml
@@ -413,7 +413,6 @@ paths:
                             description: number
                           extension:
                             type: string
-                            example: null
                             description: extension
                         description: phone
                       type:
@@ -729,7 +728,6 @@ paths:
                         description: Payment type identifier
                       sub_type:
                         type: string
-                        example: null
                         description: Secondary identifier of the payment type
                       application_data:
                         type: object

--- a/reference/api/pos.yaml
+++ b/reference/api/pos.yaml
@@ -205,90 +205,88 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    paging:
+                type: object
+                properties:
+                  paging:
+                    type: object
+                    properties:
+                      total:
+                        type: number
+                        example: 2
+                        description: total
+                      offset:
+                        type: number
+                        example: 0
+                        description: offset
+                      limit:
+                        type: number
+                        example: 0
+                        description: limit
+                    description: paging
+                  results:
+                    type: array
+                    items:
                       type: object
                       properties:
-                        total:
+                        user_id:
                           type: number
-                          example: 2
-                          description: total
-                        offset:
+                          example: 446566691
+                          description: user_id
+                        name:
+                          type: string
+                          example: Caja Principal
+                          description: name
+                        fixed_amount:
+                          type: boolean
+                          description: fixed_amount
+                        category:
                           type: number
-                          example: 0
-                          description: offset
-                        limit:
+                          example: 621102
+                          description: category
+                        store_id:
+                          type: string
+                          example: 12345678
+                          description: store_id
+                        external_id:
+                          type: string
+                          example: CAJA001
+                          description: external_id
+                        id:
                           type: number
-                          example: 0
-                          description: limit
-                      description: paging
-                    results:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          user_id:
-                            type: number
-                            example: 446566691
-                            description: user_id
-                          name:
-                            type: string
-                            example: Caja Principal
-                            description: name
-                          fixed_amount:
-                            type: boolean
-                            description: fixed_amount
-                          category:
-                            type: number
-                            example: 621102
-                            description: category
-                          store_id:
-                            type: string
-                            example: 12345678
-                            description: store_id
-                          external_id:
-                            type: string
-                            example: CAJA001
-                            description: external_id
-                          id:
-                            type: number
-                            example: 1988157
-                            description: id
-                          qr:
-                            type: object
-                            properties:
-                              image:
-                                type: string
-                                example: >-
-                                  https://www.mercadopago.com/instore/merchant/qr/1988157/1f1da6401a4645e99fa21d3f4ffe0e702c4eab2209784fce9d45c83fa93bd5a7.png
-                                description: image
-                              template_document:
-                                type: string
-                                example: >-
-                                  https://www.mercadopago.com/instore/merchant/qr/1988157/template_1f1da6401a4645e99fa21d3f4ffe0e702c4eab2209784fce9d45c83fa93bd5a7.pdf
-                                description: template_document
-                              template_image:
-                                type: string
-                                example: >-
-                                  https://www.mercadopago.com/instore/merchant/qr/1988157/template_1f1da6401a4645e99fa21d3f4ffe0e702c4eab2209784fce9d45c83fa93bd5a7.png
-                                description: template_image
-                            description: qr
-                          date_created:
-                            type: string
-                            example: 2019-06-24T13:31:56.000Z
-                            description: date_created
-                          date_last_updated:
-                            type: string
-                            example: 2019-08-07T21:07:26.000Z
-                            description: date_last_updated
-                          external_store_id:
-                            type: string
-                            example: SUC001
-                            description: external_store_id
-                      description: results
+                          example: 1988157
+                          description: id
+                        qr:
+                          type: object
+                          properties:
+                            image:
+                              type: string
+                              example: >-
+                                https://www.mercadopago.com/instore/merchant/qr/1988157/1f1da6401a4645e99fa21d3f4ffe0e702c4eab2209784fce9d45c83fa93bd5a7.png
+                              description: image
+                            template_document:
+                              type: string
+                              example: >-
+                                https://www.mercadopago.com/instore/merchant/qr/1988157/template_1f1da6401a4645e99fa21d3f4ffe0e702c4eab2209784fce9d45c83fa93bd5a7.pdf
+                              description: template_document
+                            template_image:
+                              type: string
+                              example: >-
+                                https://www.mercadopago.com/instore/merchant/qr/1988157/template_1f1da6401a4645e99fa21d3f4ffe0e702c4eab2209784fce9d45c83fa93bd5a7.png
+                              description: template_image
+                          description: qr
+                        date_created:
+                          type: string
+                          example: '2019-06-24T13:31:56.000Z'
+                          description: date_created
+                        date_last_updated:
+                          type: string
+                          example: '2019-08-07T21:07:26.000Z'
+                          description: date_last_updated
+                        external_store_id:
+                          type: string
+                          example: SUC001
+                          description: external_store_id
+                    description: results
         '400':
           description: Error
           content:
@@ -335,7 +333,60 @@ paths:
                 properties:
                   id:
                     type: string
+                    example: 2852128
                     description: POS identifier, numerical and self-generated.
+                  qr:
+                    type: object
+                    properties:
+                      image:
+                        type: string
+                        example: >-
+                          https://www.mercadopago.com/instore/merchant/qr/2852128/c955a5618d874e998c8399e3515fed3a00b8cc0ca401448ca56e2f2e18f4ba68.png
+                      template_document:
+                        type: string
+                        example: >-
+                          https://www.mercadopago.com/instore/merchant/qr/2852128/template_c955a5618d874e998c8399e3515fed3a00b8cc0ca401448ca56e2f2e18f4ba68.pdf
+                      template_image:
+                        type: string
+                        example: >-
+                          https://www.mercadopago.com/instore/merchant/qr/2852128/template_c955a5618d874e998c8399e3515fed3a00b8cc0ca401448ca56e2f2e18f4ba68.png
+                  status:
+                    type: string
+                    example: active
+                  date_created:
+                    type: string
+                    example: '2019-09-03T13:13:54.000-04:00'
+                  date_last_updated:
+                    type: string
+                    example: '2020-09-30T08:38:58.000-04:00'
+                  uuid:
+                    type: string
+                    example: c955a5618d874e998c8399e3515fed3a00b8cc0ca401448ca56e2f2e18f4ba68
+                  compatible_id:
+                    type: string
+                    example: >-
+                      4be87a269a7b863fd043658d2a0d7b3fa2f32334138ff651e2408d3f8191d6c9f67a4dc297e9efc70d1adfbb31f7c21c29c9059ac905a359e39114c9871afef9
+                  user_id:
+                    type: number
+                    example: 329653108
+                  name:
+                    type: string
+                    example: loja1
+                  fixed_amount:
+                    type: boolean
+                    example: false
+                  external_id:
+                    type: string
+                    example: loja1
+                  site:
+                    type: string
+                    example: MLB
+                  qr_code:
+                    type: string
+                    example: >-
+                      00020101021226940014BR.GOV.BCB.PIX2572pix-qr-h.mercadopago.com/instore/h/p/v2/c955a5618d874e998c8399e3515fed3a43520016com.mercadolibre0128https://mpago.la/pos/28521285204000053039865802BR5924VICTOR
+                      CORREA DE ALMEIDA6008CAMPINAS62070503***6304367C
+
         '400':
           description: Error
           content:
@@ -412,6 +463,93 @@ paths:
                     optional and is used only in the unattended integration
                     model.
       responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: number
+                    example: 2711382
+                    description: id
+                  qr:
+                    type: object
+                    properties:
+                      image:
+                        type: string
+                        example: >-
+                          https://www.mercadopago.com/instore/merchant/qr/2711382/0977011a027c4b4387e52069da4264deae2946af4dcc44ee98a8f1dbb376c8a1.png
+                        description: image
+                      template_document:
+                        type: string
+                        example: >-
+                          https://www.mercadopago.com/instore/merchant/qr/2711382/template_0977011a027c4b4387e52069da4264deae2946af4dcc44ee98a8f1dbb376c8a1.pdf
+                        description: template_document
+                      template_image:
+                        type: string
+                        example: >-
+                          https://www.mercadopago.com/instore/merchant/qr/2711382/template_0977011a027c4b4387e52069da4264deae2946af4dcc44ee98a8f1dbb376c8a1.png
+                        description: template_image
+                    description: qr
+                  status:
+                    type: string
+                    example: active
+                    description: status
+                  date_created:
+                    type: string
+                    example: '2019-08-22T14:11:12.000Z'
+                    description: date_created
+                  date_last_updated:
+                    type: string
+                    example: '2019-08-22T14:11:12.000Z'
+                    description: date_last_updated
+                  uuid:
+                    type: string
+                    example: 0977011a027c4b4387e52069da4264deae2946af4dcc44ee98a8f1dbb376c8a1
+                    description: uuid
+                  user_id:
+                    type: number
+                    example: 446566691
+                    description: user_id
+                  name:
+                    type: string
+                    example: Caja Principal
+                    description: name
+                  fixed_amount:
+                    type: boolean
+                    example: true
+                    description: fixed_amount
+                  category:
+                    type: number
+                    example: 621102
+                    description: category
+                  store_id:
+                    type: string
+                    example: 12345678
+                    description: store_id
+                  external_store_id:
+                    type: string
+                    example: BK021
+                    description: external_store_id
+                  url:
+                    type: string
+                    example: https://www.miempresa.com/MP?locationId=6232&positionId=01
+                    description: url
+                  external_id:
+                    type: string
+                    example: 4lph4num3r1c
+                    description: external_id
+                  site:
+                    type: string
+                    example: MLB
+                  qr_code:
+                    type: string
+                    example: >-
+                      00020101021226940014BR.GOV.BCB.PIX2572pix-qr-h.mercadopago.com/instore/h/p/v2/db12b6e2ec4844839825c6dce7cd2f2243530016com.mercadolibre0129https://mpago.la/pos/212798995204000053039865802BR5924VICTOR
+                      CORREA DE ALMEIDA6008CAMPINAS62070503***63040B44
+        
         '400':
           description: Error
           content:

--- a/reference/api/preferences.yaml
+++ b/reference/api/preferences.yaml
@@ -811,10 +811,7 @@ paths:
                         description:
                           type: string
                           example: >-
-                            Lorem ipsum dolor sit amet consectetur adipiscing
-                            elit. Sed ultricies est sed elit interdum quis
-                            consectetur libero mollis. Phasellus posuere sed
-                            eros vel volutpat.
+                            This is my description
                           description: description
                         category_id:
                           type: string

--- a/reference/api/preferences.yaml
+++ b/reference/api/preferences.yaml
@@ -1314,6 +1314,333 @@ paths:
                       type: number
                       description: Differential pricing ID.
       responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  additional_info:
+                    type: string
+                    example: null
+                    description: additional_info
+                  auto_return:
+                    type: string
+                    example: null
+                    description: auto_return
+                  back_urls:
+                    type: object
+                    properties:
+                      failure:
+                        type: string
+                        example: null
+                        description: failure
+                      pending:
+                        type: string
+                        example: null
+                        description: pending
+                      success:
+                        type: string
+                        example: null
+                        description: success
+                    description: back_urls
+                  binary_mode:
+                    type: boolean
+                    example: false
+                  client_id:
+                    type: string
+                    example: 6295877106812064
+                    description: client_id
+                  collector_id:
+                    type: number
+                    example: 202809963
+                    description: collector_id
+                  coupon_code:
+                    type: object
+                    properties: null
+                  coupon_labels:
+                    type: object
+                    properties: null
+                  date_created:
+                    type: string
+                    example: '2018-02-02T19:22:23.535Z'
+                    description: date_created
+                  date_of_expiration:
+                    type: object
+                    properties: null
+                  expiration_date_from:
+                    type: string
+                    properties: null
+                    format: nullable
+                    description: expiration_date_from
+                  expiration_date_to:
+                    type: string
+                    properties: null
+                    format: nullable
+                    description: expiration_date_to
+                  expires:
+                    type: boolean
+                    example: false
+                    description: expires
+                  external_reference:
+                    type: string
+                    example: null
+                    description: external_reference
+                  id:
+                    type: string
+                    example: 202809963-920c288b-4ebb-40be-966f-700250fa5370
+                    description: id
+                  init_point:
+                    type: string
+                    example: >-
+                      https://www.mercadopago.com/mla/checkout/start?pref_id=202809963-920c288b-4ebb-40be-966f-700250fa5370
+                    description: init_point
+                  internal_metadata:
+                    type: object
+                    properties: null
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          example: null
+                          description: id
+                        picture_url:
+                          type: string
+                          example: null
+                          description: picture_url
+                        title:
+                          type: string
+                          example: Dummy Item
+                          description: title
+                        description:
+                          type: string
+                          example: Multicolor Item
+                          description: description
+                        category_id:
+                          type: string
+                          example: null
+                          description: category_id
+                        currency_id:
+                          type: string
+                          example: $
+                          description: currency_id
+                        quantity:
+                          type: number
+                          example: 1
+                          description: quantity
+                        unit_price:
+                          type: number
+                          example: 10
+                          description: unit_price
+                    description: items
+                  marketplace:
+                    type: string
+                    example: MP-MKT-6295877106812064
+                    description: marketplace
+                  marketplace_fee:
+                    type: number
+                    example: 0
+                    description: marketplace_fee
+                  metadata:
+                    type: object
+                  notification_url:
+                    type: string
+                    example: https://url.com.br/notificacao
+                    format: nullable
+                    description: notification_url
+                  operation_type:
+                    type: string
+                    example: regular_payment
+                    description: operation_type
+                  payer:
+                    type: object
+                    properties:
+                      phone:
+                        type: object
+                        properties:
+                          area_code:
+                            type: string
+                            example: null
+                            description: area_code
+                          number:
+                            type: string
+                            example: null
+                            description: number
+                        description: phone
+                      address:
+                        type: object
+                        properties:
+                          zip_code:
+                            type: string
+                            example: null
+                            description: zip_code
+                          street_name:
+                            type: string
+                            example: null
+                            description: street_name
+                          street_number:
+                            type: string
+                            example: '7304'
+                            format: nullable
+                            description: street_number
+                        description: address
+                      email:
+                        type: string
+                        example: null
+                        description: email
+                      identification:
+                        type: object
+                        properties:
+                          number:
+                            type: string
+                            example: null
+                            description: number
+                          type:
+                            type: string
+                            example: null
+                            description: type
+                        description: identification
+                      name:
+                        type: string
+                        example: null
+                        description: name
+                      surname:
+                        type: string
+                        example: null
+                        description: surname
+                      date_created:
+                        type: string
+                        properties: null
+                        example: null
+                        description: date_created
+                      last_purchase:
+                        type: object
+                        properties: null
+                    description: payer
+                  payment_methods:
+                    type: object
+                    properties:
+                      default_card_id:
+                        type: object
+                        properties: null
+                      default_payment_method_id:
+                        type: string
+                        properties: null
+                        format: nullable
+                        description: default_payment_method_id
+                      excluded_payment_methods:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              example: ''
+                              description: id
+                        description: excluded_payment_methods
+                      excluded_payment_types:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              example: ''
+                              description: id
+                        description: excluded_payment_types
+                      installments:
+                        type: string
+                        properties: null
+                        format: nullable
+                        description: installments
+                      default_installments:
+                        type: string
+                        properties: null
+                        format: nullable
+                        description: default_installments
+                    description: payment_methods
+                  processing_modes:
+                    type: object
+                    properties: null
+                  product_id:
+                    type: object
+                    properties: null
+                  redirect_urls:
+                    type: object
+                    properties:
+                      failure:
+                        type: string
+                        example: ''
+                      pending:
+                        type: string
+                        example: ''
+                      success:
+                        type: string
+                        example: ''
+                  sandbox_init_point:
+                    type: string
+                    example: >-
+                      https://sandbox.mercadopago.com/mla/checkout/pay?pref_id=202809963-920c288b-4ebb-40be-966f-700250fa5370
+                    description: sandbox_init_point
+                  site_id:
+                    type: string
+                    example: MLB
+                  shipments:
+                    type: object
+                    properties:
+                      default_shipping_method:
+                        type: object
+                        properties: null
+                      receiver_address:
+                        type: object
+                        properties:
+                          zip_code:
+                            type: string
+                            example: null
+                            description: zip_code
+                          street_name:
+                            type: string
+                            example: null
+                            description: street_name
+                          street_number:
+                            type: string
+                            properties: null
+                            format: nullable
+                            description: street_number
+                          floor:
+                            type: string
+                            example: null
+                            description: floor
+                          apartment:
+                            type: string
+                            example: null
+                            description: apartment
+                          city_name:
+                            type: object
+                            properties: null
+                          state_name:
+                            type: object
+                            properties: null
+                          country_name:
+                            type: object
+                            properties: null
+                        description: receiver_address
+                    description: shipments
+                  total_amount:
+                    type: object
+                    properties: null
+                  last_updated:
+                    type: object
+                    properties: null
+                  statement_descriptor:
+                    type: string
+                    example: MERCADOPAGO
+                    description: statement_descriptor
+
         '400':
           description: Error
           content:

--- a/reference/api/preferences.yaml
+++ b/reference/api/preferences.yaml
@@ -310,11 +310,9 @@ paths:
                       properties:
                         id:
                           type: string
-                          example: null
                           description: id
                         picture_url:
                           type: string
-                          example: null
                           description: picture_url
                         title:
                           type: string
@@ -326,7 +324,6 @@ paths:
                           description: description
                         category_id:
                           type: string
-                          example: null
                           description: category_id
                         currency_id:
                           type: string
@@ -346,30 +343,24 @@ paths:
                     properties:
                       name:
                         type: string
-                        example: null
                         description: name
                       surname:
                         type: string
-                        example: null
                         description: surname
                       email:
                         type: string
-                        example: null
                         description: email
                       date_created:
                         type: string
-                        example: null
                         description: date_created
                       phone:
                         type: object
                         properties:
                           area_code:
                             type: string
-                            example: null
                             description: area_code
                           number:
                             type: string
-                            example: null
                             description: number
                         description: phone
                       identification:
@@ -377,11 +368,9 @@ paths:
                         properties:
                           type:
                             type: string
-                            example: null
                             description: type
                           number:
                             type: string
-                            example: null
                             description: number
                         description: identification
                       address:
@@ -389,7 +378,6 @@ paths:
                         properties:
                           street_name:
                             type: string
-                            example: null
                             description: street_name
                           street_number:
                             type: string
@@ -397,7 +385,6 @@ paths:
                             description: street_number
                           zip_code:
                             type: string
-                            example: null
                             description: zip_code
                         description: address
                     description: payer
@@ -406,20 +393,16 @@ paths:
                     properties:
                       success:
                         type: string
-                        example: null
                         description: success
                       pending:
                         type: string
-                        example: null
                         description: pending
                       failure:
                         type: string
-                        example: null
                         description: failure
                     description: back_urls
                   auto_return:
                     type: string
-                    example: null
                     description: auto_return
                   payment_methods:
                     type: object
@@ -431,7 +414,6 @@ paths:
                           properties:
                             id:
                               type: string
-                              example: null
                               description: id
                         description: excluded_payment_methods
                       excluded_payment_types:
@@ -441,7 +423,6 @@ paths:
                           properties:
                             id:
                               type: string
-                              example: null
                               description: id
                         description: excluded_payment_types
                       installments:
@@ -477,7 +458,6 @@ paths:
                         properties:
                           zip_code:
                             type: string
-                            example: null
                             description: zip_code
                           street_number:
                             type: string
@@ -485,15 +465,12 @@ paths:
                             description: street_number
                           street_name:
                             type: string
-                            example: null
                             description: street_name
                           floor:
                             type: string
-                            example: null
                             description: floor
                           apartment:
                             type: string
-                            example: null
                             description: apartment
                         description: receiver_address
                     description: shipments
@@ -507,11 +484,9 @@ paths:
                     description: statement_descriptor
                   external_reference:
                     type: string
-                    example: null
                     description: external_reference
                   additional_info:
                     type: string
-                    example: null
                     description: additional_info
                   expires:
                     type: boolean
@@ -653,7 +628,6 @@ paths:
                           description: expires
                         external_reference:
                           type: string
-                          example: null
                           description: external_reference
                         integrator_id:
                           type: string
@@ -682,11 +656,9 @@ paths:
                           description: operation_type
                         payer_email:
                           type: string
-                          example: null
                           description: payer_email
                         platform_id:
                           type: string
-                          example: null
                           description: platform_id
                         processing_modes:
                           type: string
@@ -694,11 +666,9 @@ paths:
                           description: processing_modes
                         product_id:
                           type: string
-                          example: null
                           description: product_id
                         purpose:
                           type: string
-                          example: null
                           description: purpose
                         site_id:
                           type: string
@@ -765,26 +735,21 @@ paths:
                 properties:
                   additional_info:
                     type: string
-                    example: null
                     description: additional_info
                   auto_return:
                     type: string
-                    example: null
                     description: auto_return
                   back_urls:
                     type: object
                     properties:
                       failure:
                         type: string
-                        example: null
                         description: failure
                       pending:
                         type: string
-                        example: null
                         description: pending
                       success:
                         type: string
-                        example: null
                         description: success
                     description: back_urls
                   client_id:
@@ -812,7 +777,6 @@ paths:
                     description: expires
                   external_reference:
                     type: string
-                    example: null
                     description: external_reference
                   id:
                     type: string
@@ -854,7 +818,6 @@ paths:
                           description: description
                         category_id:
                           type: string
-                          example: null
                           description: category_id
                         quantity:
                           type: number
@@ -893,7 +856,6 @@ paths:
                         properties:
                           area_code:
                             type: string
-                            example: null
                             description: area_code
                           number:
                             type: string
@@ -918,7 +880,6 @@ paths:
                         description: address
                       email:
                         type: string
-                        example: null
                         description: email
                       identification:
                         type: object
@@ -934,15 +895,12 @@ paths:
                         description: identification
                       name:
                         type: string
-                        example: null
                         description: name
                       surname:
                         type: string
-                        example: null
                         description: surname
                       date_created:
                         type: string
-                        example: null
                         description: date_created
                     description: payer
                   payment_methods:
@@ -955,7 +913,6 @@ paths:
                           properties:
                             id:
                               type: string
-                              example: null
                               description: id
                         description: excluded_payment_methods
                       default_installments:
@@ -973,7 +930,6 @@ paths:
                           properties:
                             id:
                               type: string
-                              example: null
                               description: id
                         description: excluded_payment_types
                       installments:
@@ -994,19 +950,15 @@ paths:
                         properties:
                           floor:
                             type: string
-                            example: null
                             description: floor
                           zip_code:
                             type: string
-                            example: null
                             description: zip_code
                           street_name:
                             type: string
-                            example: null
                             description: street_name
                           apartment:
                             type: string
-                            example: null
                             description: apartment
                           street_number:
                             type: string
@@ -1323,26 +1275,21 @@ paths:
                 properties:
                   additional_info:
                     type: string
-                    example: null
                     description: additional_info
                   auto_return:
                     type: string
-                    example: null
                     description: auto_return
                   back_urls:
                     type: object
                     properties:
                       failure:
                         type: string
-                        example: null
                         description: failure
                       pending:
                         type: string
-                        example: null
                         description: pending
                       success:
                         type: string
-                        example: null
                         description: success
                     description: back_urls
                   binary_mode:
@@ -1358,25 +1305,20 @@ paths:
                     description: collector_id
                   coupon_code:
                     type: object
-                    properties: null
                   coupon_labels:
                     type: object
-                    properties: null
                   date_created:
                     type: string
                     example: '2018-02-02T19:22:23.535Z'
                     description: date_created
                   date_of_expiration:
                     type: object
-                    properties: null
                   expiration_date_from:
                     type: string
-                    properties: null
                     format: nullable
                     description: expiration_date_from
                   expiration_date_to:
                     type: string
-                    properties: null
                     format: nullable
                     description: expiration_date_to
                   expires:
@@ -1385,7 +1327,6 @@ paths:
                     description: expires
                   external_reference:
                     type: string
-                    example: null
                     description: external_reference
                   id:
                     type: string
@@ -1398,7 +1339,6 @@ paths:
                     description: init_point
                   internal_metadata:
                     type: object
-                    properties: null
                   items:
                     type: array
                     items:
@@ -1406,11 +1346,9 @@ paths:
                       properties:
                         id:
                           type: string
-                          example: null
                           description: id
                         picture_url:
                           type: string
-                          example: null
                           description: picture_url
                         title:
                           type: string
@@ -1422,7 +1360,6 @@ paths:
                           description: description
                         category_id:
                           type: string
-                          example: null
                           description: category_id
                         currency_id:
                           type: string
@@ -1464,11 +1401,9 @@ paths:
                         properties:
                           area_code:
                             type: string
-                            example: null
                             description: area_code
                           number:
                             type: string
-                            example: null
                             description: number
                         description: phone
                       address:
@@ -1476,11 +1411,10 @@ paths:
                         properties:
                           zip_code:
                             type: string
-                            example: null
                             description: zip_code
                           street_name:
                             type: string
-                            example: null
+                            example: Mc Street
                             description: street_name
                           street_number:
                             type: string
@@ -1490,46 +1424,36 @@ paths:
                         description: address
                       email:
                         type: string
-                        example: null
                         description: email
                       identification:
                         type: object
                         properties:
                           number:
                             type: string
-                            example: null
                             description: number
                           type:
                             type: string
-                            example: null
                             description: type
                         description: identification
                       name:
                         type: string
-                        example: null
                         description: name
                       surname:
                         type: string
-                        example: null
                         description: surname
                       date_created:
                         type: string
-                        properties: null
-                        example: null
                         description: date_created
                       last_purchase:
                         type: object
-                        properties: null
                     description: payer
                   payment_methods:
                     type: object
                     properties:
                       default_card_id:
                         type: object
-                        properties: null
                       default_payment_method_id:
                         type: string
-                        properties: null
                         format: nullable
                         description: default_payment_method_id
                       excluded_payment_methods:
@@ -1554,21 +1478,17 @@ paths:
                         description: excluded_payment_types
                       installments:
                         type: string
-                        properties: null
                         format: nullable
                         description: installments
                       default_installments:
                         type: string
-                        properties: null
                         format: nullable
                         description: default_installments
                     description: payment_methods
                   processing_modes:
                     type: object
-                    properties: null
                   product_id:
                     type: object
-                    properties: null
                   redirect_urls:
                     type: object
                     properties:
@@ -1594,53 +1514,41 @@ paths:
                     properties:
                       default_shipping_method:
                         type: object
-                        properties: null
                       receiver_address:
                         type: object
                         properties:
                           zip_code:
                             type: string
-                            example: null
                             description: zip_code
                           street_name:
                             type: string
-                            example: null
                             description: street_name
                           street_number:
                             type: string
-                            properties: null
                             format: nullable
                             description: street_number
                           floor:
                             type: string
-                            example: null
                             description: floor
                           apartment:
                             type: string
-                            example: null
                             description: apartment
                           city_name:
                             type: object
-                            properties: null
                           state_name:
                             type: object
-                            properties: null
                           country_name:
                             type: object
-                            properties: null
                         description: receiver_address
                     description: shipments
                   total_amount:
                     type: object
-                    properties: null
                   last_updated:
                     type: object
-                    properties: null
                   statement_descriptor:
                     type: string
                     example: MERCADOPAGO
                     description: statement_descriptor
-
         '400':
           description: Error
           content:

--- a/reference/api/stores.yaml
+++ b/reference/api/stores.yaml
@@ -509,6 +509,70 @@ paths:
                       type: string
                       description: Reference.
       responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    example: 1234567
+                    description: id
+                  name:
+                    type: string
+                    example: Sucursal Instore
+                    description: name
+                  date_creation:
+                    type: string
+                    example: '2021-03-16T20:27:26.732Z'
+                  business_hours:
+                    type: object
+                    properties:
+                      monday:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            open:
+                              type: string
+                              example: '08:00'
+                              description: open
+                            close:
+                              type: string
+                              example: '12:00'
+                              description: close
+                        description: monday
+                    description: business_hours
+                  location:
+                    type: object
+                    properties:
+                      address_line:
+                        type: string
+                        example: Caseros 3039 Belgrano Capital Federal
+                        description: address_line
+                      latitude:
+                        type: number
+                        example: -32.8897322
+                        description: latitude
+                      longitude:
+                        type: number
+                        example: -68.8443275
+                        description: longitude
+                      reference:
+                        type: string
+                        example: 3er Piso
+                        description: reference
+                    description: location
+                  external_id:
+                    type: string
+                    example: 1234
+                    description: external_id
+                  date_created:
+                    type: string
+                    example: '2019-08-08T19:29:45.019Z'
+                    description: date_created
         '400':
           description: Error
           content:
@@ -556,6 +620,19 @@ paths:
             type: string
             example: 12123adfasdf123u4u
       responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  store:
+                    type: number
+                    example: 30148503
+                  user:
+                    type: number
+                    example: 329653108
         '400':
           description: Error
           content:


### PR DESCRIPTION
Foram adicionadas registros de respostas (principalmente exemplos) para as seguines API's:

- Cards
- Customers
- Instore Orders V2
- Merchant Orders
- Payment Methods
- POS
- Preferences
- Stores

Agora somente algumas API's que de fato não possuem dados em suas respostas ficarão vazias (exemplo: DELETE de Orders).