### PR TITLE
financial_institution should be string in Node JS

### DIFF
--- a/guides/online-payments/checkout-api/other-payment-ways.es.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.es.md
@@ -2678,7 +2678,7 @@ email: 'test_user_15748052@testuser.com',
 entity_type: "individual"
 },
 transaction_details: {
-financial_institution: 1234
+financial_institution: "1234"
 },
 additional_info: {
 ip_address: "127.0.0.1"


### PR DESCRIPTION
Si financial_institution no esta como String arroja el siguiente mensaje de error:
Error: The next fields are failing on validation: ".transaction_details.financial_institution": should be string.
  at Object.requestManager.buildRequest

## Description
In few word, describe what’s your Pull Request about.

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #<issue>

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
