### PR TITLE
Update testing.es.md

### DIFF
--- a/guides/woocommerce/testing.es.md
+++ b/guides/woocommerce/testing.es.md
@@ -8,7 +8,7 @@ Con la tienda en modo de prueba, puedes probar una compra antes de habilitarla p
 3. Selecciona un producto y haz clic en **Anãdir al carrito > Ver carrito**.
 4. Elige cualquier opción de envío y haz clic en **Finalizar compra**.
 5. Completa la información solicitada y selecciona la opción de pago con la solución de Mercado Pago que haya configurado.
-6. Selecciona el pago con tarjeta de crédito y usa la información de tarjeta disponible en nuestra página [Tarjetas locales de prueba](/developers/es/guides/additional-content/testing/test-cards).
+6. Selecciona el pago con tarjeta de crédito y usa la información de tarjeta disponible en nuestra página [Tarjetas locales de prueba](/developers/es/docs/checkout-api/integration-test/test-cards).
 7. Al completar el llenado, haz clic en **Realizar el pedido**.
 
 Si la prueba se ejecuta sin errores, significa que su tienda está lista para vender. Sin embargo, recomendamos realizar pruebas adicionales para que pueda ver los diferentes resultados de pago.


### PR DESCRIPTION
## Description

Broken link with Test Card in WooCommerce Testing documentation. Test Card has been redirected to the ones provided  by the checkout api product. 
