### PR TITLE
Oauth API: cambio de termino y edición de códigos de error

### DIFF
--- a/reference/api/oauth.yaml
+++ b/reference/api/oauth.yaml
@@ -12,8 +12,8 @@ paths:
         - $ref: '#/tags/marketplace'
         - $ref: '#/tags/mobile-checkout'
         - $ref: '#/tags/subscriptions'
-      summary: Generate credentials
-      description: To create or refresh the necessary credentials to operate your application in the name of a seller
+      summary: Generate token
+      description: To create or refresh the necessary token to operate your application in the name of a seller
       requestBody:
         content:
           application/json:

--- a/reference/api/oauth.yaml
+++ b/reference/api/oauth.yaml
@@ -107,9 +107,9 @@ paths:
                     enum:
                       - invalid_client -- The provided client_id and/or client_secret of your app is invalid.
                       - invalid_grant -- There are several reasons for this error, it could be because the authorization_code or refresh_token is invalid, expired or revoked, was sent in an incorrect flow, belongs to another client, or the redirect_uri used in the authorization flow does not match what your application has configured.
-                      - invalid_scope -- The requested scope is invalid, unknown, or wrongly formed. The allowed values ​​for the scope parameter are “offline_access”, ”write”, ”read”.
+                      - invalid_scope -- The requested scope is invalid, unknown, or wrongly formed. The allowed values for the scope parameter are “offline_access”, ”write”, ”read”.
                       - invalid_request -- The request does not include a required parameter, includes an unsupported parameter or parameter value, has a duplicated value, or is otherwise malformed.
-                      - unsupported_grant_type -- Allowed values ​​for grant_type are “authorization_code” or “refresh_token”.
+                      - unsupported_grant_type -- Allowed values for grant_type are “authorization_code” or “refresh_token”.
                       - forbidden -- The call does not authorize access, possibly another user's token is being used.
                       - unauthorized_client -- The application does not have a grant with the user or the permissions (scopes) that the application has with this user do not allow creating a token.
                   cause:

--- a/reference/api/oauth.yaml
+++ b/reference/api/oauth.yaml
@@ -105,13 +105,13 @@ paths:
                     type: string
                     example: 'expired_grant'
                     enum:
-                      - invalid_client -- 
-                      - invalid_grant -- 
-                      - invalid_scope -- 
-                      - invalid_request -- 
-                      - unsupported_grant_type -- 
-                      - forbidden -- 
-                      - unauthorized_client -- 
+                      - invalid_client -- The provided client_id and/or client_secret of your app is invalid.
+                      - invalid_grant -- There are several reasons for this error, it could be because the authorization_code or refresh_token is invalid, expired or revoked, was sent in an incorrect flow, belongs to another client, or the redirect_uri used in the authorization flow does not match what your application has configured.
+                      - invalid_scope -- The requested scope is invalid, unknown, or wrongly formed. The allowed values ​​for the scope parameter are “offline_access”, ”write”, ”read”.
+                      - invalid_request -- The request does not include a required parameter, includes an unsupported parameter or parameter value, has a duplicated value, or is otherwise malformed.
+                      - unsupported_grant_type -- Allowed values ​​for grant_type are “authorization_code” or “refresh_token”.
+                      - forbidden -- The call does not authorize access, possibly another user's token is being used.
+                      - unauthorized_client -- The application does not have a grant with the user or the permissions (scopes) that the application has with this user do not allow creating a token.
                   cause:
                     type: array
                     items:


### PR DESCRIPTION
## Description
Se cambia el término "credenciales" por "Token" en relación a OAuth. También se editan los códigos de error del yaml.

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #<issue>

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.
