### PR TITLE
Checkout API - Customers & Cards - Se modifica email payer de ejemplo

### DIFF
--- a/guides/online-payments/checkout-api/advanced-integration.en.md
+++ b/guides/online-payments/checkout-api/advanced-integration.en.md
@@ -17,7 +17,7 @@ You will add every customer using the `customer` value, and cards as `card`.
   MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
 
   $customer = new MercadoPago\Customer();
-  $customer->email = "test@test.com";
+  $customer->email = "test_payer_12345@testuser.com";
   $customer->save();
 
   $card = new MercadoPago\Card();
@@ -37,7 +37,7 @@ mercadopago.configure({
     access_token: 'ENV_ACCESS_TOKEN'
 });
 
-var customer_data = { "email": "test@test.com" }
+var customer_data = { "email": "test_payer_12345@testuser.com" }
 
 mercadopago.customers.create(customer_data).then(function (customer) {
 
@@ -102,7 +102,7 @@ MercadoPagoConfig.AccessToken = "ENV_ACCESS_TOKEN";
 
 var customerRequest = new CustomerRequest
 {
-    Email = "test@test.com",
+    Email = "test_payer_12345@testuser.com",
 };
 var customerClient = new CustomerClient();
 Customer customer = await customerClient.CreateAsync(customerRequest);
@@ -120,7 +120,7 @@ import mercadopago
 sdk = mercadopago.SDK("ENV_ACCESS_TOKEN")
 
 customer_data = {
-  "email": "test@test.com"
+  "email": "test_payer_12345@testuser.com"
 }
 customer_response = sdk.customer().create(customer_data)
 customer = customer_response["response"]
@@ -150,7 +150,7 @@ curl -X POST \
 ```json
 {
     "id": "123456789-jxOV430go9fx2e",
-    "email": "test@test.com",
+    "email": "test_payer_12345@testuser.com",
     ...
     "default_card": "1490022319978",
     "default_address": null,
@@ -178,7 +178,8 @@ curl -X POST \
 > 
 > Important
 > 
-> If you receive an error message of type `"invalid parameter"` with HTTP 400 status code, make sure you are completing the fields `payment_method_id` and `issuer_id` correctly.
+> - If you receive an error message of type `"invalid parameter"` with HTTP 400 status code, make sure you are completing the fields `payment_method_id` and `issuer_id` correctly.
+> - Cuando estés utilizando tus credenciales de prueba, recuerda respetar el siguiente formato para el email del cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por ejemplo: `test_payer_12345@testuser.com`.
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Add new cards to a customer
 
@@ -313,7 +314,7 @@ curl -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer ENV_ACCESS_TOKEN' \
     'https://api.mercadopago.com/v1/customers' \
-    -d '{"email": "test@test.com"}'
+    -d '{"email": "test_payer_12345@testuser.com"}'
 
 curl -X POST \
     -H 'Content-Type: application/json' \
@@ -605,7 +606,7 @@ var request = new PaymentCreateRequest
     Payer = new PaymentPayerRequest
     {
         Type = "customer",
-        Email = "test_payer_99999999@testuser.com",
+        Email = "test_payer_12345@testuser.com",
     },
 };
 
@@ -674,7 +675,7 @@ You can search for customer information, if needed; for example, when you don't 
 ```node
 
   var filters = {
-    email: "test@test.com"
+    email: "test_payer_12345@testuser.com"
   };
 
   mercadopago.customers.search({
@@ -687,7 +688,7 @@ You can search for customer information, if needed; for example, when you don't 
 ```java
 
   Map<String, String> filters = new HashMap<>();
-  filters.put("email", "test@test.com");
+  filters.put("email", "test_payer_12345@testuser.com");
 
   ArrayList<Customer> customers = Customer.search(filters, false).resources();
 
@@ -695,7 +696,7 @@ You can search for customer information, if needed; for example, when you don't 
 ```
 ```ruby
 
-customers_response = sdk.customer.search(filters: { email: 'test@test.com' })
+customers_response = sdk.customer.search(filters: { email: 'test_payer_12345@testuser.com' })
 customers = customers_response[:response]
 
 ```
@@ -705,7 +706,7 @@ var searchRequest = new SearchRequest
 {
     Filters = new Dictionary<string, object>
     {
-        ["email"] = "test@test.com",
+        ["email"] = "test_payer_12345@testuser.com",
     },
 };
 ResultsResourcesPage<Customer> results = await customerClient.SearchAsync(searchRequest);
@@ -715,7 +716,7 @@ IList<Customer> customers = results.Results;
 ```python
 
 filters = {
-    "email": "test@test.com"
+    "email": "test_payer_12345@testuser.com"
 }
 
 customers_response = sdk.customer().search(filters=filters)
@@ -763,7 +764,7 @@ curl -X GET \
             "default_address": null,
             "default_card": "1493990563105",
             "description": null,
-            "email": "test@test.com",
+            "email": "test_payer_12345@testuser.com",
             "first_name": null,
             "id": "123456789-jxOV430go9fx2e",
             "identification": {
@@ -899,7 +900,7 @@ mercadopago.configure({
 });
 
 var customer_data = { 
-  "email": "test@test.com",
+  "email": "test_payer_12345@testuser.com",
   "first_name": "john" ,
   "last_name": "wagner",
   "phone": {
@@ -1012,7 +1013,7 @@ var addressRequest = new AddressRequest
 
 var customerRequest = new CustomerRequest
 {
-    Email = "test@test.com",
+    Email = "test_payer_12345@testuser.com",
     FirstName = "john",
     LastName = "wagner",
     DefaultAddress = "home",

--- a/guides/online-payments/checkout-api/advanced-integration.en.md
+++ b/guides/online-payments/checkout-api/advanced-integration.en.md
@@ -179,7 +179,7 @@ curl -X POST \
 > Important
 > 
 > - If you receive an error message of type `"invalid parameter"` with HTTP 400 status code, make sure you are completing the fields `payment_method_id` and `issuer_id` correctly.
-> - Cuando estés utilizando tus credenciales de prueba, recuerda respetar el siguiente formato para el email del cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por ejemplo: `test_payer_12345@testuser.com`.
+> - When you are using your test credentials, remember to follow this particular format for the customer's email: `test_payer_[0-9]{1,10}@testuser.com`. For example: `test_payer_12345@testuser.com`.
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Add new cards to a customer
 

--- a/guides/online-payments/checkout-api/advanced-integration.es.md
+++ b/guides/online-payments/checkout-api/advanced-integration.es.md
@@ -17,7 +17,7 @@ Vas a sumar a cada cliente con el valor `customer` y a la tarjeta como `card`.
   MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
 
   $customer = new MercadoPago\Customer();
-  $customer->email = "test@test.com";
+  $customer->email = "test_payer_12345@testuser.com";
   $customer->save();
 
   $card = new MercadoPago\Card();
@@ -37,7 +37,7 @@ mercadopago.configure({
     access_token: 'ENV_ACCESS_TOKEN'
 });
 
-var customer_data = { "email": "test@test.com" }
+var customer_data = { "email": "test_payer_12345@testuser.com" }
 
 mercadopago.customers.create(customer_data).then(function (customer) {
 
@@ -102,7 +102,7 @@ MercadoPagoConfig.AccessToken = "ENV_ACCESS_TOKEN";
 
 var customerRequest = new CustomerRequest
 {
-    Email = "test@test.com",
+    Email = "test_payer_12345@testuser.com",
 };
 var customerClient = new CustomerClient();
 Customer customer = await customerClient.CreateAsync(customerRequest);
@@ -120,7 +120,7 @@ import mercadopago
 sdk = mercadopago.SDK("ENV_ACCESS_TOKEN")
 
 customer_data = {
-  "email": "test@test.com"
+  "email": "test_payer_12345@testuser.com"
 }
 customer_response = sdk.customer().create(customer_data)
 customer = customer_response["response"]
@@ -150,7 +150,7 @@ curl -X POST \
 ```json
 {
     "id": "123456789-jxOV430go9fx2e",
-    "email": "test@test.com",
+    "email": "test_payer_12345@testuser.com",
     ...
     "default_card": "1490022319978",
     "default_address": null,
@@ -308,12 +308,6 @@ print(card)
 
 ```
 ```curl
-
-curl -X POST \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer ENV_ACCESS_TOKEN' \
-  'https://api.mercadopago.com/v1/customers' \
-  -d '{"email": "test@test.com"}'
 
 curl -X POST \
   -H 'Content-Type: application/json' \
@@ -609,7 +603,7 @@ var request = new PaymentCreateRequest
     Payer = new PaymentPayerRequest
     {
         Type = "customer",
-        Email = "test_payer_99999999@testuser.com",
+        Email = "test_payer_12345@testuser.com",
     },
 };
 
@@ -678,7 +672,7 @@ Puedes buscar información sobre tu cliente si lo necesitas. Por ejemplo, en el 
 ```node
 
   var filters = {
-    email: "test@test.com"
+    email: "test_payer_12345@testuser.com"
   };
 
   mercadopago.customers.search({
@@ -691,7 +685,7 @@ Puedes buscar información sobre tu cliente si lo necesitas. Por ejemplo, en el 
 ```java
 
   Map<String, String> filters = new HashMap<>();
-  filters.put("email", "test@test.com");
+  filters.put("email", "test_payer_12345@testuser.com");
 
   ArrayList<Customer> customers = Customer.search(filters, false).resources();
 
@@ -699,7 +693,7 @@ Puedes buscar información sobre tu cliente si lo necesitas. Por ejemplo, en el 
 ```
 ```ruby
 
-customers_response = sdk.customer.search(filters: { email: 'test@test.com' })
+customers_response = sdk.customer.search(filters: { email: 'test_payer_12345@testuser.com' })
 customers = customers_response[:response]
 
 ```
@@ -709,7 +703,7 @@ var searchRequest = new SearchRequest
 {
     Filters = new Dictionary<string, object>
     {
-        ["email"] = "test@test.com",
+        ["email"] = "test_payer_12345@testuser.com",
     },
 };
 ResultsResourcesPage<Customer> results = await customerClient.SearchAsync(searchRequest);
@@ -719,7 +713,7 @@ IList<Customer> customers = results.Results;
 ```python
 
 filters = {
-    "email": "test@test.com"
+    "email": "test_payer_12345@testuser.com"
 }
 
 customers_response = sdk.customer().search(filters=filters)
@@ -732,7 +726,7 @@ curl -X GET \
   -H 'Authorization: Bearer ENV_ACCESS_TOKEN' \
   'https://api.mercadopago.com/v1/customers/search' \
   -d '{
-    "email": "test_user_19653727@testuser.com"
+    "email": "test_payer_12345@testuser.com"
 }'
 ```
 ]]]
@@ -766,7 +760,7 @@ curl -X GET \
             "default_address": null,
             "default_card": "1493990563105",
             "description": null,
-            "email": "test@test.com",
+            "email": "test_payer_12345@testuser.com",
             "first_name": null,
             "id": "123456789-jxOV430go9fx2e",
             "identification": {
@@ -901,7 +895,7 @@ mercadopago.configure({
 });
 
 var customer_data = { 
-  "email": "test@test.com",
+  "email": "test_payer_12345@testuser.com",
   "first_name": "john" ,
   "last_name": "wagner",
   "phone": {
@@ -1014,7 +1008,7 @@ var addressRequest = new AddressRequest
 
 var customerRequest = new CustomerRequest
 {
-    Email = "test@test.com",
+    Email = "test_payer_12345@testuser.com",
     FirstName = "john",
     LastName = "wagner",
     DefaultAddress = "Casa",

--- a/guides/online-payments/checkout-api/advanced-integration.es.md
+++ b/guides/online-payments/checkout-api/advanced-integration.es.md
@@ -178,7 +178,8 @@ curl -X POST \
 > 
 > Importante
 > 
-> Si recibes un mensaje de error del tipo `"invalid parameter"` con código de estado HTTP 400, asegúrate de estar completando correctamente los campos `payment_method_id` e `issuer_id`.
+> - Si recibes un mensaje de error del tipo `"invalid parameter"` con código de estado HTTP 400, asegúrate de estar completando correctamente los campos `payment_method_id` e `issuer_id`.
+> - Cuando estés utilizando tus credenciales de prueba, recuerda respetar el siguiente formato para el email del cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por ejemplo: `test_payer_12345@testuser.com`.
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Agrega nuevas tarjetas a un cliente
 

--- a/guides/online-payments/checkout-api/advanced-integration.pt.md
+++ b/guides/online-payments/checkout-api/advanced-integration.pt.md
@@ -177,8 +177,8 @@ curl -X POST \
 > 
 > Importante
 > 
-> - Se você receber uma mensagem de erro do tipo `"invalid parameter"` com código de estado HTTP 400, certifique-se de que está completando corretamente os campos `payment_method_id` e `issuer_id`.
-> - Cuando estés utilizando tus credenciales de prueba, recuerda respetar el siguiente formato para el email del cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por ejemplo: `test_payer_12345@testuser.com`.
+> - Se você receber uma mensagem de erro do tipo `"invalid parameter"` com código de estado HTTP 400, certifique-se de que está preenchendo corretamente os campos `payment_method_id` e `issuer_id`.
+> - Quando utilizando as suas credenciais de teste, tenha em mente o seguinte formato para o e-mail do cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por exemplo: `test_payer_12345@testuser.com`.
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Adicione novos cartões a um cliente
 

--- a/guides/online-payments/checkout-api/advanced-integration.pt.md
+++ b/guides/online-payments/checkout-api/advanced-integration.pt.md
@@ -17,7 +17,7 @@ Cada cliente será guardado com o valor `customer` e cada cartão com o valor `c
   MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
 
   $customer = new MercadoPago\Customer();
-  $customer->email = "test@test.com";
+  $customer->email = "test_payer_12345@testuser.com";
   $customer->save();
 
   $card = new MercadoPago\Card();
@@ -37,7 +37,7 @@ mercadopago.configure({
     access_token: 'ENV_ACCESS_TOKEN'
 });
 
-var customer_data = { "email": "test@test.com" }
+var customer_data = { "email": "test_payer_12345@testuser.com" }
 
 mercadopago.customers.create(customer_data).then(function (customer) {
 
@@ -102,7 +102,7 @@ MercadoPagoConfig.AccessToken = "ENV_ACCESS_TOKEN";
 
 var customerRequest = new CustomerRequest
 {
-    Email = "test@test.com",
+    Email = "test_payer_12345@testuser.com",
 };
 var customerClient = new CustomerClient();
 Customer customer = await customerClient.CreateAsync(customerRequest);
@@ -120,7 +120,7 @@ import mercadopago
 sdk = mercadopago.SDK("ENV_ACCESS_TOKEN")
 
 customer_data = {
-  "email": "test@test.com"
+  "email": "test_payer_12345@testuser.com"
 }
 customer_response = sdk.customer().create(customer_data)
 customer = customer_response["response"]
@@ -150,7 +150,7 @@ curl -X POST \
 ```json
 {
     "id": "123456789-jxOV430go9fx2e",
-    "email": "test@test.com",
+    "email": "test_payer_12345@testuser.com",
     ...
     "default_card": "1490022319978",
     "default_address": null,
@@ -177,7 +177,8 @@ curl -X POST \
 > 
 > Importante
 > 
-> Se você receber uma mensagem de erro do tipo `"invalid parameter"` com código de estado HTTP 400, certifique-se de que está completando corretamente os campos `payment_method_id` e `issuer_id`.
+> - Se você receber uma mensagem de erro do tipo `"invalid parameter"` com código de estado HTTP 400, certifique-se de que está completando corretamente os campos `payment_method_id` e `issuer_id`.
+> - Cuando estés utilizando tus credenciales de prueba, recuerda respetar el siguiente formato para el email del cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por ejemplo: `test_payer_12345@testuser.com`.
 
 ### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Adicione novos cartões a um cliente
 
@@ -313,7 +314,7 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer ENV_ACCESS_TOKEN' \
   'https://api.mercadopago.com/v1/customers' \
-  -d '{"email": "test@test.com"}'
+  -d '{"email": "test_payer_12345@testuser.com"}'
 
 curl -X POST \
   -H 'Content-Type: application/json' \
@@ -610,7 +611,7 @@ var request = new PaymentCreateRequest
     Payer = new PaymentPayerRequest
     {
         Type = "customer",
-        Email = "test_payer_99999999@testuser.com",
+        Email = "test_payer_12345@testuser.com",
     },
 };
 
@@ -679,7 +680,7 @@ Busque informação de um cliente caso necessário. Por exemplo, caso não saiba
 ```node
 
   var filters = {
-    email: "test@test.com"
+    email: "test_payer_12345@testuser.com"
   };
 
   mercadopago.customers.search({
@@ -692,7 +693,7 @@ Busque informação de um cliente caso necessário. Por exemplo, caso não saiba
 ```java
 
   Map<String, String> filters = new HashMap<>();
-  filters.put("email", "test@test.com");
+  filters.put("email", "test_payer_12345@testuser.com");
 
   ArrayList<Customer> customers = Customer.search(filters, false).resources();
 
@@ -700,7 +701,7 @@ Busque informação de um cliente caso necessário. Por exemplo, caso não saiba
 ```
 ```ruby
 
-customers_response = sdk.customer.search(filters: { email: 'test@test.com' })
+customers_response = sdk.customer.search(filters: { email: 'test_payer_12345@testuser.com' })
 customers = customers_response[:response]
 
 ```
@@ -710,7 +711,7 @@ var searchRequest = new SearchRequest
 {
     Filters = new Dictionary<string, object>
     {
-        ["email"] = "test@test.com",
+        ["email"] = "test_payer_12345@testuser.com",
     },
 };
 ResultsResourcesPage<Customer> results = await customerClient.SearchAsync(searchRequest);
@@ -720,7 +721,7 @@ IList<Customer> customers = results.Results;
 ```python
 
 filters = {
-    "email": "test@test.com"
+    "email": "test_payer_12345@testuser.com"
 }
 
 customers_response = sdk.customer().search(filters=filters)
@@ -767,7 +768,7 @@ curl -X GET \
             "default_address": null,
             "default_card": "1493990563105",
             "description": null,
-            "email": "test@test.com",
+            "email": "test_payer_12345@testuser.com",
             "first_name": null,
             "id": "123456789-jxOV430go9fx2e",
             "identification": {
@@ -903,7 +904,7 @@ mercadopago.configure({
 });
 
 var customer_data = { 
-  "email": "test@test.com",
+  "email": "test_payer_12345@testuser.com",
   "first_name": "john" ,
   "last_name": "wagner",
   "phone": {
@@ -1016,7 +1017,7 @@ var addressRequest = new AddressRequest
 
 var customerRequest = new CustomerRequest
 {
-    Email = "test@test.com",
+    Email = "test_payer_12345@testuser.com",
     FirstName = "john",
     LastName = "wagner",
     DefaultAddress = "home",

--- a/guides/online-payments/checkout-api/v1/advanced-integration.en.md
+++ b/guides/online-payments/checkout-api/v1/advanced-integration.en.md
@@ -17,7 +17,7 @@ You will add every customer using the `customer` value, and cards as `card`.
   MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
 
   $customer = new MercadoPago\Customer();
-  $customer->email = "test@test.com";
+  $customer->email = "test_payer_12345@testuser.com";
   $customer->save();
 
   $card = new MercadoPago\Card();
@@ -37,7 +37,7 @@ mercadopago.configure({
     access_token: 'ENV_ACCESS_TOKEN'
 });
 
-var customer_data = { "email": "test@test.com" }
+var customer_data = { "email": "test_payer_12345@testuser.com" }
 
 mercadopago.customers.create(customer_data).then(function (customer) {
 
@@ -102,7 +102,7 @@ MercadoPagoConfig.AccessToken = "ENV_ACCESS_TOKEN";
 
 var customerRequest = new CustomerRequest
 {
-    Email = "test@test.com",
+    Email = "test_payer_12345@testuser.com",
 };
 var customerClient = new CustomerClient();
 Customer customer = await customerClient.CreateAsync(customerRequest);
@@ -120,7 +120,7 @@ import mercadopago
 sdk = mercadopago.SDK("ENV_ACCESS_TOKEN")
 
 customer_data = {
-  "email": "test@test.com"
+  "email": "test_payer_12345@testuser.com"
 }
 customer_response = sdk.customer().create(customer_data)
 customer = customer_response["response"]
@@ -150,7 +150,7 @@ curl -X POST \
 ```json
 {
     "id": "123456789-jxOV430go9fx2e",
-    "email": "test@test.com",
+    "email": "test_payer_12345@testuser.com",
     ...
     "default_card": "1490022319978",
     "default_address": null,
@@ -313,7 +313,7 @@ curl -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer ENV_ACCESS_TOKEN' \
     'https://api.mercadopago.com/v1/customers' \
-    -d '{"email": "test@test.com"}'
+    -d '{"email": "test_payer_12345@testuser.com"}'
 
 curl -X POST \
     -H 'Content-Type: application/json' \
@@ -591,7 +591,7 @@ var request = new PaymentCreateRequest
     Payer = new PaymentPayerRequest
     {
         Type = "customer",
-        Email = "test_payer_99999999@testuser.com",
+        Email = "test_payer_12345@testuser.com",
     },
 };
 
@@ -660,7 +660,7 @@ You can search for customer information, if needed; for example, when you don't 
 ```node
 
   var filters = {
-    email: "test@test.com"
+    email: "test_payer_12345@testuser.com"
   };
 
   mercadopago.customers.search({
@@ -673,7 +673,7 @@ You can search for customer information, if needed; for example, when you don't 
 ```java
 
   Map<String, String> filters = new HashMap<>();
-  filters.put("email", "test@test.com");
+  filters.put("email", "test_payer_12345@testuser.com");
 
   ArrayList<Customer> customers = MercadoPago\Customer::search(filters).resources();
 
@@ -681,7 +681,7 @@ You can search for customer information, if needed; for example, when you don't 
 ```
 ```ruby
 
-customers_response = sdk.customer.search(filters: { email: 'test@test.com' })
+customers_response = sdk.customer.search(filters: { email: 'test_payer_12345@testuser.com' })
 customers = customers_response[:response]
 
 ```
@@ -691,7 +691,7 @@ var searchRequest = new SearchRequest
 {
     Filters = new Dictionary<string, object>
     {
-        ["email"] = "test@test.com",
+        ["email"] = "test_payer_12345@testuser.com",
     },
 };
 ResultsResourcesPage<Customer> results = await customerClient.SearchAsync(searchRequest);
@@ -701,7 +701,7 @@ IList<Customer> customers = results.Results;
 ```python
 
 filters = {
-    "email": "test@test.com"
+    "email": "test_payer_12345@testuser.com"
 }
 
 customers_response = sdk.customer().search(filters=filters)
@@ -749,7 +749,7 @@ curl -X GET \
             "default_address": null,
             "default_card": "1493990563105",
             "description": null,
-            "email": "test@test.com",
+            "email": "test_payer_12345@testuser.com",
             "first_name": null,
             "id": "123456789-jxOV430go9fx2e",
             "identification": {

--- a/guides/online-payments/checkout-api/v1/advanced-integration.es.md
+++ b/guides/online-payments/checkout-api/v1/advanced-integration.es.md
@@ -17,7 +17,7 @@ Vas a sumar a cada cliente con el valor `customer` y a la tarjeta como `card`.
   MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
 
   $customer = new MercadoPago\Customer();
-  $customer->email = "test@test.com";
+  $customer->email = "test_payer_12345@testuser.com";
   $customer->save();
 
   $card = new MercadoPago\Card();
@@ -37,7 +37,7 @@ mercadopago.configure({
     access_token: 'ENV_ACCESS_TOKEN'
 });
 
-var customer_data = { "email": "test@test.com" }
+var customer_data = { "email": "test_payer_12345@testuser.com" }
 
 mercadopago.customers.create(customer_data).then(function (customer) {
 
@@ -102,7 +102,7 @@ MercadoPagoConfig.AccessToken = "ENV_ACCESS_TOKEN";
 
 var customerRequest = new CustomerRequest
 {
-    Email = "test@test.com",
+    Email = "test_payer_12345@testuser.com",
 };
 var customerClient = new CustomerClient();
 Customer customer = await customerClient.CreateAsync(customerRequest);
@@ -120,7 +120,7 @@ import mercadopago
 sdk = mercadopago.SDK("ENV_ACCESS_TOKEN")
 
 customer_data = {
-  "email": "test@test.com"
+  "email": "test_payer_12345@testuser.com"
 }
 customer_response = sdk.customer().create(customer_data)
 customer = customer_response["response"]
@@ -150,7 +150,7 @@ curl -X POST \
 ```json
 {
     "id": "123456789-jxOV430go9fx2e",
-    "email": "test@test.com",
+    "email": "test_payer_12345@testuser.com",
     ...
     "default_card": "1490022319978",
     "default_address": null,
@@ -313,7 +313,7 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer ENV_ACCESS_TOKEN' \
   'https://api.mercadopago.com/v1/customers' \
-  -d '{"email": "test@test.com"}'
+  -d '{"email": "test_payer_12345@testuser.com"}'
 
 curl -X POST \
   -H 'Content-Type: application/json' \
@@ -599,7 +599,7 @@ var request = new PaymentCreateRequest
     Payer = new PaymentPayerRequest
     {
         Type = "customer",
-        Email = "test_payer_99999999@testuser.com",
+        Email = "test_payer_12345@testuser.com",
     },
 };
 
@@ -668,7 +668,7 @@ Puedes buscar información sobre tu cliente si lo necesitas. Por ejemplo, en el 
 ```node
 
   var filters = {
-    email: "test@test.com"
+    email: "test_payer_12345@testuser.com"
   };
 
   mercadopago.customers.search({
@@ -681,7 +681,7 @@ Puedes buscar información sobre tu cliente si lo necesitas. Por ejemplo, en el 
 ```java
 
   Map<String, String> filters = new HashMap<>();
-  filters.put("email", "test@test.com");
+  filters.put("email", "test_payer_12345@testuser.com");
 
   ArrayList<Customer> customers = MercadoPago\Customer::search(filters).resources();
 
@@ -689,7 +689,7 @@ Puedes buscar información sobre tu cliente si lo necesitas. Por ejemplo, en el 
 ```
 ```ruby
 
-customers_response = sdk.customer.search(filters: { email: 'test@test.com' })
+customers_response = sdk.customer.search(filters: { email: 'test_payer_12345@testuser.com' })
 customers = customers_response[:response]
 
 ```
@@ -699,7 +699,7 @@ var searchRequest = new SearchRequest
 {
     Filters = new Dictionary<string, object>
     {
-        ["email"] = "test@test.com",
+        ["email"] = "test_payer_12345@testuser.com",
     },
 };
 ResultsResourcesPage<Customer> results = await customerClient.SearchAsync(searchRequest);
@@ -709,7 +709,7 @@ IList<Customer> customers = results.Results;
 ```python
 
 filters = {
-    "email": "test@test.com"
+    "email": "test_payer_12345@testuser.com"
 }
 
 customers_response = sdk.customer().search(filters=filters)
@@ -756,7 +756,7 @@ curl -X GET \
             "default_address": null,
             "default_card": "1493990563105",
             "description": null,
-            "email": "test@test.com",
+            "email": "test_payer_12345@testuser.com",
             "first_name": null,
             "id": "123456789-jxOV430go9fx2e",
             "identification": {

--- a/guides/online-payments/checkout-api/v1/advanced-integration.pt.md
+++ b/guides/online-payments/checkout-api/v1/advanced-integration.pt.md
@@ -17,7 +17,7 @@ Cada cliente será guardado com o valor `customer` e cada cartão com o valor `c
   MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
 
   $customer = new MercadoPago\Customer();
-  $customer->email = "test@test.com";
+  $customer->email = "test_payer_12345@testuser.com";
   $customer->save();
 
   $card = new MercadoPago\Card();
@@ -37,7 +37,7 @@ mercadopago.configure({
     access_token: 'ENV_ACCESS_TOKEN'
 });
 
-var customer_data = { "email": "test@test.com" }
+var customer_data = { "email": "test_payer_12345@testuser.com" }
 
 mercadopago.customers.create(customer_data).then(function (customer) {
 
@@ -102,7 +102,7 @@ MercadoPagoConfig.AccessToken = "ENV_ACCESS_TOKEN";
 
 var customerRequest = new CustomerRequest
 {
-    Email = "test@test.com",
+    Email = "test_payer_12345@testuser.com",
 };
 var customerClient = new CustomerClient();
 Customer customer = await customerClient.CreateAsync(customerRequest);
@@ -120,7 +120,7 @@ import mercadopago
 sdk = mercadopago.SDK("ENV_ACCESS_TOKEN")
 
 customer_data = {
-  "email": "test@test.com"
+  "email": "test_payer_12345@testuser.com"
 }
 customer_response = sdk.customer().create(customer_data)
 customer = customer_response["response"]
@@ -150,7 +150,7 @@ curl -X POST \
 ```json
 {
     "id": "123456789-jxOV430go9fx2e",
-    "email": "test@test.com",
+    "email": "test_payer_12345@testuser.com",
     ...
     "default_card": "1490022319978",
     "default_address": null,
@@ -313,7 +313,7 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer ENV_ACCESS_TOKEN' \
   'https://api.mercadopago.com/v1/customers' \
-  -d '{"email": "test@test.com"}'
+  -d '{"email": "test_payer_12345@testuser.com"}'
 
 curl -X POST \
   -H 'Content-Type: application/json' \
@@ -601,7 +601,7 @@ var request = new PaymentCreateRequest
     Payer = new PaymentPayerRequest
     {
         Type = "customer",
-        Email = "test_payer_99999999@testuser.com",
+        Email = "test_payer_12345@testuser.com",
     },
 };
 
@@ -670,7 +670,7 @@ Busque informação de um cliente caso necessário. Por exemplo, caso não saiba
 ```node
 
   var filters = {
-    email: "test@test.com"
+    email: "test_payer_12345@testuser.com"
   };
 
   mercadopago.customers.search({
@@ -683,7 +683,7 @@ Busque informação de um cliente caso necessário. Por exemplo, caso não saiba
 ```java
 
   Map<String, String> filters = new HashMap<>();
-  filters.put("email", "test@test.com");
+  filters.put("email", "test_payer_12345@testuser.com");
 
   ArrayList<Customer> customers = MercadoPago\Customer::search(filters).resources();
 
@@ -691,7 +691,7 @@ Busque informação de um cliente caso necessário. Por exemplo, caso não saiba
 ```
 ```ruby
 
-customers_response = sdk.customer.search(filters: { email: 'test@test.com' })
+customers_response = sdk.customer.search(filters: { email: 'test_payer_12345@testuser.com' })
 customers = customers_response[:response]
 
 ```
@@ -701,7 +701,7 @@ var searchRequest = new SearchRequest
 {
     Filters = new Dictionary<string, object>
     {
-        ["email"] = "test@test.com",
+        ["email"] = "test_payer_12345@testuser.com",
     },
 };
 ResultsResourcesPage<Customer> results = await customerClient.SearchAsync(searchRequest);
@@ -711,7 +711,7 @@ IList<Customer> customers = results.Results;
 ```python
 
 filters = {
-    "email": "test@test.com"
+    "email": "test_payer_12345@testuser.com"
 }
 
 customers_response = sdk.customer().search(filters=filters)
@@ -758,7 +758,7 @@ curl -X GET \
             "default_address": null,
             "default_card": "1493990563105",
             "description": null,
-            "email": "test@test.com",
+            "email": "test_payer_12345@testuser.com",
             "first_name": null,
             "id": "123456789-jxOV430go9fx2e",
             "identification": {


### PR DESCRIPTION
## Description
El email del payer cuando se realizan pruebas debe respetar el formato test_payer_[0-9]{1,10}@testuser.com.
De lo contrario se obtiene el siguiente error:
`"description": "the email format is invalid. Use 'test_payer_[0-9]{1,10}@testuser.com'"`

Aclaración: no es necesario crear un test user con ese email con formato específico, puede usarse siempre el mismo email de ejemplo que no corresponde a ningún usuario real y todo funciona como si fuese un usuario guest

### Checklist:
- [x] This request modifies code snippets. 
- [x] The contribution aligns with the information stated in the repository wiki.
- [x] Requires translation