### PR TITLE
fix/collection reattempt info added

### DIFF
--- a/guides/subscriptions/subscription-no-associated-plan.en.md
+++ b/guides/subscriptions/subscription-no-associated-plan.en.md
@@ -73,7 +73,6 @@ In the case that the installment cannot be collected on the fourth reattempt, it
 
 After 3 installments with rejected payments, the subscription is automatically canceled and the seller account will be notified of the cancellation of the subscription by e-mail.
 
-
 > NOTE
 > 
 > Note

--- a/guides/subscriptions/subscription-no-associated-plan.en.md
+++ b/guides/subscriptions/subscription-no-associated-plan.en.md
@@ -21,6 +21,65 @@ After completing the fields, execute the request.
 >
 > We make a payment with a minimum amount to prove the card's validity. If it is successful, we will proceed with returning that payment. The value may differ according to each country.
 
+### Collection reattempt logic
+
+By automating the recurrence of your collections, authorized payments that will have a debit date configured based on the periodicity that was defined in the subscription are created. The first installment is charged until the period of approximately one hour to subscribe.
+
+#### Payment statuses
+
+----[mlb, mlm]----
+
+At the time the installment is collected, two alternatives may arise based on the outcome of the payment:
+
+* __Payment is successfully made__ so, the installment will remain as `processed` and will not be reattempted. 
+
+* __Payment is declined__ so the installment will always remain in `recycling` status and when the installment is not expired or has not reached the maximum number of reattempts. Otherwise, it will be processed with the `processed` status.
+
+#### Declined payments
+
+When an installment remains in `recycling` status, it enters a reattempt scheme with a maximum of 4 possibilities, when the installment is collected again. The result can be any of the two points mentioned above. 
+
+If the payment is declined, it is updated to a new collection date by adding 1 of the 4 possibilities within ten days as a reattempt time window to the last available date.
+
+By default the reattempt is within a 10 day window. In case the installment has an expiration date, the time window is adjusted to that date and maintains the logic of 4 reattempt.
+
+------------
+
+----[mla]----
+
+At the time the installment is collected, three alternatives may arise, based on the outcome of the payment:
+
+* __Payment is successfully made__ so, the installment will remain as `processed` and will not be reattempted. 
+
+* __Payment is being processed__ so the installment will be pending in a `waiting for gateway` status until the payment is resolved.
+
+* __Payment is declined__ so the installment will always remain in `recycling` status and when the installment is not expired or has not reached the maximum number of reattempts. Otherwise, it will be processed with the `processed` status.
+
+#### Declined payments
+
+When an installment remains in `recycling` status, it enters a reattempt scheme with a maximum of 4 possibilities, when the installment is collected again. The result can be any of the three points mentioned above. 
+
+If the payment is declined, it is updated to a new collection date by adding 1 of the 4 possibilities within ten days as a reattempt time window to the last available date.
+
+By default the reattempt is within a 10 day window. In case the installment has an expiration date, the time window is adjusted to that date and maintains the logic of 4 reattempts.
+
+#### Payments in process
+
+If an installment is in `waiting for gateway` status and, when the payment is resolved, it appears as declined, and the expiration date is met, the installment will automatically appear as processed with the `processed` status. Otherwise, it will enter the reattempt scheme.
+
+------------
+
+In the case that the installment cannot be collected on the fourth reattempt, it will automatically remain in `processed` status, associated with a declined payment.
+
+After 3 installments with rejected payments, the subscription is automatically canceled and the seller account will be notified of the cancellation of the subscription by e-mail.
+
+
+> NOTE
+> 
+> Note
+> 
+> The result of one installment does not affect the generation and processing of the remaining installments for the same subscription.
+
 ## Subscriptions with pending payment 
 
 Subscriptions with pending payments are a model in which the payment method is not defined when the subscription is created. According to this model, payments automatically go into `pending` status and depend on the users to complete it.

