### PR TITLE
Feature/updates revamp

### DIFF
--- a/guides/checkout-pro/add-checkout.en.md
+++ b/guides/checkout-pro/add-checkout.en.md
@@ -59,7 +59,7 @@ In the example above, a payment button will be rendered and will be responsible 
 >
 > Check how to create information sets about a product and/or service.
 >
-> [Create preferences](/developers/es/docs/checkout-pro/requirements)
+> [Create preferences](/developers/es/docs/checkout-pro/create-preference)
 
 > NEXT_STEP_CARD_EN
 >

--- a/guides/checkout-pro/add-checkout.es.md
+++ b/guides/checkout-pro/add-checkout.es.md
@@ -59,7 +59,7 @@ En el ejemplo anterior, se mostrará un botón de pago y será responsable de ab
 >
 > Vea cómo crear conjuntos de información sobre un producto y/o servicio.
 >
-> [Crear preferencias](/developers/es/docs/checkout-pro/requirements)
+> [Crear preferencias](/developers/es/docs/checkout-pro/create-preference)
 
 > NEXT_STEP_CARD_ES
 >

--- a/guides/checkout-pro/add-checkout.pt.md
+++ b/guides/checkout-pro/add-checkout.pt.md
@@ -60,7 +60,7 @@ No exemplo acima, um botão de pagamento será renderizado e ficará responsáve
 >
 > Veja como criar conjuntos de informações sobre um produto e/ou serviço.
 >
-> [Criar preferências](/developers/pt/docs/checkout-pro/requirements)
+> [Criar preferências](/developers/pt/docs/checkout-pro/create-preference)
 
 > NEXT_STEP_CARD_PT
 >

--- a/guides/checkout-pro/landing.es.md
+++ b/guides/checkout-pro/landing.es.md
@@ -14,7 +14,7 @@ available_countries: mla, mlb, mlm, mlu, mco, mlc, mpe
 
 ---
 bullet_section_with_media: 
- - title: Vantagens
+ - title: Ventajas
  - type: normal
  - message: Además de contar con los principales medios de pago del país, Checkout Pro cuenta con una experiencia de compra adaptada y accesible desde cualquier dispositivo.
  - image: /cow/cho-pro-landing__pt.png

--- a/guides/mp-delivery/accept-order.en.md
+++ b/guides/mp-delivery/accept-order.en.md
@@ -18,7 +18,7 @@ When accepting the order, the status will be changed and the new order status wi
 >
 > Learn how to get order data with Mercado Pago Delivery.
 >
-> [Get order data](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/mp-delivery/get-order-data)
+> [Get order data](/developers/en/docs/mp-delivery/order-management/get-order-data)
 
 > NEXT_STEP_CARD_EN
 >
@@ -26,4 +26,4 @@ When accepting the order, the status will be changed and the new order status wi
 >
 > Learn how to print proof of orders with Mercado Pago Delivery.
 >
-> [Print order receipt](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/mp-delivery/print-order-receipt)
+> [Print order receipt](/developers/en/docs/mp-delivery/order-management/print-order-receipt)

--- a/guides/mp-delivery/accept-order.es.md
+++ b/guides/mp-delivery/accept-order.es.md
@@ -18,7 +18,7 @@ Al aceptar la orden, se cambiará el estado y en la respuesta se indicará el es
 >
 > Conoce cómo obtener datos de órdenes con Mercado Pago Delivery.
 >
-> [Obtener datos de la orden](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/mp-delivery/get-order-data)
+> [Obtener datos de la orden](/developers/es/docs/mp-delivery/order-management/get-order-data)
 
 > NEXT_STEP_CARD_ES
 >
@@ -26,4 +26,4 @@ Al aceptar la orden, se cambiará el estado y en la respuesta se indicará el es
 >
 > Aprende a imprimir comprobantes de órdenes con Mercado Pago Delivery.
 >
-> [Imprimir recibo de orden](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/mp-delivery/print-order-receipt)
+> [Imprimir recibo de orden](/developers/es/docs/mp-delivery/order-management/print-order-receipt)

--- a/guides/mp-delivery/accept-order.pt.md
+++ b/guides/mp-delivery/accept-order.pt.md
@@ -18,7 +18,7 @@ Ao aceitar o pedido, o status será alterado e no response será indicado o novo
 >
 > Saiba como obter dados de pedidos com o Mercado Pago Delivery.
 >
-> [Obter dados do pedido](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/mp-delivery/get-order-data)
+> [Obter dados do pedido](/developers/pt/docs/mp-delivery/order-management/get-order-data)
 
 > NEXT_STEP_CARD_PT
 >
@@ -26,4 +26,4 @@ Ao aceitar o pedido, o status será alterado e no response será indicado o novo
 >
 > Saiba como imprimir o comprovante dos pedidos com o Mercado Pago Delivery.
 >
