### PR TITLE
fix/ads-sdks-insertion

### DIFF
--- a/guides/sdks/official/dotnet/preferences.en.md
+++ b/guides/sdks/official/dotnet/preferences.en.md
@@ -71,3 +71,70 @@ Preference preference = await client.CreateAsync(request);
 ]]]
 
 ------------
+
+## Associate Facebook Ads
+
+You can associate the preference with a pixel to track the conversions of Facebook ads. To obtain details about the request parameters, consult the API [Create Preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post).
+
+[[[
+```dotnet
+===
+Add the following code in the preference and replace the <code>pixel_id</code> value with its identifier.
+===
+// Associate your Facebook pixel
+var tracks = new List<PreferenceTrackRequest>
+{
+    new PreferenceTrackRequest
+    {
+        Type = "facebook_ad",
+        Values = new PreferenceTrackValuesRequest
+        {
+            PixelId = "PIXEL_ID",
+        },
+    },
+};
+
+var request = new PreferenceRequest
+{
+    // ...
+    Tracks = tracks,
+};
+
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]
+
+## Associate Google Ads
+
+You can associate a tag with your preference for tracking Google Ads conversions. For details on request parameters, check the API [Create Preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post).
+
+[[[
+```dotnet
+===
+Add the code in the preference and replace the <code>CONVERSION\_ID</code> and <code>CONVERSION\_LABEL</code> values with the data from your tag.
+===
+// Associate your tag
+var tracks = new List<PreferenceTrackRequest>
+{
+    new PreferenceTrackRequest
+    {
+        Type = "facebook_ad",
+        Values = new PreferenceTrackValuesRequest
+        {
+            ConversionId = "CONVERSION_ID",
+            ConversionLabel = "CONVERSION_LABEL",
+        },
+    },
+};
+
+var request = new PreferenceRequest
+{
+    // ...
+    Tracks = tracks,
+};
+
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]

--- a/guides/sdks/official/dotnet/preferences.es.md
+++ b/guides/sdks/official/dotnet/preferences.es.md
@@ -71,3 +71,70 @@ Preference preference = await client.CreateAsync(request);
 ]]]
 
 ------------
+
+## Asociar Facebook Ads
+
+Puede asociar la preferencia con un píxel para rastrear las conversiones de anuncios de Facebook. Para obtener detalles sobre los parámetros de solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
+
+[[[
+```dotnet
+===
+Agrega el código en la preferencia y reemplaza el valor <code>PIXEL_ID</code> por tu identificador.
+===
+// Asocia tu píxel de Facebook
+var tracks = new List<PreferenceTrackRequest>
+{
+    new PreferenceTrackRequest
+    {
+        Type = "facebook_ad",
+        Values = new PreferenceTrackValuesRequest
+        {
+            PixelId = "PIXEL_ID",
+        },
+    },
+};
+
+var request = new PreferenceRequest
+{
+    // ...
+    Tracks = tracks,
+};
+
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]
+
+## Asociar Google Ads
+
+Puede asociar una *tag* a la preferencia para realizar el seguimiento de las conversiones de Google Ads. Para obtener detalles sobre los parámetros de solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
+
+[[[
+```dotnet
+===
+Agrega el código en la preferencia y reemplaza los valores <code>CONVERSION\_ID</code> y <code>CONVERSION\_LABEL</code> por los datos de tu _tag_.
+===
+// Asocia tu tag
+var tracks = new List<PreferenceTrackRequest>
+{
+    new PreferenceTrackRequest
+    {
+        Type = "facebook_ad",
+        Values = new PreferenceTrackValuesRequest
+        {
+            ConversionId = "CONVERSION_ID",
+            ConversionLabel = "CONVERSION_LABEL",
+        },
+    },
+};
+
+var request = new PreferenceRequest
+{
+    // ...
+    Tracks = tracks,
+};
+
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]

--- a/guides/sdks/official/dotnet/preferences.pt.md
+++ b/guides/sdks/official/dotnet/preferences.pt.md
@@ -71,3 +71,70 @@ Preference preference = await client.CreateAsync(request);
 ]]]
 
 ------------
