### PR TITLE
Add links to Pix payment samples and adjust card payment samples description

### DIFF
--- a/guides/online-payments/checkout-api/other-payment-ways.en.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.en.md
@@ -3871,6 +3871,12 @@ In the `external_resource_url` field you will find an address with payment instr
 
 You can receive payment immediately with Pix from any bank or digital wallet using QR code or payment code.
 
+> GIT
+>
+> Pix integration examples
+>
+> We have [complete integration examples](https://github.com/mercadopago/pix-payment-sample) available on GitHub so you can download it immediately.
+
 ### Prerequisite
 
 #### Get a Pix key

--- a/guides/online-payments/checkout-api/other-payment-ways.en.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.en.md
@@ -3875,7 +3875,7 @@ You can receive payment immediately with Pix from any bank or digital wallet usi
 >
 > Pix integration examples
 >
-> We have [complete integration examples](https://github.com/mercadopago/pix-payment-sample) available on GitHub so you can download it immediately.
+> Use our [complete integration examples](https://github.com/mercadopago/pix-payment-sample) on GitHub to download instantly.
 
 ### Prerequisite
 

--- a/guides/online-payments/checkout-api/other-payment-ways.es.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.es.md
@@ -3879,7 +3879,7 @@ Ofrece la opción de recibir pagos al instante con Pix desde cualquier banco o b
 >
 > Ejemplos de integración Pix
 >
-> Proporcionamos [ejemplos completos de integración](https://github.com/mercadopago/pix-payment-sample) en GitHub para que pueda descargarlo de inmediato.
+> Te dejamos [ejemplos completos de integración](https://github.com/mercadopago/pix-payment-sample) en GitHub para que puedas descargar al instante.
 
 ### Requisito previo
 

--- a/guides/online-payments/checkout-api/other-payment-ways.es.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.es.md
@@ -3875,6 +3875,12 @@ En el campo `external_resource_url` vas a encontrar una dirección que contiene 
 
 Ofrece la opción de recibir pagos al instante con Pix desde cualquier banco o billetera digital a través de un código QR o un código de pago.
 
+> GIT
+>
+> Ejemplos de integración Pix
+>
+> Proporcionamos [ejemplos completos de integración](https://github.com/mercadopago/pix-payment-sample) en GitHub para que pueda descargarlo de inmediato.
+
 ### Requisito previo
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Obtén una llave Pix

--- a/guides/online-payments/checkout-api/other-payment-ways.pt.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.pt.md
@@ -3870,27 +3870,11 @@ No campo `external_resource_url` você encontrará um endereço que contêm as i
 
 Ofereça a opção de receber pagamentos no instante com Pix de qualquer banco ou carteira digital através de um código QR ou de um código de pagamento.
 
-<br>
-----[mlb]----
-
 > GIT
 >
 > Exemplos de integração Pix
 >
 > Disponibilizamos [exemplos completos de integração](https://github.com/mercadopago/pix-payment-sample) no GitHub para que você possa fazer o download imediatamente.
-
-------------
-
-----[mla, mlm, mpe, mco, mlu, mlc]----
-
-> GIT
->
-> Checkout API
->
-> Disponibilizamos [exemplos completos de integração](https://github.com/mercadopago/pix-payment-sample) no GitHub para que você possa fazer o download imediatamente.
-
-------------
-<br>
 
 ### Requisito prévio
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Obtenha uma chave Pix

--- a/guides/online-payments/checkout-api/other-payment-ways.pt.md
+++ b/guides/online-payments/checkout-api/other-payment-ways.pt.md
@@ -3870,6 +3870,28 @@ No campo `external_resource_url` você encontrará um endereço que contêm as i
 
 Ofereça a opção de receber pagamentos no instante com Pix de qualquer banco ou carteira digital através de um código QR ou de um código de pagamento.
 
+<br>
+----[mlb]----
+
+> GIT
+>
+> Exemplos de integração Pix
+>
+> Disponibilizamos [exemplos completos de integração](https://github.com/mercadopago/pix-payment-sample) no GitHub para que você possa fazer o download imediatamente.
+
+------------
+
+----[mla, mlm, mpe, mco, mlu, mlc]----
+
+> GIT
+>
+> Checkout API
+>
+> Disponibilizamos [exemplos completos de integração](https://github.com/mercadopago/pix-payment-sample) no GitHub para que você possa fazer o download imediatamente.
+
+------------
+<br>
+
 ### Requisito prévio
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Obtenha uma chave Pix
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card-core-methods.en.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card-core-methods.en.md
@@ -582,7 +582,7 @@ Finally, you always need to be notified of new payments and status updates.  For
 >
 > Checkout API
 >
-> Use our [complete integration examples](http://github.com/mercadopago/card-payment-sample) on GitHub in PHP or NodeJS to download instantly.
+> Use our [complete integration examples](http://github.com/mercadopago/card-payment-sample) on GitHub to download instantly.
 
 <span></span>
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card-core-methods.es.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card-core-methods.es.md
@@ -595,14 +595,14 @@ Por último, es importante que estés siempre informado sobre la creación de nu
 >
 > Checkout Transparente
 >
-> Te dejamos [ejemplos completos de integración](http://github.com/mercadopago/card-payment-sample) en GitHub para PHP o NodeJS para que puedas descargar al instante.
+> Te dejamos [ejemplos completos de integración](http://github.com/mercadopago/card-payment-sample) en GitHub para que puedas descargar al instante.
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
 > GIT
 >
 > Checkout API
 >
-> Te dejamos [ejemplos completos de integración](http://github.com/mercadopago/card-payment-sample) en GitHub para PHP o NodeJS para que puedas descargar al instante.
+> Te dejamos [ejemplos completos de integración](http://github.com/mercadopago/card-payment-sample) en GitHub para que puedas descargar al instante.
 ------------
 
 <span></span>

--- a/guides/online-payments/checkout-api/receiving-payment-by-card-core-methods.pt.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card-core-methods.pt.md
@@ -601,14 +601,14 @@ Por último, é importante que esteja sempre informado sobre a criação nos nov
 >
 > Checkout Transparente
 >
-> Disponibilizamos [exemplos completos de integração](http://github.com/mercadopago/card-payment-sample) no GitHub para PHP ou NodeJS para que você possa fazer o download imediatamente.
+> Disponibilizamos [exemplos completos de integração](http://github.com/mercadopago/card-payment-sample) no GitHub para que você possa fazer o download imediatamente.
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
 > GIT
 >
 > Checkout API
 >
-> Disponibilizamos [exemplos completos de integração](http://github.com/mercadopago/card-payment-sample) no GitHub para PHP ou NodeJS para que você possa fazer o download imediatamente.
+> Disponibilizamos [exemplos completos de integração](http://github.com/mercadopago/card-payment-sample) no GitHub para que você possa fazer o download imediatamente.
 ------------
 
 <span></span>

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.en.md
@@ -499,7 +499,7 @@ Finally, you always need to be notified of new payments and status updates.  For
 >
 > Checkout API
 >
-> Use our [complete integration examples](http://github.com/mercadopago/card-payment-sample) on GitHub in PHP or NodeJS to download instantly.
+> Use our [complete integration examples](http://github.com/mercadopago/card-payment-sample) on GitHub to download instantly.
 
 <span></span>
 

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.es.md
@@ -510,14 +510,14 @@ Por último, es importante que estés siempre informado sobre la creación de nu
 >
 > Checkout Transparente
 >
-> Te dejamos [ejemplos completos de integración](http://github.com/mercadopago/card-payment-sample) en GitHub para PHP o NodeJS para que puedas descargar al instante.
+> Te dejamos [ejemplos completos de integración](http://github.com/mercadopago/card-payment-sample) en GitHub para que puedas descargar al instante.
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
 > GIT
 >
 > Checkout API
 >
-> Te dejamos [ejemplos completos de integración](http://github.com/mercadopago/card-payment-sample) en GitHub para PHP o NodeJS para que puedas descargar al instante.
+> Te dejamos [ejemplos completos de integración](http://github.com/mercadopago/card-payment-sample) en GitHub para que puedas descargar al instante.
 ------------
 
 <span></span>

--- a/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
+++ b/guides/online-payments/checkout-api/receiving-payment-by-card.pt.md
@@ -518,14 +518,14 @@ Por último, é importante que esteja sempre informado sobre a criação nos nov
 >
 > Checkout Transparente
 >
-> Disponibilizamos [exemplos completos de integração](http://github.com/mercadopago/card-payment-sample) no GitHub para PHP ou NodeJS para que você possa fazer o download imediatamente.
+> Disponibilizamos [exemplos completos de integração](http://github.com/mercadopago/card-payment-sample) no GitHub para que você possa fazer o download imediatamente.
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
 > GIT
 >
 > Checkout API
 >
-> Disponibilizamos [exemplos completos de integração](http://github.com/mercadopago/card-payment-sample) no GitHub para PHP ou NodeJS para que você possa fazer o download imediatamente.
+> Disponibilizamos [exemplos completos de integração](http://github.com/mercadopago/card-payment-sample) no GitHub para que você possa fazer o download imediatamente.
 ------------
 
 <span></span>


### PR DESCRIPTION
## Description

- Add link to Pix samples in Github of Mercado Pago
https://github.com/mercadopago/pix-payment-sample
- About the credit card samples section, I removed the words "PHP" and "NodeJS" because now the languages available are described in an "index repository" in Github of Mercado Pago
https://github.com/mercadopago/card-payment-sample

### Checklist:
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [x] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [x] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