-> [Imprimir comprovante do pedido](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/mp-delivery/print-order-receipt)
+> [Imprimir comprovante do pedido](/developers/pt/docs/mp-delivery/order-management/print-order-receipt)

--- a/guides/qr-code-attended-model/introduction.en.md
+++ b/guides/qr-code-attended-model/introduction.en.md
@@ -21,4 +21,4 @@ The main characteristics are:
 >
 > Learn to integrate this model step by step.
 >
-> [How to Integrate attended model](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/qr-code/qr-attended/integrations)
+> [How to Integrate attended model](/developers/en/docs/qr-code/qr-attended-model/integrations)

--- a/guides/qr-code-attended-model/introduction.es.md
+++ b/guides/qr-code-attended-model/introduction.es.md
@@ -19,4 +19,4 @@ Las características principales son:
 >
 > Conoce paso a paso cómo integrar este modelo.
 >
-> [Cómo integrar QR modelo atendido](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/qr-code/qr-attended/integrations)
+> [Cómo integrar QR modelo atendido](/developers/es/docs/qr-code/qr-attended-model/integrations)

--- a/guides/qr-code-attended-model/introduction.pt.md
+++ b/guides/qr-code-attended-model/introduction.pt.md
@@ -20,4 +20,4 @@ As características principais são:
 >
 > Conheça passo a passo como integrar este modelo.
 >
-> [Integrar o modelo QR atendido](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/qr-code/qr-attended/integrations)
+> [Integrar o modelo QR atendido](/developers/pt/docs/qr-code/qr-attended-model/integrations)

--- a/guides/sales-processing/cancellations-and-refunds.en.md
+++ b/guides/sales-processing/cancellations-and-refunds.en.md
@@ -44,11 +44,3 @@ To make full or partial refunds of a payment and check the refunds made in your 
 
 - [Post refunds](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/chargebacks/_payments_id_refunds/post)
 - [Check refunds list](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/chargebacks/_payments_id_refunds/get)
-
-> PREV_STEP_CARD_PT
->
-> Chargeback management
->
-> Encuentra toda la información sobre los contracargos, cómo prevenirlos y gestionarlos por API.
->
-> [Chargeback management](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/sales-processing/chargebacks)

--- a/guides/sales-processing/cancellations-and-refunds.es.md
+++ b/guides/sales-processing/cancellations-and-refunds.es.md
@@ -45,10 +45,3 @@ Para realizar reembolsos totales o parciales de un pago y verificar los reembols
 - [Inserir reembolsos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/chargebacks/_payments_id_refunds/post)
 - [Obtener lista de reembolsos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/chargebacks/_payments_id_refunds/get)
 
-> PREV_STEP_CARD_PT
->
-> Gestión de contracargos
->
-> Encuentra toda la información sobre los contracargos, cómo prevenirlos y gestionarlos por API.
->
-> [Gestión de contracargos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/sales-processing/chargebacks)

--- a/guides/sales-processing/cancellations-and-refunds.pt.md
+++ b/guides/sales-processing/cancellations-and-refunds.pt.md
@@ -44,11 +44,3 @@ Para realizar reembolsos integrais ou parciais de um pagamento e consultar os re
 
 - [Inserir reembolsos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/chargebacks/_payments_id_refunds/post)
 - [Obter lista de reembolsos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/chargebacks/_payments_id_refunds/get)
-
-> PREV_STEP_CARD_PT
->
-> Gerenciamento de operações contestadas
->
-> Encontre toda a informação sobre contestação de pagamentos, como preveni-las e gerenciá-las pela API.
->
-> [Gerenciamento de operações contestadas](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/sales-processing/chargebacks)