+
+## Associar Facebook Ads
+
+É possível associar a preferência a um pixel para acompanhamento das conversões do Facebook Ads. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
+
+[[[
+```dotnet
+===
+Adicione o código na preferência e substitua o valor <code>pixel_id</code> pelo seu identificador.
+===
+// Associe seu pixel do Facebook
+var tracks = new List<PreferenceTrackRequest>
+{
+    new PreferenceTrackRequest
+    {
+        Type = "facebook_ad",
+        Values = new PreferenceTrackValuesRequest
+        {
+            PixelId = "PIXEL_ID",
+        },
+    },
+};
+
+var request = new PreferenceRequest
+{
+    // ...
+    Tracks = tracks,
+};
+
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]
+
+## Associar Google Ads
+
+É possível associar uma tag à preferência para acompanhamento das conversões do Google Ads. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
+
+[[[
+```csharp
+===
+Adicione o código na preferência e substitua os valores <code>CONVERSION\_ID</code> e <code>CONVERSION\_LABEL</code> pelos dados da sua _tag_.
+===
+// Associe sua tag do Google ads
+var tracks = new List<PreferenceTrackRequest>
+{
+    new PreferenceTrackRequest
+    {
+        Type = "facebook_ad",
+        Values = new PreferenceTrackValuesRequest
+        {
+            ConversionId = "CONVERSION_ID",
+            ConversionLabel = "CONVERSION_LABEL",
+        },
+    },
+};
+
+var request = new PreferenceRequest
+{
+    // ...
+    Tracks = tracks,
+};
+
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]

--- a/guides/sdks/official/nodejs/preferences.en.md
+++ b/guides/sdks/official/nodejs/preferences.en.md
@@ -71,3 +71,57 @@ mercadopago.preferences.create(preference)
 ]]]
 
 ------------
+
+## Associate Facebook Ads
+
+You can associate the preference with a pixel to track the conversions of Facebook ads. To obtain details about the request parameters, consult the API [Create Preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post).
+
+[[[
+```node
+===
+Add the following code in the preference and replace the <code>pixel_id</code> value with its identifier.
+===
+  // Create a preference object
+var preference = {
+
+  // Associate your Facebook Pixel
+  tracks: [
+        {
+          type: "facebook_ad",
+          values: {
+            "pixel_id": 'PIXEL_ID'
+          }
+        }
+      ]
+  //...
+};
+```
+]]]
+
+## Associate Google Ads
+
+You can associate a tag with your preference for tracking Google Ads conversions. For details on request parameters, check the API [Create Preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post).
+
+[[[
+```node
+===
+Add the code in the preference and replace the <code>CONVERSION\_ID</code> and <code>CONVERSION\_LABEL</code> values with the data from your tag.
+===
+// Configure your preference
+var preference = {
+
+ // Associate your tag
+  tracks: [
+        {
+            type: "google_ad",
+            values: {
+              conversion_id: "CONVERSION_ID",
+              conversion_label: "CONVERSION_LABEL"
+            }
+        }
+      ]
+  ...
+};
+```
+]]]
+

--- a/guides/sdks/official/nodejs/preferences.es.md
+++ b/guides/sdks/official/nodejs/preferences.es.md
@@ -71,3 +71,56 @@ mercadopago.preferences.create(preference)
 ]]]
 
 ------------
+
+## Asociar Facebook Ads
+
+Puede asociar la preferencia con un píxel para rastrear las conversiones de anuncios de Facebook. Para obtener detalles sobre los parámetros de solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
+
+[[[
+```node
+===
+Agrega el código en la preferencia y reemplaza el valor <code>PIXEL_ID</code> por tu identificador.
+===
+// Configura tu preferencia
+var preference = {
+
+  // Asocia tu píxel de Facebook
+  tracks: [
+        {
+          type: "facebook_ad",
+          values: {
+            "pixel_id": 'PIXEL_ID'
+          }
+        }
+      ]
+  //...
+};
+```
+]]]
+
+## Asociar Google Ads
+
+Puede asociar una *tag* a la preferencia para realizar el seguimiento de las conversiones de Google Ads. Para obtener detalles sobre los parámetros de solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
+
+[[[
+```node
+===
+Agrega el código en la preferencia y reemplaza los valores <code>CONVERSION\_ID</code> y <code>CONVERSION\_LABEL</code> por los datos de tu _tag_.
+===
+// Configura tu preferencia
+var preference = {
+ 
+  // Asocia tu tag
+  tracks: [
+        {
+            type: "google_ad",
+            values: {
+              conversion_id: "CONVERSION_ID",
+              conversion_label: "CONVERSION_LABEL"
+            } 
+        }
+      ]
+  ...
+};
+```
+]]]

