### PR TITLE
fix/cho api markdown fix

### DIFF
--- a/guides/checkout-api-v2/integrate-pix.pt.md
+++ b/guides/checkout-api-v2/integrate-pix.pt.md
@@ -6,7 +6,7 @@ Pix é um meio de pagamento eletrônico instantâneo oferecido pelo Banco Centra
 >
 > Importante
 >
-> Para oferecer pagamentos com Pix é preciso garantir que as chaves Pix tenham sido criadas. Caso ainda não tenha criado, [clique aqui]((https://www.youtube.com/watch?v=60tApKYVnkA)) e veja o passo a passo.
+> Para oferecer pagamentos com Pix é preciso garantir que as chaves Pix tenham sido criadas. Caso ainda não tenha criado, [clique aqui](https://www.youtube.com/watch?v=60tApKYVnkA) e veja o passo a passo.
 
 Para integrar pagamentos via Pix, siga as etapas abaixo, mas caso você já tenha integrado pagamentos via cartão, inicie a integração a partir da etapa [Adicionar formulário de pagamento](/developers/pt/docs/checkout-api/integration-configuration/integrate-with-pix#bookmark_Adicionar_formulário_de_pagamento).
 


### PR DESCRIPTION
## Description

Na seção "Integrar pagamentos com Pix", da documentação de Checkout Transparente, identificamos que o link que direcionava o usuário para o passo a passo para criação das Chaves Pix estava quebrado. Realizamos essa correção e agora funciona corretamente.


