### PR TITLE
switching paths to anchors name on checkout-bricks/configure-integration

### DIFF
--- a/guides/checkout-bricks/configure-integration.en.md
+++ b/guides/checkout-bricks/configure-integration.en.md
@@ -2,10 +2,10 @@
 
 To configure brick integration you need to follow the steps below:
 
-1. [Create container](/developers/en/docs/checkout-bricks/integration/configure-integration#bookmark_create_container)
-2. [Include and configure MercadoPago.js library](/developers/en/docs/checkout-bricks/integration/configure-integration#bookmark_include_and_configure_mercadopago.js_library)
-3. [Instantiate brick](/developers/en/docs/checkout-bricks/integration/configure-integration#bookmark_instantiate_brick)
-4. [Render brick](/developers/en/docs/checkout-bricks/integration/configure-integration#bookmark_render_brick)
+1. [Create container](#bookmark_create_container)
+2. [Include and configure MercadoPago.js library](#bookmark_include_and_configure_mercadopago.js_library)
+3. [Instantiate brick](#bookmark_instantiate_brick)
+4. [Render brick](#bookmark_render_brick)
 
 > The steps are performed on the backend or frontend. The **Client-Side** and **Server-Side** pills located immediately next to the title help you to identify which step is performed in which instance.
 > <br/>

--- a/guides/checkout-bricks/configure-integration.es.md
+++ b/guides/checkout-bricks/configure-integration.es.md
@@ -2,10 +2,10 @@
 
 Para configurar la integración de los bricks, debe seguir los pasos a continuación:
 
-1. [Crear container](/developers/es/docs/checkout-bricks/integration/configure-integration#bookmark_crear_container)
-2. [Incluir y configurar la librería MercadoPago.js](/developers/es/docs/checkout-bricks/integration/configure-integration#bookmark_incluir_y_configurar_la_librería_mercadopago.js)
-3. [Instanciar brick](/developers/es/docs/checkout-bricks/integration/configure-integration#bookmark_instanciar_brick)
-4. [Renderizar brick](/developers/es/docs/checkout-bricks/integration/configure-integration#bookmark_renderizar_brick)
+1. [Crear container](#bookmark_crear_container)
+2. [Incluir y configurar la librería MercadoPago.js](#bookmark_incluir_y_configurar_la_librería_mercadopago.js)
+3. [Instanciar brick](#bookmark_instanciar_brick)
+4. [Renderizar brick](#bookmark_renderizar_brick)
 
 > Los pasos se realizan en el backend o frontend. Las etiquetas **Client-Side** y **Server-Side** ubicadas inmediatamente al lado del título lo ayudan a identificar qué paso se realiza en qué instancia.
 > <br/>

--- a/guides/checkout-bricks/configure-integration.pt.md
+++ b/guides/checkout-bricks/configure-integration.pt.md
@@ -2,10 +2,10 @@
 
 Para configurar a integração dos bricks você precisa seguir os passos abaixo:
 
-1. [Criar container](/developers/pt/docs/checkout-bricks/integration/configure-integration#bookmark_criar_container)
-2. [Incluir e configurar a biblioteca MercadoPago.js](/developers/pt/docs/checkout-bricks/integration/configure-integration#bookmark_incluir_e_configurar_a_biblioteca_mercadopago.js)
-3. [Instanciar brick](/developers/pt/docs/checkout-bricks/integration/configure-integration#bookmark_instanciar_brick)
-4. [Renderizar brick](/developers/pt/docs/checkout-bricks/integration/configure-integration#bookmark_renderizar_brick)
+1. [Criar container](#bookmark_criar_container)
+2. [Incluir e configurar a biblioteca MercadoPago.js](#bookmark_incluir_e_configurar_a_biblioteca_mercadopago.js)
+3. [Instanciar brick](#bookmark_instanciar_brick)
+4. [Renderizar brick](#bookmark_renderizar_brick)
 
 > Os passos são realizados no back-end ou no front-end. As pills **Client-Side** e **Server-Side** localizadas imediatamentamente ao lado do título te ajudam a identificar qual passo é realizado em qual instância. <br/></br>
 > <br/></br>


### PR DESCRIPTION
## Description
Fix do href de links que redirecionam para a mesma página. Em `developers/pt/docs/checkout-bricks/integration/configure-integration`.

Referente ao bug:
https://meli.slack.com/archives/C03D8E8T9S8/p1654785470061349
