### PR TITLE
fix/oracionesduplicadas

### DIFF
--- a/guides/notifications/ipn.pt.md
+++ b/guides/notifications/ipn.pt.md
@@ -119,8 +119,6 @@ Dentro da ordem, no objeto payments, você vai encontrar todos os pagamentos del
 
 ## Pesquisa da ordem
 
-**Si estas integrando pagos presenciales**, se debe implementar como método de contingencia, la  **búsqueda de la orden** utilizando el `external_reference` de la misma como criterio de búsqueda.
-
 **Se você estiver integrando pagamentos presenciais**, é necessário aplicar como método de contingência a **pesquisa da ordem** utilizando o seu `external_reference` como critério de pesquisa.
 
 ```curl


### PR DESCRIPTION
## Description
Se encontraba duplicada la oración referida a buscar una orden, entonces la elimine. Solo pasaba en idioma portugues y la oracion repetida estaba en español.

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [X] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
