### PR TITLE
New Prestashop release link

### DIFF
--- a/guides/plugins/prestashop/faq.en.md
+++ b/guides/plugins/prestashop/faq.en.md
@@ -4,7 +4,7 @@
  
 To install the plugin manually, follow the steps below:
  
-1. [Download the .zip file](https://github.com/mercadopago/cart-prestashop-7/raw/master/mercadopago.zip) directly from our Github or from the [directory](https://addons.prestashop.com/en/payment-card-wallet/23962-mercado-pago.html) of PrestaShop modules.
+1. [Download the .zip file](https://github.com/mercadopago/cart-prestashop-7/releases/latest) directly from our Github or from the [directory](https://addons.prestashop.com/en/payment-card-wallet/23962-mercado-pago.html) of PrestaShop modules.
 2. Go to the "Modules and Services'" section in the "Modules" menu of your administrator.
 3. Click on the **Update a module** button in the upper right corner.
 4. Select or drag the **Mercadopago.zip** file downloaded earlier.

--- a/guides/plugins/prestashop/faq.es.md
+++ b/guides/plugins/prestashop/faq.es.md
@@ -4,7 +4,7 @@
  
 Para instalar el plugin manualmente, sigue los pasos:
  
-1. [Descarga el archivo .zip](https://github.com/mercadopago/cart-prestashop-7/raw/master/mercadopago.zip) directamente desde nuestro Github o desde el [directorio](https://addons.prestashop.com/es/pago-tarjeta-carteras-digitales/23962-mercado-pago.html) de los módulos de PrestaShop.
+1. [Descarga el archivo .zip](https://github.com/mercadopago/cart-prestashop-7/releases/latest) directamente desde nuestro Github o desde el [directorio](https://addons.prestashop.com/es/pago-tarjeta-carteras-digitales/23962-mercado-pago.html) de los módulos de PrestaShop.
 2. Ve a la sección "Módulos y servicios" en el menú "Módulos" de tu administrador.
 3. Haz clic en el botón **Update a module** en la esquina superior derecha.
 4. Selecciona o arrastra el archivo **Mercadopago.zip** descargado anteriormente.

--- a/guides/plugins/prestashop/faq.pt.md
+++ b/guides/plugins/prestashop/faq.pt.md
@@ -4,7 +4,7 @@
  
 Para instalar o plugin de forma manual, siga os passos abaixo:
  
-1. [Baixe o arquivo .zip](https://github.com/mercadopago/cart-prestashop-7/raw/master/mercadopago.zip) diretamente do nosso Github ou do [diretório](https://addons.prestashop.com/pt/pagamento-carta-carteira/23962-mercado-pago.html) de módulos do PrestaShop.
+1. [Baixe o arquivo .zip](https://github.com/mercadopago/cart-prestashop-7/releases/latest) diretamente do nosso Github ou do [diretório](https://addons.prestashop.com/pt/pagamento-carta-carteira/23962-mercado-pago.html) de módulos do PrestaShop.
 2. Vá à seção "Módulos e serviços'", no menu "Módulos" do seu administrador.
 3. Clique no botão **Enviar um módulo** no canto superior direito.
 4. Selecione ou arraste o arquivo **Mercadopago.zip** baixado anteriormente.


### PR DESCRIPTION
## Description
[PPWP-416] Our Prestashop release .zip file will now be available only through Github Releases. This change removes the URL that redirects to another zip inside the repo files.

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->
### Issue involved
Fixes #<issue>

### Checklist:
Before sending your contribution, please specify the following: 
<!--- Select all items that apply to this PR -->
- [ ] This request modifies code snippets. 
- [ ] The contribution aligns with the information stated in the repository wiki.
<!--In case of needing to index this documentation, specify in which section -->
- [ ] Contribution incorporates an article not included until now, which must be added to indexes as a new section. 
- [ ] Contribution includes new features. 
- [ ] New features were communicated in changelog.
- [ ] Requires translations.


[PPWP-416]: https://mercadolibre.atlassian.net/browse/PPWP-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