### PR TITLE
SDK-797: update simulator's docs to support test AT

### DIFF
--- a/guides/in-person-payments/integration-api/point-simulator.en.md
+++ b/guides/in-person-payments/integration-api/point-simulator.en.md
@@ -6,7 +6,7 @@ With this simulator, you will be able to create a payment intent and process it 
 The simulator has two modes of usage:
 
 * **PDV Mode**: Simulates the integration of a complete system (device and POS) with our Integrations API. Access the [PDV Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
-* **Device Mode**: Simulates a virtual Point device so that you can test your integration from HTTP requests. Access the [Device Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
+* **Device mode**: simulates a virtual Point device so that you can test your integration from HTTP requests. Access the [Device Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 
 ## How to use the simulator
 

--- a/guides/in-person-payments/integration-api/point-simulator.en.md
+++ b/guides/in-person-payments/integration-api/point-simulator.en.md
@@ -14,7 +14,7 @@ The simulator has two modes of usage:
 
 When using the simulator for the first time, you will need to enter your keys and select one of your available devices.
 
-* **PDV Mode:** You must enter your Test Access Token and the simulator will assign you a virtual device.
+* **PDV mode:** you must enter your test `access-token` and the simulator will assign you a virtual device.
 
 * **Device mode:** you must enter your test `access-token` and your device id obtained when [listing your devices](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/in-person-payments/integration-api/create-payment-intent#bookmark_get_the_list_of_your_available_devices).
 

--- a/guides/in-person-payments/integration-api/point-simulator.en.md
+++ b/guides/in-person-payments/integration-api/point-simulator.en.md
@@ -22,7 +22,7 @@ When using the simulator for the first time, you will need to enter your keys an
 >
 > Important
 > 
-> Remember that to use the simulator you must configure a Test Access Token(`TEST-XXXXX-XXXXX-XXXXXXX`) and you can get it in your [integrations](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/applications), option **My Credentials / Test Credentials**.
+> Remember that to use the simulator you must configure a test `access-token`(`TEST-XXXXX-XXXXX-XXXXXXX`) and you can get it in your [integrations](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/applications), option **My credentials > Test credentials**.
 
 ### 2. Simulate a payment intent
 

--- a/guides/in-person-payments/integration-api/point-simulator.en.md
+++ b/guides/in-person-payments/integration-api/point-simulator.en.md
@@ -6,8 +6,8 @@ With this simulator, you will be able to create a payment intent and process it 
 The simulator has two modes of usage:
 
 
-* **PDV Mode**: simulates the integration of a complete system (device and POS) with our Integrations API. Access the [PDV Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true)
-* **Device Mode**: simulates a virtual Point device so that you can test your integration from HTTP requests. Access the [Device Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true)
+* **PDV Mode**: Simulates the integration of a complete system (device and POS) with our Integrations API. Access the [PDV Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
+* **Device Mode**: Simulates a virtual Point device so that you can test your integration from HTTP requests. Access the [Device Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 
 ## How to use the simulator
 
@@ -15,9 +15,15 @@ The simulator has two modes of usage:
 
 When using the simulator for the first time, you will need to enter your keys and select one of your available devices.
 
-To use **PDV Mode** you will need your Access Token key. If you are using a test Access Token, the simulator will assign you a virtual device.
+* **PDV Mode:** You must enter your Test Access Token and the simulator will assign you a virtual device.
 
-When using **Device Mode**, you must enter your Access Token and your Device Id obtained when [listing your devices](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/in-person-payments/integration-api/create-payment-intent#bookmark_create_the_payment_intent).
+* **Device Mode:** You must enter your Test Access Token and your Device Id obtained when [listing your devices](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/in-person-payments/integration-api/create-payment-intent#bookmark_get_the_list_of_your_available_devices).
+
+> WARNING
+>
+> Important
+> 
+> Remember that to use the simulator you must configure a Test Access Token(`TEST-XXXXX-XXXXX-XXXXXXX`) and you can get it in your [integrations](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/applications), option **My Credentials / Test Credentials**.
 
 ### 2. Simulate a payment intent
 
@@ -43,6 +49,11 @@ If the previous step was successful, you can click on the animation of the card,
 
 If you followed the configuration steps for the [Webhooks notifications](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/in-person-payments/integration-api/integration), it is time for you to review your records. There, you will see that the notification of the transaction status was sent.
 
+> NOTE
+>
+> Note
+>
+> The simulator will allow you to make test payments, in this way, you can check out all the information corresponding in the section [Payment API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/payments/_payments_id/get).
 
 > PREV_STEP_CARD_EN
 >

--- a/guides/in-person-payments/integration-api/point-simulator.en.md
+++ b/guides/in-person-payments/integration-api/point-simulator.en.md
@@ -16,7 +16,7 @@ When using the simulator for the first time, you will need to enter your keys an
 
 * **PDV Mode:** You must enter your Test Access Token and the simulator will assign you a virtual device.
 
-* **Device Mode:** You must enter your Test Access Token and your Device Id obtained when [listing your devices](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/in-person-payments/integration-api/create-payment-intent#bookmark_get_the_list_of_your_available_devices).
+* **Device mode:** you must enter your test `access-token` and your device id obtained when [listing your devices](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/in-person-payments/integration-api/create-payment-intent#bookmark_get_the_list_of_your_available_devices).
 
 > WARNING
 >

--- a/guides/in-person-payments/integration-api/point-simulator.en.md
+++ b/guides/in-person-payments/integration-api/point-simulator.en.md
@@ -5,7 +5,7 @@ With this simulator, you will be able to create a payment intent and process it 
 
 The simulator has two modes of usage:
 
-* **PDV Mode**: Simulates the integration of a complete system (device and POS) with our Integrations API. Access the [PDV Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
+* **PDV mode**: simulates the integration of a complete system (device and POS) with our Integrations API. Access the [PDV mode simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
 * **Device mode**: simulates a virtual Point device so that you can test your integration from HTTP requests. Access the [Device Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 
 ## How to use the simulator

--- a/guides/in-person-payments/integration-api/point-simulator.en.md
+++ b/guides/in-person-payments/integration-api/point-simulator.en.md
@@ -5,7 +5,6 @@ With this simulator, you will be able to create a payment intent and process it 
 
 The simulator has two modes of usage:
 
-
 * **PDV Mode**: Simulates the integration of a complete system (device and POS) with our Integrations API. Access the [PDV Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
 * **Device Mode**: Simulates a virtual Point device so that you can test your integration from HTTP requests. Access the [Device Mode Simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 

--- a/guides/in-person-payments/integration-api/point-simulator.es.md
+++ b/guides/in-person-payments/integration-api/point-simulator.es.md
@@ -5,18 +5,24 @@ Con este simulador, podrás crear una intención de pago y procesarla desde el d
 
 El simulador cuenta con dos modos de uso:
 
-* **PDV Mode**: simula la integración de un sistema completo (dispositivo y PDV) con nuestra API de Integraciones. Ingresa al [Simulador PDV Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true)
-* **Device Mode**: simula un dispositivo Point virtual para que puedas probar tu integración desde los requests HTTP. Ingresa al [Simulador Device Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
+* **PDV Mode**: Simula la integración de un sistema completo (dispositivo y PDV) con nuestra API de Integraciones. Ingresa al [Simulador PDV Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
+* **Device Mode**: Simula un dispositivo Point virtual para que puedas probar tu integración desde los requests HTTP. Ingresa al [Simulador Device Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 
 ## Cómo usar el simulador 
 
 ### 1. Configura tus credenciales
 
-Al utilizar el simulador por primera vez, deberás ingresar tus llaves y seleccionar uno de tus dispositivos disponibles. 
+Al utilizar el simulador por primera vez, deberás ingresar tus credenciales y seleccionar uno de tus dispositivos disponibles. 
 
-Para utilizar **PDV Mode** necesitarás tu llave Access Token. Si estás utilizando un Access Token de prueba, el simulador te asignará un dispositivo virtual.
+* **PDV Mode:** Debes ingresar tu Access Token de prueba y el simulador te asignará un dispositivo virtual.
 
-Al utilizar **Device Mode**, debes ingresar tu Access Token y tu Device Id obtenido al [listar tus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/in-person-payments/integration-api/create-payment-intent#bookmark_crea_la_intención_de_pago)
+* **Device Mode:** Debes ingresar tu Access Token de prueba y tu Device Id obtenido al [listar tus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/in-person-payments/integration-api/create-payment-intent#bookmark_obtén_el_listado_de_tus_dispositivos_disponibles).
+
+> WARNING
+>
+> Importante
+>
+> Recuerda que para utilizar el simulador debes configurar un Access Token de prueba (`TEST-XXXXX-XXXXX-XXXXXXX`) y lo puedes obtener en tus [integraciones](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/applications), opción **Mis Credenciales / Credenciales de Prueba**.
 
 ### 2. Simula una intención de pago
 
@@ -42,6 +48,11 @@ Si el paso anterior fue exitoso, puedes dar clic en la animación de la tarjeta,
 
 Si realizaste los pasos de configuración de las [notificaciones Webhooks](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/in-person-payments/integration-api/integration#bookmark_3._Prepara_y_configura_tus_notificaciones_de_Webhook), es momento de que revises tus registros. Allí verás que fue enviada la notificación del estado de la transacción.
 
+> NOTE
+>
+> Nota
+>
+> El simulador te permitirá realizar pagos de prueba, de esta forma, puedes consultar toda la información correspondiente en la sección [API de Pagos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/payments/_payments_id/get).
 
 > PREV_STEP_CARD_ES
 >

--- a/guides/in-person-payments/integration-api/point-simulator.es.md
+++ b/guides/in-person-payments/integration-api/point-simulator.es.md
@@ -16,7 +16,7 @@ Al utilizar el simulador por primera vez, deberás ingresar tus credenciales y s
 
 * **PDV mode:** debes ingresar tu `access-token` de prueba y el simulador te asignará un dispositivo virtual.
 
-* **Device Mode:** Debes ingresar tu Access Token de prueba y tu Device Id obtenido al [listar tus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/in-person-payments/integration-api/create-payment-intent#bookmark_obtén_el_listado_de_tus_dispositivos_disponibles).
+* **Device mode:** debes ingresar tu `access-token` de prueba y la Identificación del dispositivo obtenido al [listar tus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/in-person-payments/integration-api/create-payment-intent#bookmark_obtén_el_listado_de_tus_dispositivos_disponibles).
 
 > WARNING
 >

--- a/guides/in-person-payments/integration-api/point-simulator.es.md
+++ b/guides/in-person-payments/integration-api/point-simulator.es.md
@@ -5,7 +5,7 @@ Con este simulador, podrás crear una intención de pago y procesarla desde el d
 
 El simulador cuenta con dos modos de uso:
 
-* **PDV Mode**: Simula la integración de un sistema completo (dispositivo y PDV) con nuestra API de Integraciones. Ingresa al [Simulador PDV Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
+* **PDV mode**: simula la integración de un sistema completo (dispositivo y PDV) con nuestra API de Integraciones. Ingresa al [Simulador PDV mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
 * **Device Mode**: Simula un dispositivo Point virtual para que puedas probar tu integración desde los requests HTTP. Ingresa al [Simulador Device Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 
 ## Cómo usar el simulador 

--- a/guides/in-person-payments/integration-api/point-simulator.es.md
+++ b/guides/in-person-payments/integration-api/point-simulator.es.md
@@ -14,7 +14,7 @@ El simulador cuenta con dos modos de uso:
 
 Al utilizar el simulador por primera vez, deberás ingresar tus credenciales y seleccionar uno de tus dispositivos disponibles. 
 
-* **PDV Mode:** Debes ingresar tu Access Token de prueba y el simulador te asignará un dispositivo virtual.
+* **PDV mode:** debes ingresar tu `access-token` de prueba y el simulador te asignará un dispositivo virtual.
 
 * **Device Mode:** Debes ingresar tu Access Token de prueba y tu Device Id obtenido al [listar tus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/in-person-payments/integration-api/create-payment-intent#bookmark_obtén_el_listado_de_tus_dispositivos_disponibles).
 

--- a/guides/in-person-payments/integration-api/point-simulator.es.md
+++ b/guides/in-person-payments/integration-api/point-simulator.es.md
@@ -22,7 +22,7 @@ Al utilizar el simulador por primera vez, deberás ingresar tus credenciales y s
 >
 > Importante
 >
-> Recuerda que para utilizar el simulador debes configurar un Access Token de prueba (`TEST-XXXXX-XXXXX-XXXXXXX`) y lo puedes obtener en tus [integraciones](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/applications), opción **Mis Credenciales / Credenciales de Prueba**.
+> Recuerda que para utilizar el simulador debes configurar un `access-token` de prueba (`TEST-XXXXX-XXXXX-XXXXXXX`) y lo puedes obtener en tus [integraciones](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/applications), opción **Mis credenciales > Credenciales de prueba**.
 
 ### 2. Simula una intención de pago
 

--- a/guides/in-person-payments/integration-api/point-simulator.es.md
+++ b/guides/in-person-payments/integration-api/point-simulator.es.md
@@ -6,7 +6,7 @@ Con este simulador, podrás crear una intención de pago y procesarla desde el d
 El simulador cuenta con dos modos de uso:
 
 * **PDV mode**: simula la integración de un sistema completo (dispositivo y PDV) con nuestra API de Integraciones. Ingresa al [Simulador PDV mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
-* **Device Mode**: Simula un dispositivo Point virtual para que puedas probar tu integración desde los requests HTTP. Ingresa al [Simulador Device Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
+* **Device mode**: simula un dispositivo Point virtual para que puedas probar tu integración desde los requests HTTP. Ingresa al [Simulador device mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 
 ## Cómo usar el simulador 
 

--- a/guides/in-person-payments/integration-api/point-simulator.pt.md
+++ b/guides/in-person-payments/integration-api/point-simulator.pt.md
@@ -16,7 +16,7 @@ Ao usar o simulador pela primeira vez, você precisará inserir suas chaves e se
 
 * **PDV mode:** você deve inserir seu `access-token` de teste e o simulador atribuirá a você um dispositivo virtual.
 
-* **Device Mode:** Você deve inserir seu token de acesso de teste e seu ID de dispositivo obtido em [lista seus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/in-person-payments/integration-api/create-payment-intent#https://www.mercadopago.com.br/developers/pt/guides/in-person-payments/integration-api/create-payment-intent#bookmark_obtenha_a_lista_de_seus_dispositivos_dispon%C3%ADveis).
+* **Device mode:** você deve inserir seu `access-token` de teste e seu ID de dispositivo obtido em [lista seus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/in-person-payments/integration-api/create-payment-intent#https://www.mercadopago.com.br/developers/pt/guides/in-person-payments/integration-api/create-payment-intent#bookmark_obtenha_a_lista_de_seus_dispositivos_dispon%C3%ADveis).
 
 > WARNING
 >

--- a/guides/in-person-payments/integration-api/point-simulator.pt.md
+++ b/guides/in-person-payments/integration-api/point-simulator.pt.md
@@ -5,8 +5,8 @@ Com este simulador, você poderá criar uma intenção de pagamento e processá-
 
 O simulador possui dois modos de uso:
 
-* **PDV Mode**: simula a integração de um sistema completo (dispositivo e PDV) com nossa API de Integrações. Acesse o [Simulador PDV Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true)
-* **Device Mode**: simula um dispositivo de ponto virtual para que você possa testar sua integração a partir de HTTP requests. Acesse o [Simulador Device Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
+* **PDV Mode**: Simula a integração de um sistema completo (dispositivo e PDV) com nossa API de Integrações. Acesse o [Simulador PDV Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
+* **Device Mode**: Simula um dispositivo de ponto virtual para que você possa testar sua integração a partir de HTTP requests. Acesse o [Simulador Device Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 
 ## Como usar o simulador
 
@@ -14,9 +14,16 @@ O simulador possui dois modos de uso:
 
 Ao usar o simulador pela primeira vez, você precisará inserir suas chaves e selecionar um dos dispositivos disponíveis.
 
-Para usar o **PDV Mode**, você precisará de sua chave Access Token. Se você estiver usando um Access Token de teste, o simulador atribuirá a você um dispositivo virtual.
+* **PDV Mode:** Você deve inserir seu Token de Acesso de teste e o simulador atribuirá a você um dispositivo virtual.
 
-Ao usar o **Device Mode**, você deve inserir seu Access Token e sua Device ID obtida quando você [lista seus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/in-person-payments/integration-api/create-payment-intent#bookmark_criar_intenção_de_pagamento)
+* **Device Mode:** Você deve inserir seu token de acesso de teste e seu ID de dispositivo obtido em [lista seus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/in-person-payments/integration-api/create-payment-intent#https://www.mercadopago.com.br/developers/pt/guides/in-person-payments/integration-api/create-payment-intent#bookmark_obtenha_a_lista_de_seus_dispositivos_dispon%C3%ADveis).
+
+> WARNING
+>
+> Importante
+>
+> Lembre-se que para usar o simulador você deve configurar um Token de Acesso de teste(`TEST-XXXXX-XXXXX-XXXXXXX`) e você pode obtê-lo em suas [integrações](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/applications), opção **Minhas Credenciais / Credenciais de teste**.
+
 
 ### 2. Simule uma intenção de pagamento
 
@@ -41,6 +48,11 @@ Se a etapa anterior foi bem-sucedida, você pode clicar na animação do cartão
 
 Se você executou as etapas de configuração para as [notificações de Webhooks](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/in-person-payments/integration-api/integration), é hora de você revisar seus registros. Lá você verá que a notificação do status da transação foi enviada.
 
+> NOTE
+>
+> Nota
+>
+> O simulador permitirá que você faça pagamentos de teste, desta forma, você pode consultar todas as informações correspondentes na seção [API de pagamento](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/payments/_payments_id/get).
 
 > PREV_STEP_CARD_PT
 >

--- a/guides/in-person-payments/integration-api/point-simulator.pt.md
+++ b/guides/in-person-payments/integration-api/point-simulator.pt.md
@@ -6,7 +6,7 @@ Com este simulador, você poderá criar uma intenção de pagamento e processá-
 O simulador possui dois modos de uso:
 
 * **PDV mode**: simula a integração de um sistema completo (dispositivo e PDV) com nossa API de Integrações. Acesse o [Simulador PDV Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
-* **Device Mode**: Simula um dispositivo de ponto virtual para que você possa testar sua integração a partir de HTTP requests. Acesse o [Simulador Device Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
+* **Device mode**: simula um dispositivo de ponto virtual para que você possa testar sua integração a partir de HTTP requests. Acesse o [Simulador device mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 
 ## Como usar o simulador
 

--- a/guides/in-person-payments/integration-api/point-simulator.pt.md
+++ b/guides/in-person-payments/integration-api/point-simulator.pt.md
@@ -5,7 +5,7 @@ Com este simulador, você poderá criar uma intenção de pagamento e processá-
 
 O simulador possui dois modos de uso:
 
-* **PDV Mode**: Simula a integração de um sistema completo (dispositivo e PDV) com nossa API de Integrações. Acesse o [Simulador PDV Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
+* **PDV mode**: simula a integração de um sistema completo (dispositivo e PDV) com nossa API de Integrações. Acesse o [Simulador PDV Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true).
 * **Device Mode**: Simula um dispositivo de ponto virtual para que você possa testar sua integração a partir de HTTP requests. Acesse o [Simulador Device Mode](https://api.mercadopago.com/point/integrator-simulator/sandbox/device?ignoreapidoc=true).
 
 ## Como usar o simulador

--- a/guides/in-person-payments/integration-api/point-simulator.pt.md
+++ b/guides/in-person-payments/integration-api/point-simulator.pt.md
@@ -22,7 +22,7 @@ Ao usar o simulador pela primeira vez, você precisará inserir suas chaves e se
 >
 > Importante
 >
-> Lembre-se que para usar o simulador você deve configurar um Token de Acesso de teste(`TEST-XXXXX-XXXXX-XXXXXXX`) e você pode obtê-lo em suas [integrações](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/applications), opção **Minhas Credenciais / Credenciais de teste**.
+> Lembre-se que para usar o simulador você deve configurar um `access-token` de teste (`TEST-XXXXX-XXXXX-XXXXXXX`) e você pode obtê-lo em suas [integrações](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/panel/applications), opção **Minhas credenciais > Credenciais de teste**.
 
 
 ### 2. Simule uma intenção de pagamento

--- a/guides/in-person-payments/integration-api/point-simulator.pt.md
+++ b/guides/in-person-payments/integration-api/point-simulator.pt.md
@@ -14,7 +14,7 @@ O simulador possui dois modos de uso:
 
 Ao usar o simulador pela primeira vez, você precisará inserir suas chaves e selecionar um dos dispositivos disponíveis.
 
-* **PDV Mode:** Você deve inserir seu Token de Acesso de teste e o simulador atribuirá a você um dispositivo virtual.
+* **PDV mode:** você deve inserir seu `access-token` de teste e o simulador atribuirá a você um dispositivo virtual.
 
 * **Device Mode:** Você deve inserir seu token de acesso de teste e seu ID de dispositivo obtido em [lista seus dispositivos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/in-person-payments/integration-api/create-payment-intent#https://www.mercadopago.com.br/developers/pt/guides/in-person-payments/integration-api/create-payment-intent#bookmark_obtenha_a_lista_de_seus_dispositivos_dispon%C3%ADveis).
 


### PR DESCRIPTION
## Description

In our [simulator](https://api.mercadopago.com/point/integrator-simulator/sandbox/?ignoreapidoc=true) we have added a new functionality to integrate it with the Payments API.

This new functionality requires the use of the test access token and this PR documents its use, how to obtain it and where to consult the test payments.
