### PR TITLE
Adicionar campo "tarjeta de crédito" en Glosario del reporte de todas las transacciones

### DIFF
--- a/guides/manage-account/reports/account-money/glossary.en.md
+++ b/guides/manage-account/reports/account-money/glossary.en.md
@@ -45,6 +45,7 @@ We know, some terms are technical and you may not be familiar with all of them. 
 | POI_ID | Point ID if payment is made through a physical retailer. |
 | POI_WALLET_NAME | Name of the digital wallet that a virtual payment comes from. Allows you to identify the origin of a transaction when you charge with a Mercado Pago QR Code.|
 | POI_BANK_NAME | Name of the bank that a virtual payment comes from. Allows you to identify the origin of a transaction when you charge with a Mercado Pago QR Code.|
+| CARD_INITIAL_NUMBER | It corresponds to the first digits of the credit or debit card that you used to make the purchase. |
 
 <hr/>
 

--- a/guides/manage-account/reports/account-money/glossary.es.md
+++ b/guides/manage-account/reports/account-money/glossary.es.md
@@ -43,6 +43,7 @@ Lo sabemos, algunos términos son técnicos y puede que no estés familiarizado 
 | PACK_ID | ----[mla, mlm]---- Identificador del paquete en el carrito. ------------ |
 | TAXES_DISAGGREGATED | Impuestos desagregados en formato JSON. |
 | POI_ID | ID del lector si el pago se realiza a través de un comercio físico. |