--- a/guides/sdks/official/nodejs/preferences.pt.md
+++ b/guides/sdks/official/nodejs/preferences.pt.md
@@ -71,3 +71,56 @@ mercadopago.preferences.create(preference)
 ]]]
 
 ------------
+
+## Associar Facebook Ads
+
+É possível associar a preferência a um pixel para acompanhamento das conversões do Facebook Ads. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
+
+[[[
+```node
+===
+Adicione o código na preferência e substitua o valor <code>pixel_id</code> pelo seu identificador.
+===
+  // Criar um objeto preferência
+var preference = {
+
+  // Associe seu píxel do Facebook
+  tracks: [
+        {
+          type: "facebook_ad",
+          values: {
+            "pixel_id": 'PIXEL_ID'
+          }
+        }
+      ]
+  //...
+};
+```
+]]]
+
+## Associar Google Ads
+
+É possível associar uma tag à preferência para acompanhamento das conversões do Google Ads. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
+
+[[[
+```node
+===
+Adicione o código na preferência e substitua os valores <code>CONVERSION\_ID</code> e <code>CONVERSION\_LABEL</code> pelos dados da sua _tag_.
+===
+  // Criar um objeto preferência
+var preference = {
+ 
+  // Associar sua tag do Google ads
+  tracks: [
+        {
+            type: "google_ad",
+            values: {
+              conversion_id: "CONVERSION_ID",
+              conversion_label: "CONVERSION_LABEL"
+            } 
+        }
+      ]
+  ...
+};
+```
+]]]

--- a/guides/sdks/official/php/preferences.en.md
+++ b/guides/sdks/official/php/preferences.en.md
@@ -55,3 +55,66 @@ $preference->save();
 ]]]
 
 ------------
+
+## Associate Facebook Ads
+
+You can associate the preference with a pixel to track the conversions of Facebook ads. To obtain details about the request parameters, consult the API [Create Preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post).
+
+[[[
+```php
+===
+Add the following code in the preference and replace the <code>pixel_id</code> value with your identifier.
+===
+<?php
+  // Create a preference object
+  $preference = new MercadoPago\Preference();
+
+  // Associate your Facebook Pixel
+  $preference->tracks = array(
+    array(
+      'type' => 'facebook_ad',
+      'values'=> array(
+        'pixel_id' => 'PIXEL_ID'
+      )
+    )
+  );
+
+  // ...
+  // Save and post the preference
+  $preference->save();
+?>
+```
+]]]
+
+## Associate Google Ads
+
+You can associate a tag with your preference for tracking Google Ads conversions. For details on request parameters, check the API [Create Preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
+
+
+[[[
+```php
+===
+Add the code in the preference and replace the <code>CONVERSION\_ID</code> and <code>CONVERSION\_LABEL</code> values with the data from your tag.
+===
+
+<?php
+  // Create a preference object
+  $preference = new MercadoPago\Preference();
+ 
+  // Associate your tag
+  $preference->tracks = array(
+    array(
+        'type' => 'google_ad',
+        'values' => array(
+          'conversion_id' => 'CONVERSION_ID',
+          'conversion_label' => 'CONVERSION_LABEL'
+        )
+    )
+  );
+
+  ...
+  // Save and post the preference
+  $preference->save();
+?>
+```
+]]]

--- a/guides/sdks/official/php/preferences.es.md
+++ b/guides/sdks/official/php/preferences.es.md
@@ -55,3 +55,65 @@ $preference->save();
 ]]]
 
 ------------
