### PR TITLE
fix/cho api localization markdown correction

### DIFF
--- a/guides/checkout-api-v2/cancel-reserve.en.md
+++ b/guides/checkout-api-v2/cancel-reserve.en.md
@@ -4,6 +4,7 @@ sites_supported:
 - mlb
 - mlm
 - mpe
+- mlu
 ---
 
 # Cancel reserve

--- a/guides/checkout-api-v2/cancel-reserve.es.md
+++ b/guides/checkout-api-v2/cancel-reserve.es.md
@@ -4,6 +4,7 @@
       - mlb
       - mlm
       - mpe
+      - mlu
 ---
 
 # Cancelar reserva

--- a/guides/checkout-api-v2/cancel-reserve.pt.md
+++ b/guides/checkout-api-v2/cancel-reserve.pt.md
@@ -4,6 +4,7 @@
       - mlb
       - mlm
       - mpe
+      - mlu
 ---
 
 # Cancelar reserva

--- a/guides/checkout-api-v2/capture-authorized-payment.en.md
+++ b/guides/checkout-api-v2/capture-authorized-payment.en.md
@@ -4,6 +4,7 @@ sites_supported:
 - mlb
 - mlm
 - mpe
+- mlu
 ---
 
 # Capture authorized payment

--- a/guides/checkout-api-v2/capture-authorized-payment.es.md
+++ b/guides/checkout-api-v2/capture-authorized-payment.es.md
@@ -4,6 +4,7 @@
       - mlb
       - mlm
       - mpe
+      - mlu 
 ---
 
 # Capturar pago autorizado

--- a/guides/checkout-api-v2/capture-authorized-payment.pt.md
+++ b/guides/checkout-api-v2/capture-authorized-payment.pt.md
@@ -4,6 +4,7 @@
       - mlb
       - mlm
       - mpe
+      - mlu
 ---
 
 # Capturar pagamento autorizado

--- a/guides/checkout-api-v2/make-test-purchase.en.md
+++ b/guides/checkout-api-v2/make-test-purchase.en.md
@@ -17,11 +17,11 @@ Done! Once these steps are finished, the integration will be complete and you wi
 
 > PREV_STEP_CARD_EN
 >
-> Create test user
+> Payment management
 >
-> Learn how to create users to test the Checkout API integration.
+> Learn how to manage your store payments.
 >
-> [Create Test User](/developers/en/docs/checkout-api/integration-test/create-test-user)
+> [Payment management](/developers/en/docs/checkout-api/payment-management)
 
 > NEXT_STEP_CARD_EN
 >

--- a/guides/checkout-api-v2/make-test-purchase.es.md
+++ b/guides/checkout-api-v2/make-test-purchase.es.md
@@ -17,11 +17,11 @@ Con las credenciales configuradas, siga los pasos a continuación para realizar 
 
 > PREV_STEP_CARD_ES
 >
-> Crear usuario de prueba
+> Gestión de pagos
 >
-> Aprenda a crear usuarios para probar la integración del Checkout API.
+> Aprende a administrar los pagos de tu tienda.
 >
-> [Crear usuario de prueba](/developers/es/docs/checkout-api/integration-test/create-test-user)
+> [Gestión de pagos](/developers/es/docs/checkout-api/payment-management)
 
 > NEXT_STEP_CARD_ES
 >

--- a/guides/checkout-api-v2/make-test-purchase.pt.md
+++ b/guides/checkout-api-v2/make-test-purchase.pt.md
@@ -17,11 +17,11 @@ Pronto! Finalizadas essas etapas a integração terá sido concluída e você j�
 
 > PREV_STEP_CARD_PT
 >
-> Criar usuário de teste
+> Gestão de pagamentos
 >
-> Saiba como criar usuários para testar a integração do Checkout Transparente.
+> Saiba como fazer a gestão dos pagamentos da sua loja.
 >
-> [Criar usuário de teste](/developers/pt/docs/checkout-api/integration-test/create-test-user)
+> [Gestão de pagamentos](/developers/pt/docs/checkout-api/payment-management)
 
 > NEXT_STEP_CARD_PT
 >

--- a/guides/checkout-api-v2/make-value-reserve.en.md
+++ b/guides/checkout-api-v2/make-value-reserve.en.md
@@ -4,6 +4,7 @@ sites_supported:
 - mlb
 - mlm
 - mpe
+- mlu
 ---
 
 # Reserve values

--- a/guides/checkout-api-v2/make-value-reserve.es.md
+++ b/guides/checkout-api-v2/make-value-reserve.es.md
@@ -4,6 +4,7 @@
       - mlb
       - mlm
       - mpe
+      - mlu
 ---
 
 # Reservar fondos

--- a/guides/checkout-api-v2/make-value-reserve.pt.md
+++ b/guides/checkout-api-v2/make-value-reserve.pt.md
@@ -4,6 +4,7 @@
       - mlb
       - mlm
       - mpe
+      - mlu
 ---
 
 # Reservar valores


### PR DESCRIPTION
## Description

Recebemos no canal #devsite-bugs um report de erro na página "Gestão de cartões e clientes", onde a página não abria para MLU. Ao investigar, identificamos que além de não estar habilitada para MLU, haviam outras seções com markdown de localização que não contemplava MLU.

Por isso, corrigimos os seguintes markdowns:

- Reservar valores
- Capturar pagamento autorizado
- Cancelar reserva
- Gestão de cartões e clientes.

Agora todos estão habilitados para MLU.
