### PR TITLE
fix/preferences sdks update

### DIFF
--- a/guides/sdks/official/dotnet/preferences.en.md
+++ b/guides/sdks/official/dotnet/preferences.en.md
@@ -2,28 +2,72 @@
 
 It is possible to create Preferences using the SDK below. For details on request parameters, check the [Create preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post) API.
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
 ```dotnet
+// Mercado Pago SDK
+using MercadoPago.Config;
+using MercadoPago.Client.Preference;
+using MercadoPago.Resource.Preference;
+
+// Add Your credentials
+MercadoPagoConfig.AccessToken = "PROD_ACCESS_TOKEN";
+
+// Create the preference request object
 var request = new PreferenceRequest
 {
     Items = new List<PreferenceItemRequest>
     {
         new PreferenceItemRequest
         {
-            Id = "1234",
-            Title = "Blue shirt",
-            Quantity = 10,
+            Title = "My Item",
+            Quantity = 1,
             CurrencyId = "[FAKER][CURRENCY][ACRONYM]",
-            UnitPrice = [FAKER][COMMERCE][PRICE]m,
+            UnitPrice = 75.56m,
         },
     },
-    Payer = new PreferencePayerRequest
-    {
-        Email = "john@yourdomain.com",
-    },
 };
+
+// Create the preference using the client
 var client = new PreferenceClient();
 Preference preference = await client.CreateAsync(request);
-
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```dotnet
+// Mercado Pago SDK
+using MercadoPago.Config;
+using MercadoPago.Client.Preference;
+using MercadoPago.Resource.Preference;
+
+// Add Your credentials
+MercadoPagoConfig.AccessToken = "PROD_ACCESS_TOKEN";
+
+// Create the preference request object
+var request = new PreferenceRequest
+{
+    Items = new List<PreferenceItemRequest>
+    {
+        new PreferenceItemRequest
+        {
+            Title = "My Item",
+            Quantity = 1,
+            CurrencyId = "[FAKER][CURRENCY][ACRONYM]",
+            UnitPrice = 75m,
+        },
+    },
+};
+
+// Create the preference using the client
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]
+
+------------

