### PR TITLE
docs(wallet button): explain new feature wallet button for woocommerce

### DIFF
--- a/guides/plugins/woocommerce/introduction.en.md
+++ b/guides/plugins/woocommerce/introduction.en.md
@@ -20,6 +20,7 @@ Install the payment processor in WooCommerce and take your sales to another leve
 | Payment cancellations | Cancel the pending payments directly from the platform |
 | Binary mode | Approve or reject payments instantly and automatically. |
 | Currency conversion | No more compatibility issues. Convert the currency you use in WooCommerce to the currency of your Mercado Pago account. |
+| Payment with card stored in Mercado Pago  | Payment with card stored in Mercado Pago function, for Mercado Pago customers to buy without having to fill in card data at the store's checkout. |
 
 >**Are you a developer?**
 >This guide is also designed to speed up the installation, integration and configuration of our module in the most recognized e-commerce platforms worldwide.

--- a/guides/plugins/woocommerce/introduction.en.md
+++ b/guides/plugins/woocommerce/introduction.en.md
@@ -20,7 +20,7 @@ Install the payment processor in WooCommerce and take your sales to another leve
 | Payment cancellations | Cancel the pending payments directly from the platform |
 | Binary mode | Approve or reject payments instantly and automatically. |
 | Currency conversion | No more compatibility issues. Convert the currency you use in WooCommerce to the currency of your Mercado Pago account. |
-| Payment with card stored in Mercado Pago  | Payment with card stored in Mercado Pago function, for Mercado Pago customers to buy without having to fill in card data at the store's checkout. |
+| Payment with card stored in Mercado Pago  | Allows customers to use their card data saved in Mercado Pago without having to fill in card data at the store's checkout. |
 
 >**Are you a developer?**
 >This guide is also designed to speed up the installation, integration and configuration of our module in the most recognized e-commerce platforms worldwide.

--- a/guides/plugins/woocommerce/introduction.es.md
+++ b/guides/plugins/woocommerce/introduction.es.md
@@ -20,7 +20,7 @@ Instala el procesador de pagos en WooCommerce y lleva tus ventas a otro nivel co
 | Cancelación de pagos | Cancela los pagos pendientes desde la plataforma. |
 | Modo binario | Aprueba o rechaza pagos al instante y de forma automática. |
 | Conversión de moneda | No más problemas de compatibilidad. Convierte la moneda que usas en WooCommerce a la moneda de tu cuenta de Mercado Pago.|
-| Pago con tarjetas guardadas en Mercado Pago | Función de Pago con tarjeta guardada en Mercado Pago, para que los clientes de Mercado Pago puedan comprar sin tener que rellenar los datos de tarjeta en el checkout de la tienda. |
+| Pago con tarjetas guardadas en Mercado Pago | Permite que los clientes puedan comprar con los datos guardados de su tarjeta en Mercado Pago, sin tener que rellenar los datos en el checkout de la tienda. |
 
 >**¿Eres desarrollador?**
 >Esta guía también está pensada para que hagas más rápido tu trabajo de instalación, integración y configuración de nuestro módulo en las plataformas de e-commerce más reconocidas a nivel mundial. 

--- a/guides/plugins/woocommerce/introduction.es.md
+++ b/guides/plugins/woocommerce/introduction.es.md
@@ -20,6 +20,7 @@ Instala el procesador de pagos en WooCommerce y lleva tus ventas a otro nivel co
 | Cancelación de pagos | Cancela los pagos pendientes desde la plataforma. |
 | Modo binario | Aprueba o rechaza pagos al instante y de forma automática. |
 | Conversión de moneda | No más problemas de compatibilidad. Convierte la moneda que usas en WooCommerce a la moneda de tu cuenta de Mercado Pago.|
+| Pago con tarjetas guardadas en Mercado Pago | Función de Pago con tarjeta guardada en Mercado Pago, para que los clientes de Mercado Pago puedan comprar sin tener que rellenar los datos de tarjeta en el checkout de la tienda. |
 
 >**¿Eres desarrollador?**
 >Esta guía también está pensada para que hagas más rápido tu trabajo de instalación, integración y configuración de nuestro módulo en las plataformas de e-commerce más reconocidas a nivel mundial. 

