### PR TITLE
fix/cho api doc link correction

### DIFF
--- a/guides/checkout-api-v2/integration-via-cardform.pt.md
+++ b/guides/checkout-api-v2/integration-via-cardform.pt.md
@@ -211,7 +211,7 @@ Com todas as informações coletadas no backend, envie um POST com os atributos 
 >
 > Importante
 >
-> Para aumentar as chances de aprovação do pagamento e evitar que a análise antifraude não autorize a transação, recomendamos inserir o máximo de informação sobre o comprador ao realizar a requisição. Para mais detalhes sobre como aumentar as chances de aprovação, veja [Como melhorar a aprovação dos pagamentos](/developers/pt/docs/checkout-api/how-tos/improve-approval).
+> Para aumentar as chances de aprovação do pagamento e evitar que a análise antifraude não autorize a transação, recomendamos inserir o máximo de informação sobre o comprador ao realizar a requisição. Para mais detalhes sobre como aumentar as chances de aprovação, veja [Como melhorar a aprovação dos pagamentos](/developers/pt/docs/checkout-api/how-tos/improve-payment-approval).
 
 
 [[[

--- a/guides/checkout-api-v2/integration-via-core-methods.es.md
+++ b/guides/checkout-api-v2/integration-via-core-methods.es.md
@@ -346,7 +346,7 @@ Con toda la información recopilada en el backend, envíe un POST con los atribu
 >
 > Importante
 >
-> Para aumentar las posibilidades de aprobación del pago y evitar que el análisis antifraude no autorice la transacción, recomendamos introducir toda la información posible sobre el comprador al realizar la solicitud. Para más detalles sobre cómo aumentar las posibilidades de aprobación, consulta [Cómo mejorar la aprobación de los pagos](/developers/es/docs/checkout-api/how-tos/improve-payment-approval.
+> Para aumentar las posibilidades de aprobación del pago y evitar que el análisis antifraude no autorice la transacción, recomendamos introducir toda la información posible sobre el comprador al realizar la solicitud. Para más detalles sobre cómo aumentar las posibilidades de aprobación, consulta [Cómo mejorar la aprobación de los pagos](/developers/es/docs/checkout-api/how-tos/improve-payment-approval).
 
 
 [[[

--- a/guides/checkout-api-v2/integration-via-core-methods.pt.md
+++ b/guides/checkout-api-v2/integration-via-core-methods.pt.md
@@ -357,7 +357,7 @@ Com todas as informações coletadas no backend, envie um POST com os atributos 
 >
 > Importante
 >
-> Para aumentar as chances de aprovação do pagamento e evitar que a análise antifraude não autorize a transação, recomendamos inserir o máximo de informação sobre o comprador ao realizar a requisição. Para mais detalhes sobre como aumentar as chances de aprovação, veja [Como melhorar a aprovação dos pagamentos](/developers/pt/docs/checkout-api/how-tos/improve-approval).
+> Para aumentar as chances de aprovação do pagamento e evitar que a análise antifraude não autorize a transação, recomendamos inserir o máximo de informação sobre o comprador ao realizar a requisição. Para mais detalhes sobre como aumentar as chances de aprovação, veja [Como melhorar a aprovação dos pagamentos](/developers/pt/docs/checkout-api/how-tos/improve-payment-approval).
 
 
 [[[


### PR DESCRIPTION
## Description

Identificamos que alguns links que direcionavam o usuário para a documentação "Como melhorar a aprovação dos pagamentos" estavam quebrados. Por isso, revisitamos as seções "Integração via Cardform" e "Integração via métodos core" e realizamos as devidas correções.