--- a/guides/sdks/official/dotnet/preferences.es.md
+++ b/guides/sdks/official/dotnet/preferences.es.md
@@ -2,29 +2,72 @@
 
 Es posible crear preferencias utilizando lo SDK a continuación. Para obtener detalles sobre los parámetros de la solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
 
 [[[
 ```dotnet
+// SDK de Mercado Pago
+using MercadoPago.Config;
+using MercadoPago.Client.Preference;
+using MercadoPago.Resource.Preference;
+
+// Agrega credenciales
+MercadoPagoConfig.AccessToken = "PROD_ACCESS_TOKEN";
+
+// Crea el objeto de request de la preference
 var request = new PreferenceRequest
 {
     Items = new List<PreferenceItemRequest>
     {
         new PreferenceItemRequest
         {
-            Id = "1234",
-            Title = "Blue shirt",
-            Quantity = 10,
+            Title = "Mi producto",
+            Quantity = 1,
             CurrencyId = "[FAKER][CURRENCY][ACRONYM]",
-            UnitPrice = [FAKER][COMMERCE][PRICE]m,
+            UnitPrice = 75.56m,
         },
     },
-    Payer = new PreferencePayerRequest
-    {
-        Email = "john@yourdomain.com",
-    },
 };
+
+// Crea la preferencia usando el client
 var client = new PreferenceClient();
 Preference preference = await client.CreateAsync(request);
-
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```dotnet
+// SDK de Mercado Pago
+using MercadoPago.Config;
+using MercadoPago.Client.Preference;
+using MercadoPago.Resource.Preference;
+
+// Agrega credenciales
+MercadoPagoConfig.AccessToken = "PROD_ACCESS_TOKEN";
+
+// Crea el objeto de request de la preference
+var request = new PreferenceRequest
+{
+    Items = new List<PreferenceItemRequest>
+    {
+        new PreferenceItemRequest
+        {
+            Title = "Mi producto",
+            Quantity = 1,
+            CurrencyId = "[FAKER][CURRENCY][ACRONYM]",
+            UnitPrice = 75m,
+        },
+    },
+};
+
+// Crea la preferencia usando el client
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]
+
+------------

--- a/guides/sdks/official/dotnet/preferences.pt.md
+++ b/guides/sdks/official/dotnet/preferences.pt.md
@@ -2,29 +2,72 @@
 
 É possível criar uma preferência utilizando o SDK abaixo. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
 
 [[[
 ```dotnet
+// SDK do Mercado Pago
+using MercadoPago.Config;
+using MercadoPago.Client.Preference;
+using MercadoPago.Resource.Preference;
+
+// Configure as credenciais
+MercadoPagoConfig.AccessToken = "PROD_ACCESS_TOKEN";
+
+// Crie o objeto de request da preferência
 var request = new PreferenceRequest
 {
     Items = new List<PreferenceItemRequest>
     {
         new PreferenceItemRequest
         {
-            Id = "1234",
-            Title = "Blue shirt",
-            Quantity = 10,
+            Title = "Meu produto",
+            Quantity = 1,
             CurrencyId = "[FAKER][CURRENCY][ACRONYM]",
-            UnitPrice = [FAKER][COMMERCE][PRICE]m,
+            UnitPrice = 75.56m,
         },
     },
-    Payer = new PreferencePayerRequest
-    {
-        Email = "john@yourdomain.com",
-    },
 };
+
+// Crie a preferência usando o client
 var client = new PreferenceClient();
 Preference preference = await client.CreateAsync(request);
-
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```dotnet
+// SDK do Mercado Pago
+using MercadoPago.Config;
+using MercadoPago.Client.Preference;
+using MercadoPago.Resource.Preference;
+
+// Configure as credenciais
+MercadoPagoConfig.AccessToken = "PROD_ACCESS_TOKEN";
+
+// Crie o objeto de request da preferência
+var request = new PreferenceRequest
+{
+    Items = new List<PreferenceItemRequest>
+    {
+        new PreferenceItemRequest
+        {
+            Title = "Meu produto",
+            Quantity = 1,
+            CurrencyId = "[FAKER][CURRENCY][ACRONYM]",
+            UnitPrice = 75m,
+        },
+    },
+};
+
+// Crie a preferência usando o client
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]
+
+------------

--- a/guides/sdks/official/java/preferences.en.md
+++ b/guides/sdks/official/java/preferences.en.md
@@ -5,27 +5,29 @@ You can create a preference using the SDK below. For details of the request para
 [[[
 ```java
 
+// Mercado Pago SDK
+import com.mercadopago.MercadoPagoConfig;
+
+// Configure credentials
+MercadoPagoConfig.setAccessToken("PROD_ACCESS_TOKEN");
+
+// Create a client from the Preference API
 PreferenceClient client = new PreferenceClient();
 
+// Create an item to add to the preference
 List<PreferenceItemRequest> items = new ArrayList<>();
 PreferenceItemRequest item =
    PreferenceItemRequest.builder()
-       .title("Dummy Title")
-       .description("Dummy description")
-       .pictureUrl("http://www.myapp.com/myimage.jpg")
+       .title("Meu produto")
        .quantity(1)
-       .currencyId("US")
-       .unitPrice(new BigDecimal("10"))
+       .unitPrice(new BigDecimal("100"))
        .build();
 items.add(item);
 
-List<PreferenceTrackRequest> tracks = new ArrayList<>();
-PreferenceTrackRequest googleTrack = PreferenceTrackRequest.builder().type("google_ad").build();
+// Associate the item with the preference
+PreferenceRequest request = PreferenceRequest.builder().items(items).build();
 
-tracks.add(googleTrack);
-
-PreferenceRequest request = PreferenceRequest.builder().items(items).tracks(tracks).build();
-
+// Save the preference
 client.create(request);
 
 ```

--- a/guides/sdks/official/java/preferences.es.md
+++ b/guides/sdks/official/java/preferences.es.md
@@ -5,27 +5,29 @@ Puede crear una preferencia usando el SDK a continuación. Para obtener detalles
 [[[
 ```java
 
+// SDK de Mercado Pago
+import com.mercadopago.MercadoPagoConfig;
+
+// Configurar credenciales
+MercadoPagoConfig.setAccessToken("PROD_ACCESS_TOKEN");
+
+// Crear un cliente de la API de preferencias
 PreferenceClient client = new PreferenceClient();
 
+// Crear un ítem para agregar a la preferencia
 List<PreferenceItemRequest> items = new ArrayList<>();
 PreferenceItemRequest item =
    PreferenceItemRequest.builder()
-       .title("Dummy Title")
-       .description("Dummy description")
-       .pictureUrl("http://www.myapp.com/myimage.jpg")
+       .title("Meu produto")
        .quantity(1)
-       .currencyId("US")
-       .unitPrice(new BigDecimal("10"))
+       .unitPrice(new BigDecimal("100"))
        .build();
 items.add(item);
 
-List<PreferenceTrackRequest> tracks = new ArrayList<>();
-PreferenceTrackRequest googleTrack = PreferenceTrackRequest.builder().type("google_ad").build();
+// Asociar el ítem con la preferencia
+PreferenceRequest request = PreferenceRequest.builder().items(items).build();
 
-tracks.add(googleTrack);
-
-PreferenceRequest request = PreferenceRequest.builder().items(items).tracks(tracks).build();
-
+// Guardar la preferencia
 client.create(request);
 
 ```

--- a/guides/sdks/official/java/preferences.pt.md
+++ b/guides/sdks/official/java/preferences.pt.md
@@ -5,27 +5,29 @@
 [[[
 ```java
 
+// SDK do Mercado Pago
+import com.mercadopago.MercadoPagoConfig;
+
+// Configure as credenciais
+MercadoPagoConfig.setAccessToken("PROD_ACCESS_TOKEN");
+
+// Crie um cliente da API de preferência
 PreferenceClient client = new PreferenceClient();
 
+// Crie um item para adicionar à preferência
 List<PreferenceItemRequest> items = new ArrayList<>();
 PreferenceItemRequest item =
    PreferenceItemRequest.builder()
-       .title("Dummy Title")
-       .description("Dummy description")
-       .pictureUrl("http://www.myapp.com/myimage.jpg")
+       .title("Meu produto")
        .quantity(1)
-       .currencyId("US")
-       .unitPrice(new BigDecimal("10"))
+       .unitPrice(new BigDecimal("100"))
        .build();
 items.add(item);
 
-List<PreferenceTrackRequest> tracks = new ArrayList<>();
-PreferenceTrackRequest googleTrack = PreferenceTrackRequest.builder().type("google_ad").build();
+// Associe o item à preferência
+PreferenceRequest request = PreferenceRequest.builder().items(items).build();
 
-tracks.add(googleTrack);
-
-PreferenceRequest request = PreferenceRequest.builder().items(items).tracks(tracks).build();
-
+// Salve a preferência
 client.create(request);
 
 ```

--- a/guides/sdks/official/nodejs/preferences.en.md
+++ b/guides/sdks/official/nodejs/preferences.en.md
@@ -2,13 +2,23 @@
 
 It is possible to create Preferences using the SDK below. For details on request parameters, check the [Create preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post) API.
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
 ```node
-// Cria um objeto de preferência
+// Mercado Pago SDK
+const mercadopago = require ('mercadopago');
+
+// Add Your credentials
+mercadopago.configure({
+  access_token: 'PROD_ACCESS_TOKEN'
+});
+
+// Create a preference object
 let preference = {
   items: [
     {
-      title: 'Meu produto',
+      title: 'My Item',
       unit_price: 100,
       quantity: 1,
     }
@@ -17,10 +27,47 @@ let preference = {
 
 mercadopago.preferences.create(preference)
 .then(function(response){
-// Este valor substituirá a string "<%= global.id %>" no seu HTML
+// This value replaces the String "<%= global.id %>" in your HTML
   global.id = response.body.id;
 }).catch(function(error){
   console.log(error);
 });
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```node
+// Mercado Pago SDK
+const mercadopago = require ('mercadopago');
+
+// Add Your credentials
+mercadopago.configure({
+  access_token: 'PROD_ACCESS_TOKEN'
+});
+
+// Create a preference object
+let preference = {
+  items: [
+    {
+      title: 'My Item',
+      unit_price: 100,
+      quantity: 1,
+    }
+  ]
+};
+
+mercadopago.preferences.create(preference)
+.then(function(response){
+// This value replaces the String "<%= global.id %>" in your HTML
+  global.id = response.body.id;
+}).catch(function(error){
+  console.log(error);
+});
+```
+]]]
+
+------------

--- a/guides/sdks/official/nodejs/preferences.es.md
+++ b/guides/sdks/official/nodejs/preferences.es.md
@@ -2,13 +2,23 @@
 
 Es posible crear preferencias utilizando lo SDK a continuación. Para obtener detalles sobre los parámetros de la solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
 ```node
-// Cria um objeto de preferência
+// SDK de Mercado Pago
+const mercadopago = require ('mercadopago');
+
+// Agrega credenciales
+mercadopago.configure({
+  access_token: 'PROD_ACCESS_TOKEN'
+});
+
+// Crea un objeto de preferencia
 let preference = {
   items: [
     {
-      title: 'Meu produto',
+      title: 'Mi producto',
       unit_price: 100,
       quantity: 1,
     }
@@ -17,10 +27,47 @@ let preference = {
 
 mercadopago.preferences.create(preference)
 .then(function(response){
-// Este valor substituirá a string "<%= global.id %>" no seu HTML
+// Este valor reemplazará el string "<%= global.id %>" en tu HTML
   global.id = response.body.id;
 }).catch(function(error){
   console.log(error);
 });
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```node
+// SDK de Mercado Pago
+const mercadopago = require ('mercadopago');
+
+// Agrega credenciales
+mercadopago.configure({
+  access_token: 'PROD_ACCESS_TOKEN'
+});
+
+// Crea un objeto de preferencia
+let preference = {
+  items: [
+    {
+      title: 'Mi producto',
+      unit_price: 100,
+      quantity: 1,
+    }
+  ]
+};
+
+mercadopago.preferences.create(preference)
+.then(function(response){
+// Este valor reemplazará el string "<%= global.id %>" en tu HTML
+  global.id = response.body.id;
+}).catch(function(error){
+  console.log(error);
+});
+```
+]]]
+
+------------

--- a/guides/sdks/official/nodejs/preferences.pt.md
+++ b/guides/sdks/official/nodejs/preferences.pt.md
@@ -2,9 +2,19 @@
 
 É possível criar uma preferência utilizando o SDK abaixo. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
 ```node
-// Cria um objeto de preferência
+// SDK do Mercado Pago
+const mercadopago = require ('mercadopago');
+
+// Configure as credenciais
+mercadopago.configure({
+  access_token: 'PROD_ACCESS_TOKEN'
+});
+
+// Crie um objeto de preferência
 let preference = {
   items: [
     {
@@ -24,3 +34,40 @@ mercadopago.preferences.create(preference)
 });
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```node
+// SDK de Mercado Pago
+const mercadopago = require ('mercadopago');
+
+// Configure as credenciais
+mercadopago.configure({
+  access_token: 'PROD_ACCESS_TOKEN'
+});
+
+// Crie um objeto de preferência
+let preference = {
+  items: [
+    {
+      title: 'Meu produto',
+      unit_price: 100,
+      quantity: 1,
+    }
+  ]
+};
+
+mercadopago.preferences.create(preference)
+.then(function(response){
+// Este valor substituirá a string "<%= global.id %>" no seu HTML
+  global.id = response.body.id;
+}).catch(function(error){
+  console.log(error);
+});
+```
+]]]
+
+------------

--- a/guides/sdks/official/php/preferences.en.md
+++ b/guides/sdks/official/php/preferences.en.md
@@ -2,23 +2,56 @@
 
 It is possible to create Preferences using the SDK below. For details on request parameters, check the [Create preferences](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post) API.
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
-```php
+ ```php
 <?php
-  $preference = new MercadoPago\Preference();
+// Mercado Pago SDK
+require __DIR__ .  '/vendor/autoload.php';
 
-  $item = new MercadoPago\Item();
-  $item->title = "Blue shirt";
-  $item->quantity = 10;
-  $item->currency_id = "[FAKER][CURRENCY][ACRONYM]";
-  $item->unit_price = [FAKER][COMMERCE][PRICE];
+// Add Your credentials
+MercadoPago\SDK::setAccessToken('PROD_ACCESS_TOKEN');
 
-  $payer = new MercadoPago\Payer();
-  $payer->email = "test_user_19653727@testuser.com";
+// Create a preference object
+$preference = new MercadoPago\Preference();
 
-  $preference->items = array($item);
-  $preference->payer = $payer;
-  $preference->save();
+// Create a preference item
+$item = new MercadoPago\Item();
+$item->title = 'My Item';
+$item->quantity = 1;
+$item->unit_price = 75.56;
+$preference->items = array($item);
+$preference->save();
 ?>
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+ ```php
+<?php
+// Mercado Pago SDK
+require __DIR__ .  '/vendor/autoload.php';
+
+// Add Your credentials
+MercadoPago\SDK::setAccessToken('PROD_ACCESS_TOKEN');
+
+// Create a preference object
+$preference = new MercadoPago\Preference();
+
+// Create a preference item
+$item = new MercadoPago\Item();
+$item->title = 'My Item';
+$item->quantity = 1;
+$item->unit_price = 75;
+$preference->items = array($item);
+$preference->save();
+?>
+```
+]]]
+
+------------

--- a/guides/sdks/official/php/preferences.es.md
+++ b/guides/sdks/official/php/preferences.es.md
@@ -2,23 +2,56 @@
 
 Es posible crear preferencias utilizando lo SDK a continuación. Para obtener detalles sobre los parámetros de la solicitud, consulte la API [Crear preferencias](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
-```php
+ ```php
 <?php
-  $preference = new MercadoPago\Preference();
+// SDK de Mercado Pago
+require __DIR__ .  '/vendor/autoload.php';
 
-  $item = new MercadoPago\Item();
-  $item->title = "Blue shirt";
-  $item->quantity = 10;
-  $item->currency_id = "[FAKER][CURRENCY][ACRONYM]";
-  $item->unit_price = [FAKER][COMMERCE][PRICE];
+// Agrega credenciales
+MercadoPago\SDK::setAccessToken('PROD_ACCESS_TOKEN');
 
-  $payer = new MercadoPago\Payer();
-  $payer->email = "test_user_19653727@testuser.com";
+// Crea un objeto de preferencia
+$preference = new MercadoPago\Preference();
 
-  $preference->items = array($item);
-  $preference->payer = $payer;
-  $preference->save();
+// Crea un ítem en la preferencia
+$item = new MercadoPago\Item();
+$item->title = 'Mi producto';
+$item->quantity = 1;
+$item->unit_price = 75.56;
+$preference->items = array($item);
+$preference->save();
 ?>
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+ ```php
+<?php
+// SDK de Mercado Pago
+require __DIR__ .  '/vendor/autoload.php';
+
+// Agrega credenciales
+MercadoPago\SDK::setAccessToken('PROD_ACCESS_TOKEN');
+
+// Crea un objeto de preferencia
+$preference = new MercadoPago\Preference();
+
+// Crea un ítem en la preferencia
+$item = new MercadoPago\Item();
+$item->title = 'Mi producto';
+$item->quantity = 1;
+$item->unit_price = 75;
+$preference->items = array($item);
+$preference->save();
+?>
+```
+]]]
+
+------------

--- a/guides/sdks/official/php/preferences.pt.md
+++ b/guides/sdks/official/php/preferences.pt.md
@@ -2,23 +2,56 @@
 
 É possível criar uma preferência utilizando o SDK abaixo. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
-```php
+ ```php
 <?php
-  $preference = new MercadoPago\Preference();
+// SDK do Mercado Pago
+require __DIR__ .  '/vendor/autoload.php';
 
-  $item = new MercadoPago\Item();
-  $item->title = "Blue shirt";
-  $item->quantity = 10;
-  $item->currency_id = "[FAKER][CURRENCY][ACRONYM]";
-  $item->unit_price = [FAKER][COMMERCE][PRICE];
+// Configure as credenciais
+MercadoPago\SDK::setAccessToken('PROD_ACCESS_TOKEN');
 
-  $payer = new MercadoPago\Payer();
-  $payer->email = "test_user_19653727@testuser.com";
+// Crie um objeto de preferência
+$preference = new MercadoPago\Preference();
 
-  $preference->items = array($item);
-  $preference->payer = $payer;
-  $preference->save();
+// Crie um item na preferência
+$item = new MercadoPago\Item();
+$item->title = 'Meu produto';
+$item->quantity = 1;
+$item->unit_price = 75.56;
+$preference->items = array($item);
+$preference->save();
 ?>
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+ ```php
+<?php
+// SDK de Mercado Pago
+require __DIR__ .  '/vendor/autoload.php';
+
+// Configura credenciais
+MercadoPago\SDK::setAccessToken('PROD_ACCESS_TOKEN');
+
+// Cria um objeto de preferência
+$preference = new MercadoPago\Preference();
+
+// Cria um item na preferência
+$item = new MercadoPago\Item();
+$item->title = 'Meu produto';
+$item->quantity = 1;
+$item->unit_price = 75;
+$preference->items = array($item);
+$preference->save();
+?>
+```
+]]]
+
+------------

--- a/guides/sdks/official/python/preferences.en.md
+++ b/guides/sdks/official/python/preferences.en.md
@@ -2,19 +2,59 @@
 
 It is possible to create Preferences using the SDK below. For details on request parameters, check the [Create preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post) API.
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
 ```python
+# Mercado Pago SDK
+import mercadopago
+
+# Add Your credentials
+sdk = mercadopago.SDK("PROD_ACCESS_TOKEN")
+
+# Create a preference item
 preference_data = {
-    "title": "Blue shirt",
-    "quantity": 1,
-    "currency_id": "[FAKER][CURRENCY][ACRONYM]",
-    "unit_price": [FAKER][COMMERCE][PRICE],
-    "payer": {
-        "email": "john@yourdomain.com"
-    }
+    "items": [
+        {
+            "title": "My Item",
+            "quantity": 1,
+            "unit_price": 75.76
+        }
+    ]
 }
 
 preference_response = sdk.preference().create(preference_data)
 preference = preference_response["response"]
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```python
+# Mercado Pago SDK
+import mercadopago
+
+# Add Your credentials
+sdk = mercadopago.SDK("PROD_ACCESS_TOKEN")
+
+# Create a preference object
+preference_data = {
+    "items": [
+        {
+            "title": "My Item",
+            "quantity": 1,
+            "unit_price": 75
+            
+        }
+    ]
+}
+
+preference_response = sdk.preference().create(preference_data)
+preference = preference_response["response"]
+```
+]]]
+
+------------

--- a/guides/sdks/official/python/preferences.es.md
+++ b/guides/sdks/official/python/preferences.es.md
@@ -2,19 +2,58 @@
 
 Es posible crear preferencias utilizando lo SDK a continuación. Para obtener detalles sobre los parámetros de la solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
 ```python
+# SDK de Mercado Pago
+import mercadopago
+
+# Agrega credenciales
+sdk = mercadopago.SDK("PROD_ACCESS_TOKEN")
+
+# Crea un ítem en la preferencia
 preference_data = {
-    "title": "Blue shirt",
-    "quantity": 1,
-    "currency_id": "[FAKER][CURRENCY][ACRONYM]",
-    "unit_price": [FAKER][COMMERCE][PRICE],
-    "payer": {
-        "email": "john@yourdomain.com"
-    }
+    "items": [
+        {
+            "title": "Mi producto",
+            "quantity": 1,
+            "unit_price": 75.76,
+        }
+    ]
 }
 
 preference_response = sdk.preference().create(preference_data)
 preference = preference_response["response"]
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```python
+# SDK de Mercado Pago
+import mercadopago
+
+# Add Your credentials
+sdk = mercadopago.SDK("PROD_ACCESS_TOKEN")
+
+# Crea un ítem en la preferencia
+preference_data = {
+    "items": [
+        {
+            "title": "Mi producto",
+            "quantity": 1,
+            "unit_price": 75
+        }
+    ]
+}
+
+preference_response = sdk.preference().create(preference_data)
+preference = preference_response["response"]
+```
+]]]
+
+------------

--- a/guides/sdks/official/python/preferences.pt.md
+++ b/guides/sdks/official/python/preferences.pt.md
@@ -2,19 +2,58 @@
 
 É possível criar uma preferência utilizando o SDK abaixo. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
 ```python
+# SDK do Mercado Pago
+import mercadopago
+
+# Configure as credenciais
+sdk = mercadopago.SDK("PROD_ACCESS_TOKEN")
+
+# Crie um item na preferência
 preference_data = {
-    "title": "Blue shirt",
-    "quantity": 1,
-    "currency_id": "[FAKER][CURRENCY][ACRONYM]",
-    "unit_price": [FAKER][COMMERCE][PRICE],
-    "payer": {
-        "email": "john@yourdomain.com"
-    }
+    "items": [
+        {
+            "title": "My Item",
+            "quantity": 1,
+            "unit_price": 75.76
+        }
+    ]
 }
 
 preference_response = sdk.preference().create(preference_data)
 preference = preference_response["response"]
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```python
+# SDK do Mercado Pago
+import mercadopago
+
+# Configure as credenciais
+sdk = mercadopago.SDK("PROD_ACCESS_TOKEN")
+
+# Crie um objeto de preferência
+preference_data = {
+    "items": [
+        {
+            "title": "My Item",
+            "quantity": 1,
+            "unit_price": 75
+        }
+    ]
+}
+
+preference_response = sdk.preference().create(preference_data)
+preference = preference_response["response"]
+```
+]]]
+
+------------

--- a/guides/sdks/official/ruby/preferences.en.md
+++ b/guides/sdks/official/ruby/preferences.en.md
@@ -2,23 +2,62 @@
 
 It is possible to create Preferences using the SDK below. For details on request parameters, check the [Create preferences](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post) API.
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
 ```ruby
+# Mercado Pago SDK
+require 'mercadopago'
+
+# Add Your credentials
+sdk = Mercadopago::SDK.new('PROD_ACCESS_TOKEN')
+
+# Create a preference request
 preference_data = {
   items: [
     {
-      title: 'Blue shirt',
-      quantity: 10,
-      currency_id: '[FAKER][CURRENCY][ACRONYM]',
-      unit_price: [FAKER][COMMERCE][PRICE]
+      title: 'My Item',
+      unit_price: 75.56,
+      quantity: 1
     }
-  ],
-  payer: {
-    email: 'john@yourdomain.com'
-  }
+  ]
 }
-
 preference_response = sdk.preference.create(preference_data)
 preference = preference_response[:response]
+
+# This value replaces the String "<%= @preference_id %>" in your HTML
+@preference_id = preference['id']
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```ruby
+# Mercado Pago SDK
+require 'mercadopago'
+
+# Add Your credentials
+sdk = Mercadopago::SDK.new('PROD_ACCESS_TOKEN')
+
+# Create a preference request
+preference_data = {
+  items: [
+    {
+      title: 'My Item',
+      unit_price: 75,
+      quantity: 1
+    }
+  ]
+}
+preference_response = sdk.preference.create(preference_data)
+preference = preference_response[:response]
+
+# This value replaces the String "<%= @preference_id %>" in your HTML
+@preference_id = preference['id']
+```
+]]]
+
+------------

--- a/guides/sdks/official/ruby/preferences.es.md
+++ b/guides/sdks/official/ruby/preferences.es.md
@@ -2,23 +2,62 @@
 
 Es posible crear preferencias utilizando lo SDK a continuación. Para obtener detalles sobre los parámetros de la solicitud, consulte la API [Crear preferencias](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
+
 [[[
 ```ruby
+# SDK de Mercado Pago
+require 'mercadopago'
+
+# Agrega credenciales
+sdk = Mercadopago::SDK.new('PROD_ACCESS_TOKEN')
+
+# Crea un objeto de preferencia
 preference_data = {
   items: [
     {
-      title: 'Blue shirt',
-      quantity: 10,
-      currency_id: '[FAKER][CURRENCY][ACRONYM]',
-      unit_price: [FAKER][COMMERCE][PRICE]
+      title: 'Mi producto',
+      unit_price: 75.56,
+      quantity: 1
     }
-  ],
-  payer: {
-    email: 'john@yourdomain.com'
-  }
+  ]
 }
-
 preference_response = sdk.preference.create(preference_data)
 preference = preference_response[:response]
+
+# Este valor reemplazará el string "<%= @preference_id %>" en tu HTML
+@preference_id = preference['id']
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```ruby
+# SDK de Mercado Pago
+require 'mercadopago'
+
+# Agrega credenciales
+sdk = Mercadopago::SDK.new('PROD_ACCESS_TOKEN')
+
+# Crea un objeto de preferencia
+preference_data = {
+  items: [
+    {
+      title: 'Mi producto',
+      unit_price: 75,
+      quantity: 1
+    }
+  ]
+}
+preference_response = sdk.preference.create(preference_data)
+preference = preference_response[:response]
+
+# Este valor reemplazará el string "<%= @preference_id %>" en tu HTML
+@preference_id = preference['id']
+```
+]]]
+
+------------

--- a/guides/sdks/official/ruby/preferences.pt.md
+++ b/guides/sdks/official/ruby/preferences.pt.md
@@ -2,24 +2,62 @@
 
 É possível criar uma preferência utilizando o SDK abaixo. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
 
+----[mla, mlb, mlu, mpe, mlm]----
 
 [[[
 ```ruby
+# SDK do Mercado Pago
+require 'mercadopago'
+
+# Configure as credenciais
+sdk = Mercadopago::SDK.new('PROD_ACCESS_TOKEN')
+
+# Crie um objeto de preferência
 preference_data = {
   items: [
     {
-      title: 'Blue shirt',
-      quantity: 10,
-      currency_id: '[FAKER][CURRENCY][ACRONYM]',
-      unit_price: [FAKER][COMMERCE][PRICE]
+      title: 'Meu produto',
+      unit_price: 75.56,
+      quantity: 1
     }
-  ],
-  payer: {
-    email: 'john@yourdomain.com'
-  }
+  ]
 }
-
 preference_response = sdk.preference.create(preference_data)
 preference = preference_response[:response]
+
+# Este valor substituirá a string "<%= @preference_id %>" no seu HTML
+@preference_id = preference['id']
 ```
 ]]]
+
+------------
+
+----[mlc, mco]----
+
+[[[
+```ruby
+# SDK do Mercado Pago
+require 'mercadopago'
+
+# Configure as credenciais
+sdk = Mercadopago::SDK.new('PROD_ACCESS_TOKEN')
+
+# Crie um objeto de preferência
+preference_data = {
+  items: [
+    {
+      title: 'Meu produto',
+      unit_price: 75,
+      quantity: 1
+    }
+  ]
+}
+preference_response = sdk.preference.create(preference_data)
+preference = preference_response[:response]
+
+# Este valor substituirá a string "<%= @preference_id %>" no seu HTML
+@preference_id = preference['id']
+```
+]]]
+
+------------


### PR DESCRIPTION
## Description

Ao atualizar a documentação de CHO Pro identificamos que os snippets de SDKs para criação de preferências não contemplavam a etapa de inserção das credenciais. Dessa forma, ao avaliar com o Rossafa entendemos que os snippets disponíveis na doc atual estavam corretos e fazia sentido termos essas infos na nova biblioteca de SDKs.

Somente os SDKs de **criação de preferências** precisaram de atualização.
