### PR TITLE
feature/checkout bricks new section

### DIFF
--- a/guides/checkout-bricks/configure-payment-methods.en.md
+++ b/guides/checkout-bricks/configure-payment-methods.en.md
@@ -1,0 +1,32 @@
+> CLIENT_SIDE
+>
+> h1
+>
+> Configure accepted payment methods
+
+With Checkout Bricks it is possible to define which payment methods (debit and/or credit) will be accepted in a purchase. **By default, both are enabled at the time of integration**, however, it is also possible to offer only one of these options, limiting payment to debit or credit only.
+
+In the table below you will find the details of the customization and the code necessary to carry out the configuration.
+
+| Brick | Card Payment Brick |
+| --- | --- |
+| Customization moment | When rendering Brick |
+| Property | customization.paymentMethods.types.excluded |
+| Type | string [] |
+| Notes | The values ​​accepted within the array are: `credit_card`, `debit_card`. |
+
+[[[
+```Javascript
+
+settings = {
+  ...,
+  customization: {
+    paymentMethods: {
+      types:{
+        excluded: ['debit_card']
+      }
+    }
+  }
+}
+```
+]]]

--- a/guides/checkout-bricks/configure-payment-methods.es.md
+++ b/guides/checkout-bricks/configure-payment-methods.es.md
@@ -1,0 +1,32 @@
+> CLIENT_SIDE
+>
+> h1
+>
+> Configurar medios de pago aceptados
+
+A través de Checkout Bricks es posible definir qué medios de pago (débito y/o crédito) serán aceptados en una compra. **Por defecto, ambos están habilitados en el momento de la integración**, sin embargo, también es posible ofrecer solo una de estas opciones, limitando el pago solo a débito o crédito.
+
+En la siguiente tabla encontrarás los detalles de la personalización y el código necesario para realizar la configuración.
+
+| Brick | Card Payment Brick |
+| --- | --- |
+| Momento de personalización | Al renderizar Brick |
+| Propiedad | personalización.métodos.pago.tipos.excluidos |
+| Tipo | string [] |
+| Notas | Los valores aceptados dentro del array son: `credit_card`, `debit_card`. |
+
+[[[
+```Javascript
+
+settings = {
+  ...,
+  customization: {
+    paymentMethods: {
+      types:{
+        excluded: ['debit_card']
+      }
+    }
+  }
+}
+```
+]]]

--- a/guides/checkout-bricks/configure-payment-methods.pt.md
+++ b/guides/checkout-bricks/configure-payment-methods.pt.md
@@ -4,7 +4,7 @@
 >
 > Configurar meios de pagamento aceitos
 
-Através do Checkout Bricks é possível definir quais meios de pagamento (débito e/ou crédito) serão aceitos em uma compra. Por padrão, ambos são ativado s durante a integração, contudo, também é possível oferecer somente uma dessas opções, limitando o pagamento exclusivamente a débito ou crédito.
+Através do Checkout Bricks é possível definir quais meios de pagamento (débito e/ou crédito) serão aceitos em uma compra. **Por padrão, ambos são ativados no momento da integração**, contudo, também é possível oferecer somente uma dessas opções, limitando o pagamento exclusivamente a débito ou crédito.
 
 Na tabela abaixo você encontra os detalhes da customização e o código necessário para realizar a configuração.
 