--- a/guides/subscriptions/subscription-no-associated-plan.es.md
+++ b/guides/subscriptions/subscription-no-associated-plan.es.md
@@ -21,6 +21,65 @@ Después de completar los campos, ejecuta la solicitud.
 >
 > Para acreditar la validez de la tarjeta, realizamos un pago con un importe mínimo. Si el pago es exitoso, procederemos a la devolución de dicho pago. El valor puede diferir según cada país.
 
+### Lógica de reintentos de cobro
+
+Al automatizar la recurrencia de tus cobros, se crean pagos autorizados que tendrán una fecha de débito configurada en base a la periodicidad que se definió en la suscripción. Luego de suscribirse, el pago de la la primera cuota se acreditará en 1 hora.
+
+#### Estados de pago
+
+----[mlb, mlm]----
+
+En el momento en que se cobre la cuota pueden surgir dos alternativas en base al resultado de su pago:
+
+* __El pago es realizado exitosamente__ por lo que la cuota quedará `processed` y ya no se reintentará cobrarla. 
+
+* __El pago es rechazado__ por lo que la cuota quedará en `recycling` siempre y cuando la cuota no esté expirada o no haya alcanzado el máximo de reintentos. Caso contrario, quedará en `processed`.
+
+#### Pagos rechazados
+
+Cuando una cuota queda en el estado `recycling` entra en un esquema de reintentos con un máximo de 4 posibilidades, en los que se vuelve a realizar el cobro de la cuota. El resultado puede ser cualquiera de los dos puntos mencionados arriba. 
+
+Si el pago resulta rechazado, se actualiza a una nueva fecha de cobro sumando 1 de las 4 posibilidades dentro de los diez días como ventana de tiempo de reintento a la última fecha de disponible.
+
+Por defecto se reintenta dentro de una ventana de 10 días. En caso de que la cuota tenga fecha de expiración, la ventana de tiempo se ajusta a esa fecha y mantiene la lógica de 4 reintentos.
+
+------------
+
+----[mla]----
+
+En el momento en que se cobre la cuota pueden surgir tres alternativas en base al resultado de su pago:
+
+* __El pago es realizado exitosamente__ por lo que la cuota quedará `processed` y ya no se reintentará cobrarla. 
+
+* __El pago se está procesando__ por lo que la cuota quedará en `waiting for gateway` hasta que se resuelva el pago.
+
+* __El pago es rechazado__ por lo que la cuota quedará en `recycling` siempre y cuando la cuota no esté expirada o no haya alcanzado el máximo de reintentos. Caso contrario, quedará en `processed`.
+
+#### Pagos rechazados
+
+Cuando una cuota queda en el estado `recycling` entra en un esquema de reintentos con un máximo de 4 posibilidades, en los que se vuelve a realizar el cobro de la cuota. El resultado puede ser cualquiera de los tres puntos mencionados arriba. 
+
+Si el pago resulta rechazado, se actualiza a una nueva fecha de cobro sumando 1 de las 4 posibilidades dentro de los diez días como ventana de tiempo de reintento a la última fecha de disponible.
+
+Por defecto se reintenta dentro de una ventana de 10 días. En caso de que la cuota tenga fecha de expiración, la ventana de tiempo se ajusta a esa fecha y mantiene la lógica de 4 reintentos.
+
+#### Pagos en proceso
+
+Si una cuota se encuentra en el estado `waiting for gateway` y cuando se resuelve el pago resulta rechazada y se cumplió la fecha de expiración, la cuota automáticamente pasará a procesada con el estado `processed`. Caso contrario, entrará al esquema de reintento.
+
+------------
+
+En el caso de que no se pueda cobrar la cuota en el cuarto reintento, la cuota automáticamente quedará en el estado `processed` asociada a un pago rechazado.
+
+Luego de 3 cuotas con pagos rechazados se da de baja automáticamente la suscripción y la cuenta del vendedor será notificada de la cancelación de la suscripción por e-mail.
+
+
+> NOTE
+> 
+> Nota
+> 
+> El resultado de una cuota no afecta la generación y procesamiento del resto de las cuotas para la misma suscripción.
+
 ## Suscripciones con pago pendiente 
 
 Las suscripciones con pago pendiente son un modelo de suscripción donde no se define un método de pago en el momento de su creación. Cuando esto ocurre, los pagos pasan automáticamente al estado `pending` y dependen de que el usuario busque una forma de completar el pago.

