### PR TITLE
Adicionar campo "tarjeta de crédito" en Glosario del reporte de liberaciones

### DIFF
--- a/guides/manage-account/reports/released-money/glossary.en.md
+++ b/guides/manage-account/reports/released-money/glossary.en.md
@@ -38,6 +38,7 @@ If you have any doubts about the technical terms used, check the glossary below.
 | TAXES_DISAGGREGATED | Taxes disaggregated in JSON format. |
 | EFFECTIVE_COUPON_AMOUNT | Cost for offering discount. |
 | POI_ID | Point ID if payment is made through a physical retailer. |
+| CARD_INITIAL_NUMBER | It corresponds to the first digits of the credit or debit card that you used to make the purchase. |
 
 <hr/>
 

--- a/guides/manage-account/reports/released-money/glossary.es.md
+++ b/guides/manage-account/reports/released-money/glossary.es.md
@@ -38,6 +38,7 @@ Lo sabemos, algunos términos son técnicos y puede que no estés familiarizado 
 | TAXES_DISAGGREGATED | Impuestos desagregados en formato JSON. |
 | EFFECTIVE_COUPON_AMOUNT | Costo por ofrecer descuento. |
 | POI_ID | ID del lector si el pago se realiza a través de un comercio físico. |
+| CARD_INITIAL_NUMBER | Corresponde a los primeros dígitos de la tarjeta crédito o débito con la que se hizo la compra. |
 ----[mpe, mlu]----
 > INFO
 >

--- a/guides/manage-account/reports/released-money/glossary.pt.md
+++ b/guides/manage-account/reports/released-money/glossary.pt.md
@@ -38,7 +38,7 @@ Sabemos que alguns termos são técnicos e você pode não estar familiarizado c
 | TAXES_DISAGGREGATED | Impostos desagregados no formato JSON. |
 | EFFECTIVE_COUPON_AMOUNT | Custo de oferecer desconto. |
 | POI_ID | ID da maquininha se o pagamento é feito em uma loja física. |
-| CARD_INITIAL_NUMBER | Corresponde aos primeiros dígitos do cartão de crédito ou débito utilizado para fazer a compra. |
+| CARD_INITIAL_NUMBER | Corresponde aos primeiros dígitos do cartão de crédito ou débito utilizado para realizar a compra. |
 
 <hr/>
 

--- a/guides/manage-account/reports/released-money/glossary.pt.md
+++ b/guides/manage-account/reports/released-money/glossary.pt.md
@@ -38,6 +38,7 @@ Sabemos que alguns termos são técnicos e você pode não estar familiarizado c
 | TAXES_DISAGGREGATED | Impostos desagregados no formato JSON. |
 | EFFECTIVE_COUPON_AMOUNT | Custo de oferecer desconto. |
 | POI_ID | ID da maquininha se o pagamento é feito em uma loja física. |
+| CARD_INITIAL_NUMBER | Corresponde aos primeiros dígitos do cartão de crédito ou débito utilizado para fazer a compra. |
 
 <hr/>
 


### PR DESCRIPTION
## Adicionar campo "tarjeta de crédito" en Glosario del reporte de liberaciones

Se agrega nueva columna al Reporte de liberaciones para mostrar al seller los primeros seis dígitos de la tarjeta de crédito (si aplica) usada por un cliente al momento de realizar la compra.

PT:

<img width="841" alt="Captura de Pantalla 2022-03-25 a la(s) 2 41 02 p m" src="https://user-images.githubusercontent.com/96143694/160190284-e2b17366-8cb5-4b26-99b7-82352d3ee633.png">

ES:

<img width="833" alt="Captura de Pantalla 2022-03-25 a la(s) 2 42 51 p m" src="https://user-images.githubusercontent.com/96143694/160190495-179d3b64-a87b-408a-9aa6-a8e8b0bc64e1.png">

EN:

<img width="888" alt="Captura de Pantalla 2022-03-25 a la(s) 2 43 11 p m" src="https://user-images.githubusercontent.com/96143694/160190553-8a559665-bfe0-451b-bf50-96f0b8c4cf7c.png">

