### PR TITLE
Corrección de link en base.yaml para MP Delivery

### DIFF
--- a/reference/base.yaml
+++ b/reference/base.yaml
@@ -69,7 +69,7 @@ tags:
       en: 'Mercado Pago Delivery'
       es: 'Mercado Pago Delivery'
     externalDocs: 
-      url: '/guides/mp-delivery/introduction'
+      url: '/docs/mp-delivery/landing'
   
 #------DEFAULT - ALL ARCHIVES - END------
 


### PR DESCRIPTION
## Description

Se corrige en el archivo base.yaml el enlace que lleva a la documentación de Mercado Pago Delivery