--- a/guides/subscriptions/subscription-no-associated-plan.es.md
+++ b/guides/subscriptions/subscription-no-associated-plan.es.md
@@ -73,7 +73,6 @@ En el caso de que no se pueda cobrar la cuota en el cuarto reintento, la cuota a
 
 Luego de 3 cuotas con pagos rechazados se da de baja automáticamente la suscripción y la cuenta del vendedor será notificada de la cancelación de la suscripción por e-mail.
 
-
 > NOTE
 > 
 > Nota

--- a/guides/subscriptions/subscription-no-associated-plan.pt.md
+++ b/guides/subscriptions/subscription-no-associated-plan.pt.md
@@ -21,6 +21,68 @@ Finalizando o preenchimento dos campos, execute a requisição.
 >
 > Para comprovar a validade do cartão, realizamos um pagamento com um valor mínimo. Se o pagamento obter sucesso, procedemos com a realização da devolução desse pagamento. O valor pode diferir conforme cada país.
 
+
+### Lógica de novas tentativas de cobrança
+
+Ao automatizar a recorrência de suas cobranças, são criados pagamentos autorizados que terão uma data de débito configurada com base na periodicidade definida na assinatura. A primeira parcela é cobrada até o período aproximado de uma hora após a assinatura.
+
+#### Status de pagamento
+
+----[mlb, mlm]----
+
+Duas alternativas podem surgir na hora em que a parcela é cobrada com base no resultado do seu pagamento:
+
+* __O pagamento é feito com sucesso__ assim a parcela será processada no status `processed` e não ocorrerá uma nova tentativa de cobrança. 
+
+* __O pagamento é recusado__ portanto, a parcela permanecerá em status de `recycling` enquanto a parcela não estiver vencida ou não tiver atingido o número máximo de novas tentativas. Caso contrário, será processada com o status `processed`. 
+
+
+#### Pagamentos recusados
+
+Quando uma parcela permanece no status de `recycling` ela entra em um esquema de nova tentativa com um máximo de 4 possibilidades, no qual a parcela é cobrada novamente. O resultado pode ser qualquer um dos dois pontos mencionados acima.
+
+Se o pagamento for recusado, ele é atualizado para uma nova data de cobrança adicionando 1 das 4 possibilidades dentro de dez dias como uma janela de tempo de nova tentativa à última data disponível.
+
+Por padrão, o pagamento é tentado novamente dentro de uma janela de 10 dias. Caso a parcela tenha uma data de vencimento, a janela de tempo é ajustada a essa data e mantém a lógica de 4 tentativas.
+
+------------
+
+----[mla]----
+
+Três alternativas podem surgir na hora em que a parcela é cobrada com base no resultado do seu pagamento:
+
+* __O pagamento é feito com sucesso__ assim a parcela será processada no status `processed` e não será mais tentado novamente. 
+
+* __O pagamento está sendo processado__ portanto, a parcela permanecerá pendente em status `waiting for gateway` até que o pagamento seja resolvido.
+
+* __O pagamento é recusado__ portanto, a parcela permanecerá em status de `recycling` enquanto a parcela não estiver vencida ou não tiver atingido o número máximo de novas tentativas. Caso contrário, será processada com o status `processed`.
+
+
+#### Pagamentos recusados
+
+Quando uma parcela permanece no status de `recycling` ela entra em um esquema de nova tentativa com um máximo de 4 possibilidades, no qual a parcela é cobrada novamente. O resultado pode ser qualquer um dos três pontos mencionados acima.
+
+Se o pagamento for recusado, ele é atualizado para uma nova data de cobrança adicionando 1 das 4 possibilidades dentro de dez dias como uma janela de tempo de nova tentativa à última data disponível.
+
+Por padrão, o pagamento é tentado novamente dentro de uma janela de 10 dias. Caso a parcela tenha uma data de vencimento, a janela de tempo é ajustada a essa data e mantém a lógica de 4 tentativas.
+
+#### Pagamentos em processamento
+
+Se uma parcela está com o status `waiting for gateway` e quando o pagamento é resolvido resulta em rejeitado e a data de vencimento é cumprida, a parcela passará automaticamente a processada com o status `processed`. Caso contrário, entrará no esquema de nova tentativa.
+
+------------
+
+Caso a parcela não possa ser cobrada na quarta tentativa, ela estará automaticamente no status `processed` associada a um pagamento recusado.
+
+Após 3 parcelas com pagamentos recusados a assinatura será automaticamente cancelada e a conta do vendedor será notificada do cancelamento da assinatura por e-mail.
+
+
+> NOTE
+> 
+> Importante
+> 
+> O resultado de uma assinatura não afeta a geração e o processamento das parcelas restantes para a mesma assinatura.
+
 ## Assinaturas com pagamento pendente 
 
 Assinaturas com pagamento pendente são um modelo de assinaturas onde um meio de pagamento não é definido no momento de sua criação. Quando isso ocorre, os pagamentos automaticamente ficam com status `pending` e dependem que o usuário busque uma forma de concluir o pagamento.