+
+## Asociar Facebook Ads
+
+Puede asociar la preferencia con un píxel para rastrear las conversiones de anuncios de Facebook. Para obtener detalles sobre los parámetros de solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
+
+[[[
+```php
+===
+Agrega el código en la preferencia y reemplaza el valor <code>PIXEL_ID</code> por tu identificador.
+===
+<?php
+  // Crear un objeto preferencia
+  $preference = new MercadoPago\Preference();
+
+  // Asocia tu píxel de Facebook
+  $preference->tracks = array(
+    array(
+      'type' => 'facebook_ad',
+      'values'=> array(
+        'pixel_id' => 'PIXEL_ID'
+      )
+    )
+  );
+
+  // ...
+  // Guardar y postear la preferencia
+  $preference->save();
+?>
+```
+]]]
+
+## Asociar Google Ads
+
+Puede asociar una *tag* a la preferencia para realizar el seguimiento de las conversiones de Google Ads. Para obtener detalles sobre los parámetros de solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
+
+[[[
+```php
+===
+Agrega el código en la preferencia y reemplaza los valores <code>CONVERSION\_ID</code> y <code>CONVERSION\_LABEL</code> por los datos de tu _tag_.
+===
+
+<?php
+  // Crear un objeto preferencia
+  $preference = new MercadoPago\Preference();
+ 
+  // Asocia tu tag
+  $preference->tracks = array(
+    array(
+        'type' => 'google_ad',
+        'values' => array(
+          'conversion_id' => 'CONVERSION_ID',
+          'conversion_label' => 'CONVERSION_LABEL'
+        )
+    )
+  );
+
+  ...
+  // Guardar y postear la preferencia
+  $preference->save();
+?>
+```
+]]]

--- a/guides/sdks/official/php/preferences.pt.md
+++ b/guides/sdks/official/php/preferences.pt.md
@@ -55,3 +55,65 @@ $preference->save();
 ]]]
 
 ------------
+
+## Associar Facebook Ads
+
+É possível associar a preferência a um pixel para acompanhamento das conversões do Facebook Ads. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
+
+[[[
+```php
+===
+Adicione o código na preferência e substitua o valor <code>pixel_id</code> pelo seu identificador.
+===
+<?php
+  // Criar um objeto preferência
+  $preference = new MercadoPago\Preference();
+
+  // Associar pixel do Facebook
+  $preference->tracks = array(
+    array(
+      'type' => 'facebook_ad',
+      'values'=> array(
+        'pixel_id' => 'PIXEL_ID'
+      )
+    )
+  );
+
+  // ...
+  // Salvar e postar a preferência
+  $preference->save();
+?>
+```
+]]]
+
+## Associar Google Ads
+
+É possível associar uma tag à preferência para acompanhamento das conversões do Google Ads. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
+
+[[[
+```php
+===
+Adicione o código na preferência e substitua os valores <code>CONVERSION\_ID</code> e <code>CONVERSION\_LABEL</code> pelos dados da sua _tag_.
+===
+
+<?php
+  // Criar um objeto preferência
+  $preference = new MercadoPago\Preference();
+ 
+  // Associar sua tag do Google ads
+  $preference->tracks = array(
+    array(
+        'type' => 'google_ad',
+        'values' => array(
+          'conversion_id' => 'CONVERSION_ID',
+          'conversion_label' => 'CONVERSION_LABEL'
+        )
+    )
+  );
+
+  ...
+  // Salvar e postar a preferência
+  $preference->save();
+?>
+```
+]]]

--- a/guides/sdks/official/python/preferences.en.md
+++ b/guides/sdks/official/python/preferences.en.md
@@ -58,3 +58,58 @@ preference = preference_response["response"]
 ]]]
 
 ------------
+
+## Associate Facebook Ads
+
+You can associate the preference with a pixel to track the conversions of Facebook ads. To obtain details about the request parameters, consult the API [Create Preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post).
+
+[[[
+```python
+===
+Add the following code in the preference and replace the <code>pixel_id</code> value with its identifier.
+===
+# Associate your Facebook Pixel
+preference_data = {
+    # ...
+    "tracks": [
+        {
+            "type": "facebook_ad",
+            "values": {
+                "pixel_id": "PIXEL_ID"
+            }
+        }
+    ]
+}
+
+preference_response = sdk.preference().create(preference_data)
+preference = preference_response["response"]
+```
+]]]
+
+## Associate Google Ads
+
+You can associate a tag with your preference for tracking Google Ads conversions. For details on request parameters, check the API [Create Preference](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/preferences/_checkout_preferences/post).
+
+[[[
+```python
+===
+Add the code in the preference and replace the <code>CONVERSION\_ID</code> and <code>CONVERSION\_LABEL</code> values with the data from your tag.
+===
+# Associate your tag
+preference_data = {
+    # ...
+    "tracks": [
+        {
+            "type": "google_ad",
+            "values": {
+                "conversion_id": "CONVERSION_ID",
+                "conversion_label": "CONVERSION_LABEL"
+            }
+        }
+    ]
+}
+
+preference_response = sdk.preference().create(preference_data)
+preference = preference_response["response"]
+```
+]]]

