### PR TITLE
replace 'credentials' with 'users' as it was incorrect

### DIFF
--- a/guides/checkout-api/remember-customers-and-cards.en.md
+++ b/guides/checkout-api/remember-customers-and-cards.en.md
@@ -182,7 +182,7 @@ curl -X POST \
 > Important
 > 
 > - If you receive an error message of type `"invalid parameter"` with HTTP 400 status code, make sure you are completing the fields `payment_method_id` and `issuer_id` correctly.
-> - When you are using your test credentials, remember to follow this particular format for the customer's email: `test_payer_[0-9]{1,10}@testuser.com`. For example: `test_payer_12345@testuser.com`.
+> - When you are using your test users, remember to follow this particular format for the customer's email: `test_payer_[0-9]{1,10}@testuser.com`. For example: `test_payer_12345@testuser.com`.
 
 ## Add new cards to a customer
 

--- a/guides/checkout-api/remember-customers-and-cards.es.md
+++ b/guides/checkout-api/remember-customers-and-cards.es.md
@@ -182,7 +182,7 @@ curl -X POST \
 > Importante
 > 
 > - Si recibes un mensaje de error del tipo `"invalid parameter"` con código de estado HTTP 400, asegúrate de estar completando correctamente los campos `payment_method_id` e `issuer_id`.
-> - Cuando estés utilizando tus credenciales de prueba, recuerda respetar el siguiente formato para el email del cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por ejemplo: `test_payer_12345@testuser.com`.
+> - Cuando estés utilizando usuarios de prueba, recuerda respetar el siguiente formato para el email del cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por ejemplo: `test_payer_12345@testuser.com`.
 
 ## Agrega nuevas tarjetas a un cliente
 

--- a/guides/checkout-api/remember-customers-and-cards.pt.md
+++ b/guides/checkout-api/remember-customers-and-cards.pt.md
@@ -181,7 +181,7 @@ curl -X POST \
 > Importante
 > 
 > - Se você receber uma mensagem de erro do tipo `"invalid parameter"` com código de estado HTTP 400, certifique-se de que está preenchendo corretamente os campos `payment_method_id` e `issuer_id`.
-> - Quando utilizando as suas credenciais de teste, tenha em mente o seguinte formato para o e-mail do cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por exemplo: `test_payer_12345@testuser.com`.
+> - Quando utilizando usuários de teste, tenha em mente o seguinte formato para o e-mail do cliente: `test_payer_[0-9]{1,10}@testuser.com`. Por exemplo: `test_payer_12345@testuser.com`.
 
 ## Adicione novos cartões a um cliente
 


### PR DESCRIPTION
## Description

Describe what your Pull Request is about, including important information about what was done.

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->

### Issue involved
3 issues (same article on all languages)
Fixes #<issue>
There was an incorrect sentence with instructions on how to configure a test payer's email, it said "when using test credentials", and it should say "when using test users", as test credentials (sandbox) requiere live users or emails.