### PR TITLE
[ADD] Include content related to interop impl to add new columns in release-report. 

### DIFF
--- a/guides/additional-content/reports/released-money/generate.en.md
+++ b/guides/additional-content/reports/released-money/generate.en.md
@@ -1,5 +1,11 @@
 # How to generate your Releases report?
 
+> NOTE
+>
+> Easily keep track of your sales made with a QR Code
+>
+> We have created new columns that allow you to identify which digital wallets or banks your clients use when they pay with a Mercado Pago QR Code. Update your settings preferences [from the panel](https://www.mercadopago[FAKER][URL][DOMAIN]/balance/reports/release/settings) or [via API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/additional-content/reports/released-money/api) so that you can include these columns in your reports.
+
 ## Generating channels
 
 You can generate a Release report from your Mercado Pago account:

--- a/guides/additional-content/reports/released-money/generate.es.md
+++ b/guides/additional-content/reports/released-money/generate.es.md
@@ -2,6 +2,12 @@
 # ¿Cómo generar tu reporte de Liberaciones?
 ------------
 
+> NOTE
+>
+> Lleva con facilidad el control de tus ventas con QR
+>
+> Creamos nuevas columnas que te permiten identificar las billeteras virtuales o los bancos que tus clientes usan para pagar cuando les cobras con un QR de Mercado Pago. Actualiza tus preferencias de configuración [desde el panel](https://www.mercadopago[FAKER][URL][DOMAIN]/balance/reports/release/settings) o [vía API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/manage-account/reports/released-money/api) para incluir las columnas en tus reportes.
+
 ## Canales de generación
 
 Puedes generar un reporte de ----[mla]---- Liquidaciones ------------ ----[mlm, mlb, mlc, mco, mlu, mpe]---- Liberaciones ------------ desde tu cuenta de Mercado Pago:

--- a/guides/additional-content/reports/released-money/generate.pt.md
+++ b/guides/additional-content/reports/released-money/generate.pt.md
@@ -2,6 +2,12 @@
 # Como gerar o seu relatório de Liberações?
 ------------
 
+> NOTE
+>
+> Gerencie suas vendas com código QR de um jeito fácil
+>
+> Criamos novas colunas que permitem que você identifique as carteiras digitais ou os bancos que seus clientes utilizam ao pagarem com um código QR do Mercado Pago. Atualize suas preferências de configuração [no painel](https://www.mercadopago[FAKER][URL][DOMAIN]/balance/reports/release/settings) ou [via API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/manage-account/reports/released-money/api) para incluir as colunas nos seus relatórios.
+
 ## Canais de geração
 
 Você pode gerar um relatório de ----[mla]---- Liquidações ------------ ----[mlm, mlb, mlc, mco, mlu, mpe]---- Liberações ------------ pela sua conta Mercado Pago:

--- a/guides/additional-content/reports/released-money/glossary.en.md
+++ b/guides/additional-content/reports/released-money/glossary.en.md
@@ -40,7 +40,9 @@ If you have any doubts about the technical terms used, check the glossary below.
 | POI_ID | Point ID if payment is made through a physical retailer. |
 | CARD_INITIAL_NUMBER | It corresponds to the first digits of the credit or debit card that you used to make the purchase. |
 | OPERATION_TAGS | These are labels to categorize and/or segment different aspects of the transaction, such as the channels used to make a payment. They are identified as:<br>WHATSAPP_PAY: This label indicates that the payment was made via WhatsApp<br>QR: This label indicates that the payment was made with a QR code<br>PO: This label indicates that the payment was made with Point<br>MARKETPLACE: This label indicates that the payment was made directly in Mercado Libre. |
-| ITEM_ID | Identifier of the product sold. |
+| ITEM_ID | Identifierssss of the product sold. |
+| POI_WALLET_NAME | Name of the digital wallet that a virtual payment comes from. Allows you to identify the origin of a transaction when you charge with a Mercado Pago QR Code.|
+| POI_BANK_NAME | Name of the bank that a virtual payment comes from. Allows you to identify the origin of a transaction when you charge with a Mercado Pago QR Code.|
 
 ### Next steps
 

--- a/guides/additional-content/reports/released-money/glossary.es.md
+++ b/guides/additional-content/reports/released-money/glossary.es.md
@@ -41,6 +41,8 @@ Lo sabemos, algunos términos son técnicos y puede que no estés familiarizado 
 | CARD_INITIAL_NUMBER | Corresponde a los primeros dígitos de la tarjeta crédito o débito con la que se hizo la compra. |
 | OPERATION_TAGS | Son las etiquetas para categorizar y/o segmentar diferentes aspectos de la transacción, como por ejemplo los canales usados para hacer un pago.Se identifican como:<br><br>  -   WHATSAPP_PAY: Esta etiqueta indica que el pago fue hecho a través de whatsApp. <br> -   CASHOUT: Esta etiqueta indica que la operación corresponde a un Pix Saque. <br> -   EXTRACASHOUT: Esta etiqueta indica que la operación corresponde a un Pix Troco. <br> -   PIX: Esta etiqueta indica que la operación corresponde a un pago Pix. |
 | ITEM_ID | Identificador del producto vendido. |
+| POI_WALLET_NAME | Nombre de la billetera virtual desde la que se origina un pago digital. Permite identificar el origen de una operación cuando cobras con un ----[mla]----[código QR interoperable](https://vendedores.mercadolibre.com.ar/nota/cobra-a-otras-billeteras-con-tu-qr-de-mercado-pago)------------ ----[mlu, mpe, mlm, mco, mlc, mlb]----código QR de Mercado Pago------------.|
+| POI_BANK_NAME | Nombre de la entidad bancaria desde la que se origina un pago digital. Permite identificar el origen de una operación cuando cobras con un ----[mla]----[código QR interoperable](https://vendedores.mercadolibre.com.ar/nota/cobra-a-otras-billeteras-con-tu-qr-de-mercado-pago)------------ ----[mlu, mpe, mlm, mco, mlc, mlb]----código QR de Mercado Pago------------.|
 
 ----[mpe, mlu]----
 > INFO

--- a/guides/additional-content/reports/released-money/glossary.pt.md
+++ b/guides/additional-content/reports/released-money/glossary.pt.md
@@ -41,6 +41,8 @@ Sabemos que alguns termos são técnicos e você pode não estar familiarizado c
 | CARD_INITIAL_NUMBER | Corresponde aos primeiros dígitos do cartão de crédito ou débito utilizado para realizar a compra. |
 | OPERATION_TAGS | São etiquetas para categorizar e/ou segmentar diferentes aspectos da transação, como por exemplo, os canais usados para fazer um pagamento. Eles são identificados como:<br><br>  -   WHATSAPP_PAY: Esta etiqueta indica que o pagamento foi feito via WhatsApp <br> -   CASHOUT: Esta etiqueta indica que a transação corresponde a um Pix Saque <br> -   EXTRACASHOUT: Esta etiqueta indica que a transação corresponde a um Pix Troco <br> -   PIX: Esta etiqueta indica que a transação corresponde a um pagamento via Pix. |
 | ITEM_ID | Identificador do produto vendido. |
+| POI_WALLET_NAME | Nome da carteira digital de onde um pagamento virtual saiu. Permite identificar a origem de uma transação quando você cobra com um código QR do Mercado Pago.|
+| POI_BANK_NAME | Nome da instituição bancária de onde um pagamento virtual saiu. Permite identificar a origem de uma transação quando você cobra com um código QR do Mercado Pago.|
 
 ### Próximos passos
 


### PR DESCRIPTION
## [ADD] Include content related to interop impl to add new columns in release-report.

Includes description related to the implementation of Interop columns for balance reports (Release Report). Sections affected (For guides/manage-account/released-money):

Glossary: Include description of new columns.
Generation: Include alert message to notify new features.
Changelog: Changelog record.
The columns POI_WALLET_NAME y POI_BANK_NAME allow businesses that charge with a Mercado Pago QR code to identify from which digital wallets or banks their payments came from.

By default, these columns are disabled. To display them in the "All Transactions" report it is necessary to update the settings preferences from the dashboard or via API.


### Información relevante
- **Iniciativa:** Incluir campos de banco y billetera en Release Report
- **Referentes / Responsables:** Edwin Giraldo
- **Ticket de Jira:**[ [[MPRC-10385](https://mercadolibre.atlassian.net/browse/MPRC-10385)](https://mercadolibre.atlassian.net/browse/MPRC-10109)](https://mercadolibre.atlassian.net/browse/MPRC-10201)

### ¿Qué tipo de PR es?
- [X] Feature nuevo
- [ ] Breaking change
- [ ] Fix
- [ ] Refactor
- [ ] Otro:

## Pruebas funcionales


<img width="910" alt="Captura de Pantalla 2022-05-19 a la(s) 3 58 52 p m" src="https://user-images.githubusercontent.com/96143694/169408244-1a936e37-52f2-4787-98c1-26cfaeec6bb6.png">

<img width="907" alt="Captura de Pantalla 2022-05-19 a la(s) 3 58 37 p m" src="https://user-images.githubusercontent.com/96143694/169408281-665d6421-4aff-4322-9379-4d336eb9c67a.png">

<img width="899" alt="Captura de Pantalla 2022-05-19 a la(s) 3 59 05 p m" src="https://user-images.githubusercontent.com/96143694/169408298-bd0ae0ba-7038-41f7-a270-c442a18ee365.png">

<img width="947" alt="Captura de Pantalla 2022-05-19 a la(s) 4 01 21 p m" src="https://user-images.githubusercontent.com/96143694/169408318-11ae2aed-1fb6-4659-9ee1-bbf29bee6485.png">

<img width="950" alt="Captura de Pantalla 2022-05-19 a la(s) 4 01 38 p m" src="https://user-images.githubusercontent.com/96143694/169408414-e2056b16-51be-45a7-af1a-00724e873886.png">

<img width="917" alt="Captura de Pantalla 2022-05-19 a la(s) 4 01 55 p m" src="https://user-images.githubusercontent.com/96143694/169408371-69a4ad46-79ef-4058-b5b7-202d059bdeb8.png">