--- a/guides/sdks/official/python/preferences.es.md
+++ b/guides/sdks/official/python/preferences.es.md
@@ -57,3 +57,62 @@ preference = preference_response["response"]
 ]]]
 
 ------------
+
+## Asociar Facebook Ads
+
+Puede asociar la preferencia con un píxel para rastrear las conversiones de anuncios de Facebook. Para obtener detalles sobre los parámetros de solicitud, consulte la API [Crear preferencia](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/preferences/_checkout_preferences/post).
+
+[[[
+```dotnet
+===
+Agrega el código en la preferencia y reemplaza el valor <code>PIXEL_ID</code> por tu identificador.
+===
+// Asocia tu píxel de Facebook
+var tracks = new List<PreferenceTrackRequest>
+{
+    new PreferenceTrackRequest
+    {
+        Type = "facebook_ad",
+        Values = new PreferenceTrackValuesRequest
+        {
+            PixelId = "PIXEL_ID",
+        },
+    },
+};
+
+var request = new PreferenceRequest
+{
+    // ...
+    Tracks = tracks,
+};
+
+var client = new PreferenceClient();
+Preference preference = await client.CreateAsync(request);
+```
+]]]
+
+## Asociar Google Ads
+
+[[[
+```python
+===
+Agrega el código en la preferencia y reemplaza los valores <code>CONVERSION\_ID</code> y <code>CONVERSION\_LABEL</code> por los datos de tu _tag_.
+===
+# Asocia tu tag
+preference_data = {
+    # ...
+    "tracks": [
+        {
+            "type": "google_ad",
+            "values": {
+                "conversion_id": "CONVERSION_ID",
+                "conversion_label": "CONVERSION_LABEL"
+            }
+        }
+    ]
+}
+
+preference_response = sdk.preference().create(preference_data)
+preference = preference_response["response"]
+```
+]]]

--- a/guides/sdks/official/python/preferences.pt.md
+++ b/guides/sdks/official/python/preferences.pt.md
@@ -57,3 +57,58 @@ preference = preference_response["response"]
 ]]]
 
 ------------
+
+## Associar Facebook Ads
+
+É possível associar a preferência a um pixel para acompanhamento das conversões do Facebook Ads. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
+
+[[[
+```python
+===
+Adicione o código na preferência e substitua o valor <code>pixel_id</code> pelo seu identificador.
+===
+# Associar seu pixel do Facebook
+preference_data = {
+    # ...
+    "tracks": [
+        {
+            "type": "facebook_ad",
+            "values": {
+                "pixel_id": "PIXEL_ID"
+            }
+        }
+    ]
+}
+
+preference_response = sdk.preference().create(preference_data)
+preference = preference_response["response"]
+```
+]]]
+
+## Associar Google Ads
+
+É possível associar uma tag à preferência para acompanhamento das conversões do Google Ads. Para detalhamento dos parâmetros de requisição, verifique a API [Criar preferência](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/preferences/_checkout_preferences/post).
+
+[[[
+```python
+===
+Adicione o código na preferência e substitua os valores <code>CONVERSION\_ID</code> e <code>CONVERSION\_LABEL</code> pelos dados da sua _tag_.
+===
+# Associar sua tag do Google ads
+preference_data = {
+    # ...
+    "tracks": [
+        {
+            "type": "google_ad",
+            "values": {
+                "conversion_id": "CONVERSION_ID",
+                "conversion_label": "CONVERSION_LABEL"
+            }
+        }
+    ]
+}
+
+preference_response = sdk.preference().create(preference_data)
+preference = preference_response["response"]
+```
+]]]


### PR DESCRIPTION
## Description

Alguns SDKs para associar o Facebook Ads e Google Ads às preferências estavam faltando. Agora, todos foram inseridos em suas respectivas linguagens (Java e Ruby ainda não contemplam essas opções).
