### PR TITLE
Release v4.10.0 - Prestashop and v3.15.0 - Magento 2

### DIFF
--- a/guides/resources/changelog/current-year.en.md
+++ b/guides/resources/changelog/current-year.en.md
@@ -4,6 +4,46 @@ Find out everything about the new versions and updates of Mercado Pago integrati
 
 ---
 
+## March 2022
+
+### March 21st
+
+> CHANGELOG
+>
+> New PrestaShop plugin version
+>
+> NEW_VERSION: NEW VERSION
+>
+> PRODUCT: PRESTASHOP
+
+We have released the new version 4.10.0 for PrestaShop.
+
+[Go to PrestaShop documentation](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/plugins/prestashop/introduction)
+
+> GIT
+>
+> GitHub
+>
+> [Check GitHub](https://github.com/mercadopago/cart-prestashop-7/releases/tag/v4.10.0) for further details regarding this release.
+
+> CHANGELOG
+>
+> New Magento 2 plugin version
+>
+> NEW_VERSION: NEW VERSION
+>
+> PRODUCT: MAGENTO 2
+
+We have released the new version 3.15.0 for Magento 2.
+
+[Go to Magento 2 documentation](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/plugins/official/magento-two)
+
+> GIT
+>
+> GitHub
+>
+> [Check GitHub](https://github.com/mercadopago/cart-magento2/releases/tag/v3.15.0) for further details regarding this release.
+
 ## February 2022
 
 ### February 14th

--- a/guides/resources/changelog/current-year.en.md
+++ b/guides/resources/changelog/current-year.en.md
@@ -36,7 +36,7 @@ We have released the new version 4.10.0 for PrestaShop.
 
 We have released the new version 3.15.0 for Magento 2.
 
-[Go to Magento 2 documentation](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/plugins/official/magento-two)
+[Go to Magento 2 documentation](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/plugins/magento-two/introduction)
 
 > GIT
 >

--- a/guides/resources/changelog/current-year.es.md
+++ b/guides/resources/changelog/current-year.es.md
@@ -4,6 +4,46 @@ Entérate todo sobre las nuevas versiones y actualizaciones de las integraciones
 
 ---
 
+## Marzo 2022
+
+### 21 de marzo
+
+> CHANGELOG
+>
+> Nueva versión PrestaShop
+>
+> NEW_VERSION: NUEVA VERSIÓN
+>
+> PRODUCT: PRESTASHOP
+
+Lanzamos la nueva versión 4.10.0 para PrestaShop.
+
+[Ir a documentación de PrestaShop](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/plugins/prestashop/introduction)
+
+> GIT
+>
+> GitHub
+>
+> Consulta en GitHub el detalle de los [últimos cambios productivos](https://github.com/mercadopago/cart-prestashop-7/releases/tag/v4.10.0).
+
+> CHANGELOG
+>
+> Nueva versión Magento 2
+>
+> NEW_VERSION: NUEVA VERSIÓN
+>
+> PRODUCT: MAGENTO 2
+
+Lanzamos la nueva versión 3.15.0 para Magento 2.
+
+[Ir a documentación de Magento 2](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/plugins/official/magento-two)
+
+> GIT
+>
+> GitHub
+>
+> Consulta en GitHub el detalle de los [últimos cambios productivos](https://github.com/mercadopago/cart-magento2/releases/tag/v3.15.0).
+
 ## Febrero 2022
 
 ### 14 de febrero

--- a/guides/resources/changelog/current-year.es.md
+++ b/guides/resources/changelog/current-year.es.md
@@ -36,7 +36,7 @@ Lanzamos la nueva versión 4.10.0 para PrestaShop.
 
 Lanzamos la nueva versión 3.15.0 para Magento 2.
 
-[Ir a documentación de Magento 2](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/plugins/official/magento-two)
+[Ir a documentación de Magento 2](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/plugins/magento-two/introduction)
 
 > GIT
 >

--- a/guides/resources/changelog/current-year.pt.md
+++ b/guides/resources/changelog/current-year.pt.md
@@ -36,7 +36,7 @@ Lançamos a nova versão 4.10.0 para PrestaShop.
 
 Lançamos a nova versão 3.15.0 para Magento 2.
 
-[Ir para a documentação de Magento 2](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/plugins/official/magento-two)
+[Ir para a documentação de Magento 2](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/plugins/magento-two/introduction)
 
 > GIT
 >

--- a/guides/resources/changelog/current-year.pt.md
+++ b/guides/resources/changelog/current-year.pt.md
@@ -4,6 +4,46 @@ Descubra tudo sobre as novas versões e atualizações das integrações do Merc
 
 ---
 
+## Março 2022
+
+### 21 de março
+
+> CHANGELOG
+>
+> Nova versão PrestaShop
+>
+> NEW_VERSION: NOVA VERSÃO
+>
+> PRODUCT: PRESTASHOP
+
+Lançamos a nova versão 4.10.0 para PrestaShop.
+
+[Ir para a documentação de PrestaShop](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/plugins/prestashop/introduction)
+
+> GIT
+>
+> GitHub
+>
+> Confira no GitHub o detalhe das [últimas atualizações produtivas](https://github.com/mercadopago/cart-prestashop-7/releases/tag/v4.10.0)
+
+> CHANGELOG
+>
+> Nova versão Magento 2
+>
+> NEW_VERSION: NOVA VERSÃO
+>
+> PRODUCT: MAGENTO 2
+
+Lançamos a nova versão 3.15.0 para Magento 2.
+
+[Ir para a documentação de Magento 2](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/plugins/official/magento-two)
+
+> GIT
+>
+> GitHub
+>
+> Confira no GitHub o detalhe das [últimas atualizações produtivas](https://github.com/mercadopago/cart-magento2/releases/tag/v3.15.0).
+
 ## Fevereiro 2022
 
 ### 14 de fevereiro


### PR DESCRIPTION
## Description
New version of Prestashop and Magento 2.
New versions have been communicated in the changelog.
