### PR TITLE
Change snippets for BIN 8 support

### DIFF
--- a/guides/checkout-api/receiving-payment-by-card-core-methods.en.md
+++ b/guides/checkout-api/receiving-payment-by-card-core-methods.en.md
@@ -161,7 +161,7 @@ function createSelectOptions(elem, options, labelsAndKeys = { label : "name", va
 
 #### Get card payment method
 
-Avoid mistakes and offer the correct available installments by validating your customers' data as they fill it out. Use the code in the following example to identify payment method with the first 6 digits of the card.
+Avoid mistakes and offer the correct available installments by validating your customers' data as they fill it out. Use the code in the following example to identify payment method with the first 8 digits of the card.
 
 ```javascript
 // Step #getPaymentMethods
@@ -179,15 +179,15 @@ cardNumberElement.addEventListener('keyup', async () => {
        const installmentsElement = document.getElementById('form-checkout__installments');
        let cardNumber = cardNumberElement.value;
 
-       if (cardNumber.length < 6 && paymentMethodElement.value) {
+       if (cardNumber.length < 8 && paymentMethodElement.value) {
            clearHTMLSelectChildrenFrom(issuerElement);
            clearHTMLSelectChildrenFrom(installmentsElement);
            paymentMethodElement.value = "";
            return
        }
 
-       if (cardNumber.length >= 6 && !paymentMethodElement.value) {
-           let bin = cardNumber.substring(0,6);
+       if (cardNumber.length >= 8 && !paymentMethodElement.value) {
+           let bin = cardNumber.substring(0,8);
            const paymentMethods = await mp.getPaymentMethods({'bin': bin});
 
            const { id: paymentMethodId, additional_info_needed, issuer } = paymentMethods.results[0];
@@ -225,7 +225,7 @@ const getIssuers = async () => {
        const paymentMethodId = document.getElementById('paymentMethodId').value;
        const issuerElement = document.getElementById('form-checkout__issuer');
 
-       const issuers = await mp.getIssuers({paymentMethodId, bin: cardNumber.slice(0,6)});
+       const issuers = await mp.getIssuers({paymentMethodId, bin: cardNumber.slice(0,8)});
 
        createSelectOptions(issuerElement, issuers);
 
@@ -249,7 +249,7 @@ const getInstallments = async () => {
 
        const installments = await mp.getInstallments({
            amount: document.getElementById('transactionAmount').value,
-           bin: cardNumber.slice(0,6),
+           bin: cardNumber.slice(0,8),
            paymentTypeId: 'credit_card'
        });
 

--- a/guides/checkout-api/receiving-payment-by-card-core-methods.es.md
+++ b/guides/checkout-api/receiving-payment-by-card-core-methods.es.md
@@ -174,7 +174,7 @@ function createSelectOptions(elem, options, labelsAndKeys = { label : "name", va
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Obtener método de pago de la tarjeta
 
-Valida los datos de tus clientes mientras los completan para evitar errores y que puedas ofrecer correctamente las cuotas disponibles. Usa el siguiente código de ejemplo para identificar el medio de pago con los primeros 6 dígitos de la tarjeta.
+Valida los datos de tus clientes mientras los completan para evitar errores y que puedas ofrecer correctamente las cuotas disponibles. Usa el siguiente código de ejemplo para identificar el medio de pago con los primeros 8 dígitos de la tarjeta.
 
 ```javascript
 // Step #getPaymentMethods
@@ -192,15 +192,15 @@ cardNumberElement.addEventListener('keyup', async () => {
        const installmentsElement = document.getElementById('form-checkout__installments');
        let cardNumber = cardNumberElement.value;
 
-       if (cardNumber.length < 6 && paymentMethodElement.value) {
+       if (cardNumber.length < 8 && paymentMethodElement.value) {
            clearHTMLSelectChildrenFrom(issuerElement);
            clearHTMLSelectChildrenFrom(installmentsElement);
            paymentMethodElement.value = "";
            return
        }
 
-       if (cardNumber.length >= 6 && !paymentMethodElement.value) {
-           let bin = cardNumber.substring(0,6);
+       if (cardNumber.length >= 8 && !paymentMethodElement.value) {
+           let bin = cardNumber.substring(0,8);
            const paymentMethods = await mp.getPaymentMethods({'bin': bin});
 
            const { id: paymentMethodId, additional_info_needed, issuer } = paymentMethods.results[0];
@@ -237,7 +237,7 @@ const getIssuers = async () => {
        const paymentMethodId = document.getElementById('paymentMethodId').value;
        const issuerElement = document.getElementById('form-checkout__issuer');
 
-       const issuers = await mp.getIssuers({paymentMethodId, bin: cardNumber.slice(0,6)});
+       const issuers = await mp.getIssuers({paymentMethodId, bin: cardNumber.slice(0,8)});
 
        createSelectOptions(issuerElement, issuers);
 
@@ -261,7 +261,7 @@ const getInstallments = async () => {
 
        const installments = await mp.getInstallments({
            amount: document.getElementById('transactionAmount').value,
-           bin: cardNumber.slice(0,6),
+           bin: cardNumber.slice(0,8),
            paymentTypeId: 'credit_card'
        });
 

--- a/guides/checkout-api/receiving-payment-by-card-core-methods.pt.md
+++ b/guides/checkout-api/receiving-payment-by-card-core-methods.pt.md
@@ -177,7 +177,7 @@ function createSelectOptions(elem, options, labelsAndKeys = { label : "name", va
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Obtenha o método de pagamento do cartão
 
-Valide os dados dos seus clientes enquanto são preenchidos para evitar erros e oferecer corretamente as parcelas disponíveis. Use o seguinte código de exemplo para identificar o meio de pagamento com os primeiros 6 dígitos do cartão.
+Valide os dados dos seus clientes enquanto são preenchidos para evitar erros e oferecer corretamente as parcelas disponíveis. Use o seguinte código de exemplo para identificar o meio de pagamento com os primeiros 8 dígitos do cartão.
 
 ```javascript
 // Step #getPaymentMethods
@@ -195,15 +195,15 @@ cardNumberElement.addEventListener('keyup', async () => {
        const installmentsElement = document.getElementById('form-checkout__installments');
        let cardNumber = cardNumberElement.value;
 
-       if (cardNumber.length < 6 && paymentMethodElement.value) {
+       if (cardNumber.length < 8 && paymentMethodElement.value) {
            clearHTMLSelectChildrenFrom(issuerElement);
            clearHTMLSelectChildrenFrom(installmentsElement);
            paymentMethodElement.value = "";
            return
        }
 
-       if (cardNumber.length >= 6 && !paymentMethodElement.value) {
-           let bin = cardNumber.substring(0,6);
+       if (cardNumber.length >= 8 && !paymentMethodElement.value) {
+           let bin = cardNumber.substring(0,8);
            const paymentMethods = await mp.getPaymentMethods({'bin': bin});
 
            const { id: paymentMethodId, additional_info_needed, issuer } = paymentMethods.results[0];
@@ -241,7 +241,7 @@ const getIssuers = async () => {
        const paymentMethodId = document.getElementById('paymentMethodId').value;
        const issuerElement = document.getElementById('form-checkout__issuer');
 
-       const issuers = await mp.getIssuers({paymentMethodId, bin: cardNumber.slice(0,6)});
+       const issuers = await mp.getIssuers({paymentMethodId, bin: cardNumber.slice(0,8)});
 
        createSelectOptions(issuerElement, issuers);
 
@@ -265,7 +265,7 @@ const getInstallments = async () => {
 
        const installments = await mp.getInstallments({
            amount: document.getElementById('transactionAmount').value,
-           bin: cardNumber.slice(0,6),
+           bin: cardNumber.slice(0,8),
            paymentTypeId: 'credit_card'
        });
 

--- a/guides/checkout-api/v1/receiving-payment-by-card.en.md
+++ b/guides/checkout-api/v1/receiving-payment-by-card.en.md
@@ -162,15 +162,15 @@ window.Mercadopago.getIdentificationTypes();
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Get card payment method
 
-Avoid mistakes and offer the correct available installments by validating your customers' data as they fill it out. Use the code in the following example to identify payment method with the first 6 digits of the card.
+Avoid mistakes and offer the correct available installments by validating your customers' data as they fill it out. Use the code in the following example to identify payment method with the first 8 digits of the card.
 
 ```javascript
 document.getElementById('cardNumber').addEventListener('change', guessPaymentMethod);
 
 function guessPaymentMethod(event) {
    let cardnumber = document.getElementById("cardNumber").value;
-   if (cardnumber.length >= 6) {
-       let bin = cardnumber.substring(0,6);
+   if (cardnumber.length >= 8) {
+       let bin = cardnumber.substring(0,8);
        window.Mercadopago.getPaymentMethod({
            "bin": bin
        }, setPaymentMethod);

--- a/guides/checkout-api/v1/receiving-payment-by-card.es.md
+++ b/guides/checkout-api/v1/receiving-payment-by-card.es.md
@@ -184,15 +184,15 @@ window.Mercadopago.getIdentificationTypes();
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Obtener método de pago de la tarjeta
 
-Valida los datos de tus clientes mientras los completan para evitar errores y que puedas ofrecer correctamente las cuotas disponibles. Usa el siguiente código de ejemplo para identificar el medio de pago con los primeros 6 dígitos de la tarjeta.
+Valida los datos de tus clientes mientras los completan para evitar errores y que puedas ofrecer correctamente las cuotas disponibles. Usa el siguiente código de ejemplo para identificar el medio de pago con los primeros 8 dígitos de la tarjeta.
 
 ```javascript
 document.getElementById('cardNumber').addEventListener('change', guessPaymentMethod);
 
 function guessPaymentMethod(event) {
    let cardnumber = document.getElementById("cardNumber").value;
-   if (cardnumber.length >= 6) {
-       let bin = cardnumber.substring(0,6);
+   if (cardnumber.length >= 8) {
+       let bin = cardnumber.substring(0,8);
        window.Mercadopago.getPaymentMethod({
            "bin": bin
        }, setPaymentMethod);

--- a/guides/checkout-api/v1/receiving-payment-by-card.pt.md
+++ b/guides/checkout-api/v1/receiving-payment-by-card.pt.md
@@ -188,15 +188,15 @@ window.Mercadopago.getIdentificationTypes();
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Obtenha o método de pagamento do cartão
 
-Valide os dados dos seus clientes enquanto são preenchidos para evitar erros e oferecer corretamente as parcelas disponíveis. Use o seguinte código de exemplo para identificar o meio de pagamento com os primeiros 6 dígitos do cartão.
+Valide os dados dos seus clientes enquanto são preenchidos para evitar erros e oferecer corretamente as parcelas disponíveis. Use o seguinte código de exemplo para identificar o meio de pagamento com os primeiros 8 dígitos do cartão.
 
 ```javascript
 document.getElementById('cardNumber').addEventListener('change', guessPaymentMethod);
 
 function guessPaymentMethod(event) {
    let cardnumber = document.getElementById("cardNumber").value;
-   if (cardnumber.length >= 6) {
-       let bin = cardnumber.substring(0,6);
+   if (cardnumber.length >= 8) {
+       let bin = cardnumber.substring(0,8);
        window.Mercadopago.getPaymentMethod({
            "bin": bin
        }, setPaymentMethod);

--- a/guides/snippets/test-integration/secure-fields-core.en.md
+++ b/guides/snippets/test-integration/secure-fields-core.en.md
@@ -176,7 +176,7 @@ function createSelectOptions(elem, options, labelsAndKeys = { label : "name", va
 
 #### Get card payment method
 
-Avoid mistakes and offer the correct available installments by validating your customers' data as they fill it out. Use the code in the following example to identify payment method with the first 6 digits of the card.
+Avoid mistakes and offer the correct available installments by validating your customers' data as they fill it out. Use the code in the following example to identify payment method with the first 8 digits of the card.
 
 ```javascript
 function clearHTMLSelectChildrenFrom(element) {

--- a/guides/snippets/test-integration/secure-fields-core.es.md
+++ b/guides/snippets/test-integration/secure-fields-core.es.md
@@ -177,7 +177,7 @@ function createSelectOptions(elem, options, labelsAndKeys = { label : "name", va
 
 #### Obtener método de pago de la tarjeta
 
-Valida los datos de tus clientes mientras los completan para evitar errores y que puedas ofrecer correctamente las cuotas disponibles. Usa el siguiente código de ejemplo para identificar el medio de pago con los primeros 6 dígitos de la tarjeta.
+Valida los datos de tus clientes mientras los completan para evitar errores y que puedas ofrecer correctamente las cuotas disponibles. Usa el siguiente código de ejemplo para identificar el medio de pago con los primeros 8 dígitos de la tarjeta.
 
 ```javascript
 function clearHTMLSelectChildrenFrom(element) {

--- a/guides/snippets/test-integration/secure-fields-core.pt.md
+++ b/guides/snippets/test-integration/secure-fields-core.pt.md
@@ -177,7 +177,7 @@ function createSelectOptions(elem, options, labelsAndKeys = { label : "name", va
 
 #### Obtenha o meio de pagamento do cartão
 
-Valide os dados dos seus clientes enquanto estes são preenchidos para evitar erros e oferecer corretamente as parcelas disponíveis. Use o seguinte código de exemplo para identificar o meio de pagamento com os primeiros 6 dígitos do cartão.
+Valide os dados dos seus clientes enquanto estes são preenchidos para evitar erros e oferecer corretamente as parcelas disponíveis. Use o seguinte código de exemplo para identificar o meio de pagamento com os primeiros 8 dígitos do cartão.
 
 ```javascript
 function clearHTMLSelectChildrenFrom(element) {


### PR DESCRIPTION
## Description

With the change of card BIN size from 6 to 8, we need to adapt some scripts to send the first 8 digits to the payment_methods API in order to be able to process payments with BIN 8 cards.