--- a/guides/checkout-bricks/configure-payment-methods.pt.md
+++ b/guides/checkout-bricks/configure-payment-methods.pt.md
@@ -1,0 +1,60 @@
+> CLIENT_SIDE
+>
+> h1
+>
+> Configurar meios de pagamento aceitos
+
+Através do Checkout Bricks é possível definir quais meios de pagamento (débito e/ou crédito) serão aceitos em uma compra. Contudo, também é possível oferecer **somente uma dessas opções** limitando o pagamento exclusivamente a débito ou crédito.
+
+Na tabela abaixo você encontra os detalhes da customização e o código necessário para realizar a configuração.
+
+| Brick  | Card Payment Brick  |
+| --- | --- |
+| Momento da customização  | Ao renderizar Brick  |
+| Propriedade  | customization.paymentMethods.types.excluded <br><br> customization.paymentMethods.types.included |
+| Tipo  | string  |
+| Observações  | Os valores aceitos dentro do array são: `credit_card`, `debit_card`.  |
+
+
+
+> WARNING
+>
+> Importante
+>
+> As propriedades `included` e `excluded` não devem ser utilizadas simultaneamente, por isso, ao definir os meios de pagamento aceitos, escolha somente uma delas.
+
+## Excluir meio de pagamento 
+
+[[[
+```Javascript
+
+settings = {
+  ...,
+  customization: {
+    paymentMethods: {
+      types:{
+        excluded: ['debit_card']
+      }
+    }
+  }
+}
+```
+]]]
+
+## Incluir meio de pagamento 
+
+[[[
+```Javascript
+
+settings = {
+  ...,
+  customization: {
+    paymentMethods: {
+      types:{
+        included: ['credit_card']
+      }
+    }
+  }
+}
+```
+]]]

--- a/guides/checkout-bricks/configure-payment-methods.pt.md
+++ b/guides/checkout-bricks/configure-payment-methods.pt.md
@@ -12,7 +12,7 @@ Na tabela abaixo você encontra os detalhes da customização e o código necess
 | --- | --- |
 | Momento da customização  | Ao renderizar Brick  |
 | Propriedade  | customization.paymentMethods.types.excluded |
-| Tipo  | string  |
+| Tipo  | string [] |
 | Observações  | Os valores aceitos dentro do array são: `credit_card`, `debit_card`.  |
 
 

--- a/guides/checkout-bricks/configure-payment-methods.pt.md
+++ b/guides/checkout-bricks/configure-payment-methods.pt.md
@@ -4,26 +4,18 @@
 >
 > Configurar meios de pagamento aceitos
 
-Através do Checkout Bricks é possível definir quais meios de pagamento (débito e/ou crédito) serão aceitos em uma compra. Contudo, também é possível oferecer **somente uma dessas opções** limitando o pagamento exclusivamente a débito ou crédito.
+Através do Checkout Bricks é possível definir quais meios de pagamento (débito e/ou crédito) serão aceitos em uma compra. Por padrão, ambos são ativado s durante a integração, contudo, também é possível oferecer somente uma dessas opções, limitando o pagamento exclusivamente a débito ou crédito.
 
 Na tabela abaixo você encontra os detalhes da customização e o código necessário para realizar a configuração.
 
 | Brick  | Card Payment Brick  |
 | --- | --- |
 | Momento da customização  | Ao renderizar Brick  |
-| Propriedade  | customization.paymentMethods.types.excluded <br><br> customization.paymentMethods.types.included |
+| Propriedade  | customization.paymentMethods.types.excluded |
 | Tipo  | string  |
 | Observações  | Os valores aceitos dentro do array são: `credit_card`, `debit_card`.  |
 
 
-
-> WARNING
->
-> Importante
->
-> As propriedades `included` e `excluded` não devem ser utilizadas simultaneamente, por isso, ao definir os meios de pagamento aceitos, escolha somente uma delas.
-
-## Excluir meio de pagamento 
 
 [[[
 ```Javascript
@@ -41,20 +33,3 @@ settings = {
 ```
 ]]]
 
-## Incluir meio de pagamento 
-
-[[[
-```Javascript
-
-settings = {
-  ...,
-  customization: {
-    paymentMethods: {
-      types:{
-        included: ['credit_card']
-      }
-    }
-  }
-}
-```
-]]]


### PR DESCRIPTION
## Description

Recentemente recebi o contato do Alexandre Fossati Filho levantando uma questão importante sobre a configuração de meios de pagamento aceitos.

Um integrador do nosso Brick nos escreveu dizendo: "...No encuentro en la documentación la manera de customizar el formulario para que sólo acepte tarjeta de crédito (no débito) como medio de pago..."

Acontece que essa customização pode ser feita através da propriedade customization.paymentMethods.types.excluded. E essa informação precisa constar na nossa documentação.