--- a/guides/subscriptions/subscription-no-associated-plan.pt.md
+++ b/guides/subscriptions/subscription-no-associated-plan.pt.md
@@ -21,7 +21,6 @@ Finalizando o preenchimento dos campos, execute a requisição.
 >
 > Para comprovar a validade do cartão, realizamos um pagamento com um valor mínimo. Se o pagamento obter sucesso, procedemos com a realização da devolução desse pagamento. O valor pode diferir conforme cada país.
 
-
 ### Lógica de novas tentativas de cobrança
 
 Ao automatizar a recorrência de suas cobranças, são criados pagamentos autorizados que terão uma data de débito configurada com base na periodicidade definida na assinatura. A primeira parcela é cobrada até o período aproximado de uma hora após a assinatura.

--- a/guides/subscriptions/subscription-no-associated-plan.pt.md
+++ b/guides/subscriptions/subscription-no-associated-plan.pt.md
@@ -74,7 +74,6 @@ Caso a parcela não possa ser cobrada na quarta tentativa, ela estará automatic
 
 Após 3 parcelas com pagamentos recusados a assinatura será automaticamente cancelada e a conta do vendedor será notificada do cancelamento da assinatura por e-mail.
 
-
 > NOTE
 > 
 > Importante

--- a/guides/subscriptions/subscription-no-associated-plan.pt.md
+++ b/guides/subscriptions/subscription-no-associated-plan.pt.md
@@ -35,7 +35,6 @@ Duas alternativas podem surgir na hora em que a parcela é cobrada com base no r
 
 * __O pagamento é recusado__ portanto, a parcela permanecerá em status de `recycling` enquanto a parcela não estiver vencida ou não tiver atingido o número máximo de novas tentativas. Caso contrário, será processada com o status `processed`. 
 
-
 #### Pagamentos recusados
 
 Quando uma parcela permanece no status de `recycling` ela entra em um esquema de nova tentativa com um máximo de 4 possibilidades, no qual a parcela é cobrada novamente. O resultado pode ser qualquer um dos dois pontos mencionados acima.


### PR DESCRIPTION
## Description

Na antiga doc de assinaturas tínhamos uma seção chamada "Lógica de novas tentativas de cobrança" que acabou não sendo inserida na reescritura. 

Dia 28/06, Manuel Cortés escreveu para Gosti solicitando que essa info voltasse para a doc e por isso alteramos a seção "Assinaturas sem plano associado", adicionando essas informações no melhor local da doc.