--- a/guides/sales-processing/chargebacks.en.md
+++ b/guides/sales-processing/chargebacks.en.md
@@ -168,19 +168,3 @@ Eventually, the chargeback may have two types of possible resolutions in the `co
 | **false** | Shows that the decision was against the seller and the money is discounted.
 
 Upon resolution, a new IPN notification will be sent so that you can verify the case.
-
-> PREV_STEP_CARD_EN
->
-> Received payments management
->
-> Check more informations about generated payments using our APIs.
->
-> [Received payments management](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/sales-processing/chargebacks)
-
-> NEXT_STEP_CARD_EN
->
-> Refunds and cancellations
->
-> Check more informations to perform a full and partial refund, and cancel a purchase in your store.
->
-> [Refunds and cancellations](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/sales-processing/chargebacks)

--- a/guides/sales-processing/chargebacks.es.md
+++ b/guides/sales-processing/chargebacks.es.md
@@ -168,19 +168,3 @@ Eventualmente el contracargo podrá tener dos tipos de resoluciones posibles en 
 | **false** | Indica que se falló en contra del vendedor y se le descuenta el dinero.
 
 Al resolverse, se enviará una nueva notificación IPN para que puedas verificar el caso.
-
-> PREV_STEP_CARD_ES
->
-> Gestión de pagos recibidos
->
-> Consulta más información sobre pagos generados usando nuestras APIs.
->
-> [Gestión de pagos recibidos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/sales-processing/chargebacks)
-
-> NEXT_STEP_CARD_ES
->
-> Devoluciones y cancelaciones
->
-> Consulta más información para realizar un reembolso total, parcial y cancelar una compra en tu tienda.
->
-> [Devoluciones y cancelaciones](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/sales-processing/chargebacks)

--- a/guides/sales-processing/chargebacks.pt.md
+++ b/guides/sales-processing/chargebacks.pt.md
@@ -169,19 +169,3 @@ Eventualmente, a contestação poderá ter dois tipos de resoluções possíveis
 | **false** | Indica que a decisão foi contra o vendedor e o dinheiro será descontado.
 
 Após a resolução, será enviada uma nova notificação IPN para você conferir o caso.
-
-> PREV_STEP_CARD_PT
->
-> Gestão de pagamentos recebidos
->
-> Confira mais informações sobre pagamentos gerados usando nossas APIs.
->
-> [Gestão de pagamentos recebidos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/sales-processing/chargebacks)
-
-> NEXT_STEP_CARD_PT
->
-> Devoluções e cancelamentos
->
-> Consulte mais informações para efetuar o reembolso total e parcial, e cancelar uma compra em sua loja.
->
-> [Devoluções e cancelamentos](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/sales-processing/chargebacks)

--- a/guides/sdks-v2/official/landing.es.md
+++ b/guides/sdks-v2/official/landing.es.md
@@ -8,7 +8,7 @@ content_section_with_media:
 
 >>>> Disponibilidad por país <<<<
 ---
-available_countries: mla, mlm, mco, mpe, mlu, mlm, mlc
+available_countries: mla, mlb, mlm, mco, mpe, mlu, mlc
 ---
 
 ---

--- a/guides/testing/create-test-user.en.md
+++ b/guides/testing/create-test-user.en.md
@@ -10,11 +10,3 @@ Below we list the two types of users required to perform the tests:
 * **Buyer:** This is the account you use to test the purchase process.
 
 To create a test user, send a POST with your production credential Access token to the [/users/test_user](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/test_user/_users_test_user/post) endpoint and execute the request.
-
-> NEXT_STEP_CARD_EN
->
-> Making test purchase
->
-> Check how to make a test purchase and validate your integration.
->
-> [Making test purchase](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/testing/test-purchase)

--- a/guides/testing/create-test-user.es.md
+++ b/guides/testing/create-test-user.es.md
@@ -10,11 +10,3 @@ A continuación enumeramos los dos tipos de usuarios necesarios para realizar la
 * **Comprador:** esta es la cuenta que utiliza para probar el proceso de compra.
 
 Para crear un usuario de prueba, envía un POST con su **credencial de producción** _Access token_ al [/users/test_user](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/test_user/_users_test_user/post) y ejecuta la solicitud.
-
-> NEXT_STEP_CARD_ES
->
-> Realiza una compra de prueba
->
-> Vea cómo hacer una compra de prueba y validar su integración.
->
-> [Realiza una compra de prueba](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/testing/test-purchase)


### PR DESCRIPTION
### Fixes
PR com alguns dos fixes citados pelo @mminestrelli  na [thread do Slack](https://meli.slack.com/archives/G014MT5C5A7/p1650469730058339). Realizei fixes de wording e links principalmente. Correções mais complexas ou referente ao Sidebar deixo a cargo de devcomm para evitar erros.

- [x] 1 Landing de CHO Pro dice “Vantagens” en español, debería ser Ventajas.
- [x] 2 En landing de SDKs para español Brasil está deshabilitado, debería estar habilitado.
- [x] 3 El step card “previous” en añadir checkout vuelve a requerimientos en lugar de crear preferencia.
- [x] 4 En mercado pago delivery el next step de aceptar pedido tiene mal el link
- [ ] 5 En administración de la sucursal el link anterior todas las next step cards de la sección están rotas
- [x] 6 En suscripciones>crear un usuario de prueba el link de la next step card está roto
- [x] 7 En suscripciones >pagos el link de la next step card está roto
- [x] 8 En suscripciones>Reembolsos y cancelaciones el prev step está roto
- [ ] 9 En el menú de link de pago Contenido Adicional está cargado como un item vacío 
- [ ] 10 En point el link a notificaciones es legacy y además de eso si está linkeado no debería estar dentro del contenido adicional?
- [ ] 11 En checkout pro> tarjetas de prueba en español el artículo está en inglés
- [ ] 12 En checkout pro hay una sección recursos vacía
- [ ] 13 En checkout API también pasa que el artículo de tarjetas de prueba está en inglés
- [ ] 14 Em mp-delivery a maioria dos Next Steps estão quebrados
- [x] 15 Em QR Modelo Atendido Introdução o Next Steps está quebrado

