### PR TITLE
Add client_api in marketplace credentials

### DIFF
--- a/guides/online-payments/marketplace/checkout-api/create-marketplace.en.md
+++ b/guides/online-payments/marketplace/checkout-api/create-marketplace.en.md
@@ -58,6 +58,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret=ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=authorization_code' \
      -d 'code=AUTHORIZATION_CODE' \
      -d 'redirect_uri=REDIRECT_URI'
@@ -66,6 +67,7 @@ curl -X POST \
 The parameters you need to include are:
 
 * `client_secret`: Your `ACCESS_TOKEN`. You can get it from the detail of your [application.]([FAKER][CREDENTIALS][URL])
+* `client_id`: Your `ACCESS_TOKEN`. It is the APP ID of the application that was created.
 * `code`: The authorization code you got when redirecting the user back to your site.
 * `redirect_uri`: It must be the same Redirect URI that you set up in your application.
 
@@ -106,6 +108,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret= ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=refresh_token' \
      -d 'refresh_token=USER_RT'
 ```

--- a/guides/online-payments/marketplace/checkout-api/create-marketplace.es.md
+++ b/guides/online-payments/marketplace/checkout-api/create-marketplace.es.md
@@ -60,6 +60,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret=ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=authorization_code' \
      -d 'code=AUTHORIZATION_CODE' \
      -d 'redirect_uri=REDIRECT_URI'
@@ -68,6 +69,7 @@ curl -X POST \
 Los parámetros que debes incluir son:
 
 * `client_secret`: Tu `ACCESS_TOKEN`. Puedes obtenerlo desde el detalle de tu [aplicación.]([FAKER][CREDENTIALS][URL])
+* `client_id`: Tu `ACCESS_TOKEN`. Es el APP ID de la aplicación que se creó.
 * `code`: El código de autorización que obtuviste al redirigir al usuario de vuelta a tu sitio.
 * `redirect_uri`: Debe ser la misma Redirect URI que configuraste en tu aplicación.
 
@@ -109,6 +111,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret= ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=refresh_token' \
      -d 'refresh_token=USER_RT'
 ```

--- a/guides/online-payments/marketplace/checkout-api/create-marketplace.pt.md
+++ b/guides/online-payments/marketplace/checkout-api/create-marketplace.pt.md
@@ -59,6 +59,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret=ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=authorization_code' \
      -d 'code=AUTHORIZATION_CODE' \
      -d 'redirect_uri=REDIRECT_URI'
@@ -67,6 +68,7 @@ curl -X POST \
 Os parâmetros que você deve incluir são:
 
 * `client_secret`: seu `ACCESS_TOKEN`. Pode obter apartir das configurações da sua [aplicação.]([FAKER][CREDENTIALS][URL])
+* `client_id`: seu `APP_ID`. é o APP ID do aplicativo que foi criado.
 * `code`: o código de autorização obtido ao redirecionar o usuário de volta para o seu site.
 * `redirect_uri`: deve ser a mesma Redirect URI que você configurou na sua aplicação.
 
@@ -110,6 +112,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret= ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=refresh_token' \
      -d 'refresh_token=USER_RT'
 ```

--- a/guides/online-payments/marketplace/checkout-pro/create-marketplace.en.md
+++ b/guides/online-payments/marketplace/checkout-pro/create-marketplace.en.md
@@ -59,6 +59,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret=ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=authorization_code' \
      -d 'code=AUTHORIZATION_CODE' \
      -d 'redirect_uri=REDIRECT_URI'
@@ -66,6 +67,7 @@ curl -X POST \
 The parameters you need to include are:
 
 * `client_secret`: Your `ACCESS_TOKEN`. You can get it from the detail of your [application]([FAKER][CREDENTIALS][URL]).
+* `client_id`: Your `APP_ID`. It is the APP ID of the application that was created.
 * `code`: The authorization code you got when redirecting the user back to your site.
 * `redirect_uri`: It must be the same Redirect URI that you set up in your application.
 
@@ -104,6 +106,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret= ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=refresh_token' \
      -d 'refresh_token=USER_RT'
 ```

--- a/guides/online-payments/marketplace/checkout-pro/create-marketplace.es.md
+++ b/guides/online-payments/marketplace/checkout-pro/create-marketplace.es.md
@@ -60,6 +60,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret=ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=authorization_code' \
      -d 'code=AUTHORIZATION_CODE' \
      -d 'redirect_uri=REDIRECT_URI'
@@ -68,6 +69,7 @@ curl -X POST \
 Los parámetros que debes incluir son:
 
 * `client_secret`: Tu `ACCESS_TOKEN`. Puedes obtenerlo desde el detalle de tu [aplicación]([FAKER][CREDENTIALS][URL]).
+* `client_id`: Tu `ACCESS_TOKEN`. Es el APP ID de la aplicación que se creó.
 * `code`: El código de autorización que obtuviste al redirigir al usuario de vuelta a tu sitio.
 * `redirect_uri`: Debe ser la misma _Redirect URI_ que configuraste en tu aplicación.
 
@@ -107,6 +109,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret= ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=refresh_token' \
      -d 'refresh_token=USER_RT'
 ```

--- a/guides/online-payments/marketplace/checkout-pro/create-marketplace.pt.md
+++ b/guides/online-payments/marketplace/checkout-pro/create-marketplace.pt.md
@@ -60,6 +60,7 @@ curl -X POST \
      -H 'content-type: application/x-www-form-urlencoded' \
      'https://api.mercadopago.com/oauth/token' \
      -d 'client_secret=ACCESS_TOKEN' \
+     -d 'client_id=APP_ID' \
      -d 'grant_type=authorization_code' \
      -d 'code=AUTHORIZATION_CODE' \
      -d 'redirect_uri=REDIRECT_URI'
@@ -67,6 +68,7 @@ curl -X POST \
 Os parâmetros que você deve incluir são:
 
 * `client_secret`: seu `ACCESS_TOKEN`. Pode obter apartir das configurações da sua [aplicação]([FAKER][CREDENTIALS][URL]).
+* `client_id`: seu `APP_ID`. é o APP ID do aplicativo que foi criado.
 * `code`: O código de autorização obtido ao redirecionar o usuário de volta para o seu site.
 * `redirect_uri`: Deve ser a mesmo Redirect URI que você configurou na sua aplicação.
 


### PR DESCRIPTION
## Description
Usando la documentación actual, la request responde:

> {
  "message": "the following parameters are required: grant_type, client_id, client_secret. Missing parameters: client_id",
  "error": "invalid_request",
  "status": 400,
  "cause": []
}

Por esta razón se agrega en la documentación  el campo 'client_api '.

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [x] This request modifies code snippets. 
- [x] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