--- a/guides/plugins/woocommerce/introduction.pt.md
+++ b/guides/plugins/woocommerce/introduction.pt.md
@@ -20,7 +20,7 @@ Instale nosso gateway de pagamento no WooCommerce e leve suas vendas para outro 
 | Cancelamento de pagamentos | Cancele pagamentos pendentes pela plataforma. |
 | Modo binário | Aprovar ou rejeitar pagamentos instantaneamente. |
 | Conversão de moeda | Não há mais problemas de compatibilidade. Faça a conversão da moeda que você usa no WooCommerce para a moeda da sua conta do Mercado Pago.|
-| Pagamento com cartões salvos no Mercado Pago  | Função Pagamento com cartão salvo no Mercado Pago, para clientes do Mercado Pago comprarem sem precisar preencher dados de cartão no checkout da loja. |
+| Pagamento com cartões salvos no Mercado Pago  | Função Pagamento com cartão salvo no Mercado Pago, para clientes do Mercado Pago comprarem sem precisar preencher dados do cartão no checkout da loja. |
 
 >**Você é desenvolvedor?**
 >Este manual também foi pensado para que você faça a instalação, integração e configuração mais rapidamente. Você não vai precisar escrever uma linha de códigos sequer para instalá-lo nas lojas dos seus clientes. 

--- a/guides/plugins/woocommerce/introduction.pt.md
+++ b/guides/plugins/woocommerce/introduction.pt.md
@@ -20,7 +20,7 @@ Instale nosso gateway de pagamento no WooCommerce e leve suas vendas para outro 
 | Cancelamento de pagamentos | Cancele pagamentos pendentes pela plataforma. |
 | Modo binário | Aprovar ou rejeitar pagamentos instantaneamente. |
 | Conversão de moeda | Não há mais problemas de compatibilidade. Faça a conversão da moeda que você usa no WooCommerce para a moeda da sua conta do Mercado Pago.|
-| Pagamento com cartões salvos no Mercado Pago  | Função Pagamento com cartão salvo no Mercado Pago, para clientes do Mercado Pago comprarem sem precisar preencher dados do cartão no checkout da loja. |
+| Pagamento com cartões salvos no Mercado Pago  | Permite que os clientes comprem com os dados do cartão guardados no Mercado Pago, sem precisar preencher dados do cartão no checkout da loja. |
 
 >**Você é desenvolvedor?**
 >Este manual também foi pensado para que você faça a instalação, integração e configuração mais rapidamente. Você não vai precisar escrever uma linha de códigos sequer para instalá-lo nas lojas dos seus clientes. 

--- a/guides/plugins/woocommerce/introduction.pt.md
+++ b/guides/plugins/woocommerce/introduction.pt.md
@@ -20,6 +20,7 @@ Instale nosso gateway de pagamento no WooCommerce e leve suas vendas para outro 
 | Cancelamento de pagamentos | Cancele pagamentos pendentes pela plataforma. |
 | Modo binário | Aprovar ou rejeitar pagamentos instantaneamente. |
 | Conversão de moeda | Não há mais problemas de compatibilidade. Faça a conversão da moeda que você usa no WooCommerce para a moeda da sua conta do Mercado Pago.|
+| Pagamento com cartões salvos no Mercado Pago  | Função Pagamento com cartão salvo no Mercado Pago, para clientes do Mercado Pago comprarem sem precisar preencher dados de cartão no checkout da loja. |
 
 >**Você é desenvolvedor?**
 >Este manual também foi pensado para que você faça a instalação, integração e configuração mais rapidamente. Você não vai precisar escrever uma linha de códigos sequer para instalá-lo nas lojas dos seus clientes. 

--- a/guides/plugins/woocommerce/preferences.en.md
+++ b/guides/plugins/woocommerce/preferences.en.md
@@ -101,7 +101,7 @@ Choose what shopping experience your customers will have when paying:
 | Configuration | Description |
 | --- | --- |
 | Discount coupon | Activate this option when you want to offer discounts to your customers. A field will appear on the form where they can enter their coupon. |
-| Payment with stored cards | Payment with card stored in Mercado Pago function, for Mercado Pago customers to buy without having to fill in card data at the store's checkout. |
+| Payment with stored cards | Allows customers to use their card data saved in Mercado Pago without having to fill in card data at the store's checkout. |
 
 #### Pay with cash
 

--- a/guides/plugins/woocommerce/preferences.en.md
+++ b/guides/plugins/woocommerce/preferences.en.md
@@ -101,6 +101,7 @@ Choose what shopping experience your customers will have when paying:
 | Configuration | Description |
 | --- | --- |
 | Discount coupon | Activate this option when you want to offer discounts to your customers. A field will appear on the form where they can enter their coupon. |
