### PR TITLE
[DEVCOMMS-1028] Apagado Baloto para mco

### DIFF
--- a/guides/checkout-api/other-payment-methods.en.md
+++ b/guides/checkout-api/other-payment-methods.en.md
@@ -1603,24 +1603,6 @@ Keep in mind that the answer will return all the payments methods. For this reas
         ]
     },
 {
-        "id": "baloto",
-        "name": "Baloto",
-        "payment_type_id": "ticket",
-        "status": "active",
-        "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/baloto.gif",
-        "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/baloto.gif",
-        "deferred_capture": "supported",
-        "settings": [],
-        "additional_info_needed": [],
-        "min_allowed_amount": 1500,
-        "max_allowed_amount": 1000000,
-        "accreditation_time": 0,
-        "financial_institutions": [],
-        "processing_modes": [
-            "aggregator"
-        ]
-    },
-{
         "id": "pse",
         "name": "PSE",
         "payment_type_id": "bank_transfer",

--- a/guides/checkout-api/other-payment-methods.es.md
+++ b/guides/checkout-api/other-payment-methods.es.md
@@ -1607,24 +1607,6 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
         ]
     },
 {
-        "id": "baloto",
-        "name": "Baloto",
-        "payment_type_id": "ticket",
-        "status": "active",
-        "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/baloto.gif",
-        "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/baloto.gif",
-        "deferred_capture": "supported",
-        "settings": [],
-        "additional_info_needed": [],
-        "min_allowed_amount": 1500,
-        "max_allowed_amount": 1000000,
-        "accreditation_time": 0,
-        "financial_institutions": [],
-        "processing_modes": [
-            "aggregator"
-        ]
-    },
-{
         "id": "pse",
         "name": "PSE",
         "payment_type_id": "bank_transfer",

--- a/guides/checkout-api/other-payment-methods.pt.md
+++ b/guides/checkout-api/other-payment-methods.pt.md
@@ -1604,24 +1604,6 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
         ]
     },
 {
-        "id": "baloto",
-        "name": "Baloto",
-        "payment_type_id": "ticket",
-        "status": "active",
-        "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/baloto.gif",
-        "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/baloto.gif",
-        "deferred_capture": "supported",
-        "settings": [],
-        "additional_info_needed": [],
-        "min_allowed_amount": 1500,
-        "max_allowed_amount": 1000000,
-        "accreditation_time": 0,
-        "financial_institutions": [],
-        "processing_modes": [
-            "aggregator"
-        ]
-    },
-{
         "id": "pse",
         "name": "PSE",
         "payment_type_id": "bank_transfer",

--- a/guides/checkout-api/v1/other-payment-ways.en.md
+++ b/guides/checkout-api/v1/other-payment-ways.en.md
@@ -1552,24 +1552,6 @@ Keep in mind that the answer will return all the payments methods. For this reas
         ]
     },
 {
-        "id": "baloto",
-        "name": "Baloto",
-        "payment_type_id": "ticket",
-        "status": "active",
-        "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/baloto.gif",
-        "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/baloto.gif",
-        "deferred_capture": "supported",
-        "settings": [],
-        "additional_info_needed": [],
-        "min_allowed_amount": 1500,
-        "max_allowed_amount": 1000000,
-        "accreditation_time": 0,
-        "financial_institutions": [],
-        "processing_modes": [
-            "aggregator"
-        ]
-    },
-{
         "id": "pse",
         "name": "PSE",
         "payment_type_id": "bank_transfer",

--- a/guides/checkout-api/v1/other-payment-ways.es.md
+++ b/guides/checkout-api/v1/other-payment-ways.es.md
@@ -1560,24 +1560,6 @@ Ten en cuenta que la respuesta devolverá todos los medios de pago. Por eso, tie
         ]
     },
 {
-        "id": "baloto",
-        "name": "Baloto",
-        "payment_type_id": "ticket",
-        "status": "active",
-        "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/baloto.gif",
-        "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/baloto.gif",
-        "deferred_capture": "supported",
-        "settings": [],
-        "additional_info_needed": [],
-        "min_allowed_amount": 1500,
-        "max_allowed_amount": 1000000,
-        "accreditation_time": 0,
-        "financial_institutions": [],
-        "processing_modes": [
-            "aggregator"
-        ]
-    },
-{
         "id": "pse",
         "name": "PSE",
         "payment_type_id": "bank_transfer",

--- a/guides/checkout-api/v1/other-payment-ways.pt.md
+++ b/guides/checkout-api/v1/other-payment-ways.pt.md
@@ -1556,24 +1556,6 @@ Tenha em conta que essa resposta devolverá todos os meios de pagamento. Por iss
         ]
     },
 {
-        "id": "baloto",
-        "name": "Baloto",
-        "payment_type_id": "ticket",
-        "status": "active",
-        "secure_thumbnail": "https://www.mercadopago.com/org-img/MP3/API/logos/baloto.gif",
-        "thumbnail": "http://img.mlstatic.com/org-img/MP3/API/logos/baloto.gif",
-        "deferred_capture": "supported",
-        "settings": [],
-        "additional_info_needed": [],
-        "min_allowed_amount": 1500,
-        "max_allowed_amount": 1000000,
-        "accreditation_time": 0,
-        "financial_institutions": [],
-        "processing_modes": [
-            "aggregator"
-        ]
-    },
-{
         "id": "pse",
         "name": "PSE",
         "payment_type_id": "bank_transfer",

--- a/guides/unofficial/vtex/payment-methods.en.md
+++ b/guides/unofficial/vtex/payment-methods.en.md
@@ -60,7 +60,6 @@ This document contains the means and types of payment available for your integra
 |Diners|`diners`|`credit_car`|Diners, MercadoPagoPro and MercadoPagoWallet|
 |Mastercard Debit|`debmaster`|`debit_card`|Mastercard Debit, MercadoPagoPro yand MercadoPagoWallet|
 |Visa Debit|`debvisa`|`debit_card`|Visa Electron, MercadoPagoPro and MercadoPagoWallet|
-|Baloto|`baloto`|`ticket`|MercadoPagoPro and MercadoPagoOff|
 |Efecty|`efecty`|`ticket`|MercadoPagoPro and MercadoPagoOff|
 |PSE|`pse`|`bank_transfer`|PSE and MercadoPagoPro|
 

--- a/guides/unofficial/vtex/payment-methods.es.md
+++ b/guides/unofficial/vtex/payment-methods.es.md
@@ -60,7 +60,6 @@ Este documento contiene los medios y tipos de pago disponibles para tu integraci
 |Diners|`diners`|`credit_car`|Diners, MercadoPagoPro y MercadoPagoWallet|
 |Mastercard Débito|`debmaster`|`debit_card`|Mastercard Debit, MercadoPagoPro y MercadoPagoWallet|
 |Visa Débito|`debvisa`|`debit_card`|Visa Electron, MercadoPagoPro y MercadoPagoWallet|
-|Baloto|`baloto`|`ticket`|MercadoPagoPro y MercadoPagoOff|
 |Efecty|`efecty`|`ticket`|MercadoPagoPro y MercadoPagoOff|
 |PSE|`pse`|`bank_transfer`|PSE y MercadoPagoPro|
 

--- a/guides/unofficial/vtex/payment-methods.pt.md
+++ b/guides/unofficial/vtex/payment-methods.pt.md
@@ -60,7 +60,6 @@ Este documento contém os métodos e tipos de pagamento disponíveis para sua in
 |Diners|`diners`|`credit_car`|Diners, MercadoPagoPro e MercadoPagoWallet|
 |Mastercard Débito|`debmaster`|`debit_card`|Mastercard Debit, MercadoPagoPro e MercadoPagoWallet|
 |Visa Débito|`debvisa`|`debit_card`|Visa Electron, MercadoPagoPro e MercadoPagoWallet|
-|Baloto|`baloto`|`ticket`|MercadoPagoPro e MercadoPagoOff|
 |Efecty|`efecty`|`ticket`|MercadoPagoPro e MercadoPagoOff|
 |PSE|`pse`|`bank_transfer`|PSE e MercadoPagoPro|
 

--- a/guides/vtex/payment-methods.en.md
+++ b/guides/vtex/payment-methods.en.md
@@ -60,7 +60,6 @@ This document contains the means and types of payment available for your integra
 |Diners|`diners`|`credit_car`|Diners, MercadoPagoPro and MercadoPagoWallet|
 |Mastercard Debit|`debmaster`|`debit_card`|Mastercard Debit, MercadoPagoPro yand MercadoPagoWallet|
 |Visa Debit|`debvisa`|`debit_card`|Visa Electron, MercadoPagoPro and MercadoPagoWallet|
-|Baloto|`baloto`|`ticket`|MercadoPagoPro and MercadoPagoOff|
 |Efecty|`efecty`|`ticket`|MercadoPagoPro and MercadoPagoOff|
 |PSE|`pse`|`bank_transfer`|PSE and MercadoPagoPro|
 

--- a/guides/vtex/payment-methods.es.md
+++ b/guides/vtex/payment-methods.es.md
@@ -60,7 +60,6 @@ Este documento contiene los medios y tipos de pago disponibles para tu integraci
 |Diners|`diners`|`credit_car`|Diners, MercadoPagoPro y MercadoPagoWallet|
 |Mastercard Débito|`debmaster`|`debit_card`|Mastercard Debit, MercadoPagoPro y MercadoPagoWallet|
 |Visa Débito|`debvisa`|`debit_card`|Visa Electron, MercadoPagoPro y MercadoPagoWallet|
-|Baloto|`baloto`|`ticket`|MercadoPagoPro y MercadoPagoOff|
 |Efecty|`efecty`|`ticket`|MercadoPagoPro y MercadoPagoOff|
 |PSE|`pse`|`bank_transfer`|PSE y MercadoPagoPro|
 

--- a/guides/vtex/payment-methods.pt.md
+++ b/guides/vtex/payment-methods.pt.md
@@ -60,7 +60,6 @@ Este documento contém os métodos e tipos de pagamento disponíveis para sua in
 |Diners|`diners`|`credit_car`|Diners, MercadoPagoPro e MercadoPagoWallet|
 |Mastercard Débito|`debmaster`|`debit_card`|Mastercard Debit, MercadoPagoPro e MercadoPagoWallet|
 |Visa Débito|`debvisa`|`debit_card`|Visa Electron, MercadoPagoPro e MercadoPagoWallet|
-|Baloto|`baloto`|`ticket`|MercadoPagoPro e MercadoPagoOff|
 |Efecty|`efecty`|`ticket`|MercadoPagoPro e MercadoPagoOff|
 |PSE|`pse`|`bank_transfer`|PSE e MercadoPagoPro|
 


### PR DESCRIPTION
## Description

El día 24/5 se eliminó Baloto como medio de pago en Colombia. Se procede con la eliminación del medio de pago en la documentación de Mercado Pago Developers.

Documentación afectada:

- checkout api
- VTEX