+| CARD_INITIAL_NUMBER | Corresponde a los primeros dígitos de la tarjeta crédito o débito con la que se hizo la compra. |
 | POI_WALLET_NAME | Nombre de la billetera virtual desde la que se origina un pago digital. Permite identificar el origen de una operación cuando cobras con un ----[mla]----[código QR interoperable](https://vendedores.mercadolibre.com.ar/nota/cobra-a-otras-billeteras-con-tu-qr-de-mercado-pago)------------ ----[mlu, mpe, mlm, mco, mlc, mlb]----código QR de Mercado Pago------------.|
 | POI_BANK_NAME | Nombre de la entidad bancaria desde la que se origina un pago digital. Permite identificar el origen de una operación cuando cobras con un ----[mla]----[código QR interoperable](https://vendedores.mercadolibre.com.ar/nota/cobra-a-otras-billeteras-con-tu-qr-de-mercado-pago)------------ ----[mlu, mpe, mlm, mco, mlc, mlb]----código QR de Mercado Pago------------.|
 

--- a/guides/manage-account/reports/account-money/glossary.es.md
+++ b/guides/manage-account/reports/account-money/glossary.es.md
@@ -43,9 +43,9 @@ Lo sabemos, algunos términos son técnicos y puede que no estés familiarizado 
 | PACK_ID | ----[mla, mlm]---- Identificador del paquete en el carrito. ------------ |
 | TAXES_DISAGGREGATED | Impuestos desagregados en formato JSON. |
 | POI_ID | ID del lector si el pago se realiza a través de un comercio físico. |
-| CARD_INITIAL_NUMBER | Corresponde a los primeros dígitos de la tarjeta crédito o débito con la que se hizo la compra. |
 | POI_WALLET_NAME | Nombre de la billetera virtual desde la que se origina un pago digital. Permite identificar el origen de una operación cuando cobras con un ----[mla]----[código QR interoperable](https://vendedores.mercadolibre.com.ar/nota/cobra-a-otras-billeteras-con-tu-qr-de-mercado-pago)------------ ----[mlu, mpe, mlm, mco, mlc, mlb]----código QR de Mercado Pago------------.|
 | POI_BANK_NAME | Nombre de la entidad bancaria desde la que se origina un pago digital. Permite identificar el origen de una operación cuando cobras con un ----[mla]----[código QR interoperable](https://vendedores.mercadolibre.com.ar/nota/cobra-a-otras-billeteras-con-tu-qr-de-mercado-pago)------------ ----[mlu, mpe, mlm, mco, mlc, mlb]----código QR de Mercado Pago------------.|
+| CARD_INITIAL_NUMBER | Corresponde a los primeros dígitos de la tarjeta crédito o débito con la que se hizo la compra. |
 
 <hr/>
 

--- a/guides/manage-account/reports/account-money/glossary.pt.md
+++ b/guides/manage-account/reports/account-money/glossary.pt.md
@@ -46,6 +46,7 @@ Sabemos que alguns termos são técnicos e você pode não estar familiarizado c
 | POI_BANK_NAME | Nome da instituição bancária de onde um pagamento virtual saiu. Permite identificar a origem de uma transação quando você cobra com um código QR do Mercado Pago.|
 | DESCRIPTION | Ajuda a identificar transações ou operações registradas em um período de tempo.<br> Quando se tratar de pagamento parcelado, a linha será identificada como "INSTALLMENT".|
 | MONEY_RELEASE_DATE | Data de previsão da liberação do pagamento de cada parcela ou da parcela única.|
+| CARD_INITIAL_NUMBER | Corresponde aos primeiros dígitos do cartão de crédito ou débito que você usou para fazer a compra. |
 ----[mlb]----| INSTALLMENT_NUMBER* | Indica o número da parcela que será paga, do total de parcelas contratadas.<br> Essa informação aparece quando o cliente solicita o parcelamento da compra.<br> Por exemplo: 2 / 5 indica o pagamento da segunda parcela, de um total das 5 parcelas contratadas.<br> Quando o pagamento é liberado em uma única parcela essa coluna não estará preenchida.|------------
 ----[mlb]----| INSTALLMENT_NET_AMOUNT* | Mostra o valor líquido da parcela que será paga.<br> Essa informação aparece quando o cliente escolhe pagar o valor total da compra em parcelas mensais. |------------
 

--- a/guides/manage-account/reports/account-money/glossary.pt.md
+++ b/guides/manage-account/reports/account-money/glossary.pt.md
@@ -46,7 +46,7 @@ Sabemos que alguns termos são técnicos e você pode não estar familiarizado c
 | POI_BANK_NAME | Nome da instituição bancária de onde um pagamento virtual saiu. Permite identificar a origem de uma transação quando você cobra com um código QR do Mercado Pago.|
 | DESCRIPTION | Ajuda a identificar transações ou operações registradas em um período de tempo.<br> Quando se tratar de pagamento parcelado, a linha será identificada como "INSTALLMENT".|
 | MONEY_RELEASE_DATE | Data de previsão da liberação do pagamento de cada parcela ou da parcela única.|
-| CARD_INITIAL_NUMBER | Corresponde aos primeiros dígitos do cartão de crédito ou débito que você usou para fazer a compra. |
+| CARD_INITIAL_NUMBER | Corresponde aos primeiros dígitos do cartão de crédito ou débito utilizado para fazer a compra. |
 ----[mlb]----| INSTALLMENT_NUMBER* | Indica o número da parcela que será paga, do total de parcelas contratadas.<br> Essa informação aparece quando o cliente solicita o parcelamento da compra.<br> Por exemplo: 2 / 5 indica o pagamento da segunda parcela, de um total das 5 parcelas contratadas.<br> Quando o pagamento é liberado em uma única parcela essa coluna não estará preenchida.|------------
 ----[mlb]----| INSTALLMENT_NET_AMOUNT* | Mostra o valor líquido da parcela que será paga.<br> Essa informação aparece quando o cliente escolhe pagar o valor total da compra em parcelas mensais. |------------
 


### PR DESCRIPTION
## Description

Se agrega nueva columna al Reporte de todas las transacciones, para mostrar al seller algunos dígitos de la tarjeta de crédito (si aplica) usada por un cliente al momento de realizar la compra. Como fuente de datos se usan los 6 primeros dígitos de la tarjeta.