+| Payment with stored cards | Payment with card stored in Mercado Pago function, for Mercado Pago customers to buy without having to fill in card data at the store's checkout. |
 
 #### Pay with cash
 

--- a/guides/plugins/woocommerce/preferences.es.md
+++ b/guides/plugins/woocommerce/preferences.es.md
@@ -103,6 +103,7 @@ Elige qué experiencia de compra tendrán tus clientes a la hora de pagar:
 | Configuración | Descripción |
 | --- | --- |
 | Cupon de descuento | Activa esta opción cuando quieras ofrecer descuentos a tus clientes. Aparecerá un campo en el formulario donde podrán ingresar su cupón. |
+| Pago con tarjetas guardadas | Función de Pago con tarjeta guardada en Mercado Pago, para que los clientes de Mercado Pago puedan comprar sin tener que rellenar los datos de tarjeta en el checkout de la tienda. |
 
 #### Pagos presenciales
 

--- a/guides/plugins/woocommerce/preferences.es.md
+++ b/guides/plugins/woocommerce/preferences.es.md
@@ -103,7 +103,7 @@ Elige qué experiencia de compra tendrán tus clientes a la hora de pagar:
 | Configuración | Descripción |
 | --- | --- |
 | Cupon de descuento | Activa esta opción cuando quieras ofrecer descuentos a tus clientes. Aparecerá un campo en el formulario donde podrán ingresar su cupón. |
-| Pago con tarjetas guardadas | Función de Pago con tarjeta guardada en Mercado Pago, para que los clientes de Mercado Pago puedan comprar sin tener que rellenar los datos de tarjeta en el checkout de la tienda. |
+| Pago con tarjetas guardadas | Permite que los clientes puedan comprar con los datos guardados de su tarjeta en Mercado Pago, sin tener que rellenar los datos en el checkout de la tienda. |
 
 #### Pagos presenciales
 

--- a/guides/plugins/woocommerce/preferences.pt.md
+++ b/guides/plugins/woocommerce/preferences.pt.md
@@ -101,7 +101,7 @@ Escolha qual experiência de compra seus clientes terão na hora de pagar:
 | Configuração | Descrição |
 | --- | --- |
 | Cupons de desconto | Ative esta opção quando quiser oferecer descontos aos seus clientes. Aparecerá um campo no formulário onde poderão inserir seu cupom. |
-| Pagamento com cartões salvos | Função Pagamento com cartão salvo no Mercado Pago, para clientes do Mercado Pago comprarem sem precisar preencher dados do cartão no checkout da loja |
+| Pagamento com cartões salvos | Permite que os clientes comprem com os dados do cartão guardados no Mercado Pago, sem precisar preencher dados do cartão no checkout da loja. |
 
 #### Pagamentos presenciais
 

--- a/guides/plugins/woocommerce/preferences.pt.md
+++ b/guides/plugins/woocommerce/preferences.pt.md
@@ -101,7 +101,7 @@ Escolha qual experiência de compra seus clientes terão na hora de pagar:
 | Configuração | Descrição |
 | --- | --- |
 | Cupons de desconto | Ative esta opção quando quiser oferecer descontos aos seus clientes. Aparecerá um campo no formulário onde poderão inserir seu cupom. |
-| Pagamento com cartões salvos | Função Pagamento com cartão salvo no Mercado Pago, para clientes do Mercado Pago comprarem sem precisar preencher dados de cartão no checkout da loja |
+| Pagamento com cartões salvos | Função Pagamento com cartão salvo no Mercado Pago, para clientes do Mercado Pago comprarem sem precisar preencher dados do cartão no checkout da loja |
 
 #### Pagamentos presenciais
 

--- a/guides/plugins/woocommerce/preferences.pt.md
+++ b/guides/plugins/woocommerce/preferences.pt.md
@@ -101,6 +101,7 @@ Escolha qual experiência de compra seus clientes terão na hora de pagar:
 | Configuração | Descrição |
 | --- | --- |
 | Cupons de desconto | Ative esta opção quando quiser oferecer descontos aos seus clientes. Aparecerá um campo no formulário onde poderão inserir seu cupom. |
+| Pagamento com cartões salvos | Função Pagamento com cartão salvo no Mercado Pago, para clientes do Mercado Pago comprarem sem precisar preencher dados de cartão no checkout da loja |
 
 #### Pagamentos presenciais
 


### PR DESCRIPTION
## Description
New feature for WooCommerce, the buyer can use blue money with Wallet Button

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [x] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
