### PR TITLE
Feature/Servipag and Khipu deprecation

### DIFF
--- a/guides/resources/localization/payment-methods.en.md
+++ b/guides/resources/localization/payment-methods.en.md
@@ -154,8 +154,6 @@ The payment methods available for each country are shown below.
 | Visa Debit | `debit_card` | `debvisa` |
 | Mastercard Debit | `debit_card` | `debmaster` |
 | Redcompra | `debit_card` | `redcompra` |
-| Servipag | `ticket` | `servipag` |
-| Khipu | `bank_transfer` | `khipu` |
 | Account money | `account_money` | `account_money` |
 
 ### Colombia

--- a/guides/resources/localization/payment-methods.es.md
+++ b/guides/resources/localization/payment-methods.es.md
@@ -154,8 +154,6 @@ A continuación se indican los medios de pago disponibles para cada país.
 | Visa Débito | `debit_card` | `debvisa` |
 | Mastercard Débito | `debit_card` | `debmaster` |
 | Redcompra | `debit_card` | `redcompra` |
-| Servipag | `ticket` | `servipag` |
-| Khipu | `bank_transfer` | `khipu` |
 | Dinero en cuenta | `account_money` | `account_money` |
 
 ### Colombia

--- a/guides/resources/localization/payment-methods.pt.md
+++ b/guides/resources/localization/payment-methods.pt.md
@@ -137,8 +137,6 @@ A seguir estão os meios de pagamento disponíveis para cada país.
 | Visa Débito | `debit_card` | `debvisa` |
 | Mastercard Débito | `debit_card` | `debmaster` |
 | Redcompra | `debit_card` | `redcompra` |
-| Servipag | `ticket` | `servipag` |
-| Khipu | `bank_transfer` | `khipu` |
 | Dinheiro em conta | `account_money` | `account_money` |
 
 ### Colômbia

--- a/guides/resources/localization/products.en.md
+++ b/guides/resources/localization/products.en.md
@@ -81,10 +81,10 @@ Subscriptions | Checkout API | `naranja`, `nativa`, `shopping`, `debvisa`, `debm
 | :--- | :--- | :--- |
 | Payments | Payment link | N/A |
 | Payments | Checkout Pro | N/A |
-| Payments | Mobile Checkout | `account_money`,`khipu`,`servipag`|
-| Payments | Checkout API | `khipu` |
+| Payments | Mobile Checkout | `account_money`|
+| Payments | Checkout API | N/A |
 | Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout API | `khipu` |
+| Marketplace | Checkout API | N/A|
 
 
 ### Colombia

--- a/guides/resources/localization/products.es.md
+++ b/guides/resources/localization/products.es.md
@@ -139,20 +139,20 @@ Suscripciones | Checkout API | `naranja`, `nativa`, `shopping`, `debvisa`, `debm
 | :--- | :--- | :--- |
 | Pagos | Link de pago | N/A |
 | Pagos | Checkout Pro | N/A |
-| Pagos | Mobile Checkout | `account_money`,`khipu`,`servipag` |
-| Pagos | Checkout Transparente | `khipu` |
+| Pagos | Mobile Checkout | `account_money` |
+| Pagos | Checkout Transparente | N/A |
 | Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout Transparente | `khipu` |
+| Marketplace | Checkout Transparente | N/A |
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
 | Producto | Solución | Medios de pago no disponibles |
 | :--- | :--- | :--- |
 | Pagos | Link de pago | N/A |
 | Pagos | Checkout Pro | N/A |
-| Pagos | Mobile Checkout | `account_money`,`khipu`,`servipag` |
-| Pagos | Checkout API | `khipu` |
+| Pagos | Mobile Checkout | `account_money` |
+| Pagos | Checkout API | N/A |
 | Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout API | `khipu` |
+| Marketplace | Checkout API | N/A |
 ------------
 
 ### Colombia

--- a/guides/resources/localization/products.pt.md
+++ b/guides/resources/localization/products.pt.md
@@ -139,20 +139,20 @@ Assinaturas | Checkout API | `naranja`, `nativa`, `shopping`, `debvisa`, `debmas
 | :--- | :--- | :--- |
 | Pagamentos | Link de pagamento | N/A |
 | Pagamentos | Checkout Pro | N/A |
-| Pagamentos | Mobile Checkout | `account_money`,`khipu`,`servipag` |
-| Pagamentos | Checkout Transparente | `khipu` |
+| Pagamentos | Mobile Checkout | `account_money` |
+| Pagamentos | Checkout Transparente | N/A|
 | Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout Transparente | `khipu` |
+| Marketplace | Checkout Transparente | N/A |
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
 | Produto | Solução | Meios de pagamento não disponíveis |
 | :--- | :--- | :--- |
 | Pagamentos | Link de pagamento | N/A |
 | Pagamentos | Checkout Pro | N/A |
-| Pagamentos | Mobile Checkout | `account_money`,`khipu`,`servipag` |
-| Pagamentos | Checkout API | `khipu` |
+| Pagamentos | Mobile Checkout | `account_money`|
+| Pagamentos | Checkout API | N/A|
 | Marketplace | Checkout Pro | N/A |
-| Marketplace | Checkout API | `khipu` |
+| Marketplace | Checkout API | N/A |
 ------------
 
 


### PR DESCRIPTION
## Description

Khipu and Servipag are solutions no longer available for Mercado Pago integration, so, it was necessary to remove them from our existing documentation.
