### PR TITLE
fix/cho bricks new info

### DIFF
--- a/guides/checkout-bricks/configure-integration.en.md
+++ b/guides/checkout-bricks/configure-integration.en.md
@@ -134,7 +134,7 @@ The result of rendering the brick should be like the image below:”
 >
 > Attention
 >
-> For an effective Brick control, the function submitted in `onSubmit` must always return a Promise. You can call `resolve()` only if processing on your backend was successful. Call `reject(`) if an error occurs. The `reject()` will make the brick allow the fields to be filled in again and a new payment attempt possible. Also, when calling the `resolve()` method inside the `onSubmit` Promise, the brick does not allow new payments. If you want to make a new payment, you must create a new instance.
+> For an effective Brick control, the function submitted in `onSubmit` must always return a Promise. You should call `resolve()` only if your backend processes was successful. Call `reject()` if an error occurs. The `reject()` will make the brick allow the fields to be filled in again and a new payment attempt possible. Also, when calling the `resolve()` method inside the `onSubmit` Promise, the brick does not allow new payments. If you want to make a new payment, you must create a new Brick instance.
 
 > PREV_STEP_CARD_EN
 >

--- a/guides/checkout-bricks/configure-integration.en.md
+++ b/guides/checkout-bricks/configure-integration.en.md
@@ -130,6 +130,12 @@ The result of rendering the brick should be like the image below:”
 
 ![cardform](checkout-bricks/card-form-en.png)
 
+> WARNING
+>
+> Attention
+>
+> For an effective Brick control, the function submitted in `onSubmit` must always return a Promise. You can call `resolve()` only if processing on your backend was successful. Call `reject(`) if an error occurs. The `reject()` will make the brick allow the fields to be filled in again and a new payment attempt possible. Also, when calling the `resolve()` method inside the `onSubmit` Promise, the brick does not allow new payments. If you want to make a new payment, you must create a new instance.
+
 > PREV_STEP_CARD_EN
 >
 > Prerequisites

--- a/guides/checkout-bricks/configure-integration.es.md
+++ b/guides/checkout-bricks/configure-integration.es.md
@@ -130,6 +130,12 @@ El resultado de renderizar el brick debe ser como la imagen de abajo:
 
 ![cardform](checkout-bricks/card-form-es.png)
 
+> WARNING
+>
+> Atención
+>
+> Para un control efectivo del Brick, la función enviada en `onSubmit` siempre debe devolver una Promise. Haz una llamada `resolve()` solo si el procesamiento de tu backend fue exitoso. Haz una llamada `reject()` en caso de que ocurra un error. Esto hará que el Brick te permita completar los campos nuevamente y haga posible un nuevo intento de pago. Además, al hacer una llamada `resolve()` dentro de la Promise de `onSubmit`, el brick no permite nuevos pagos. Si deseas realizar un nuevo pago, deberás crear una nueva instancia.
+
 > PREV_STEP_CARD_ES
 >
 > Requisitos previos

--- a/guides/checkout-bricks/configure-integration.es.md
+++ b/guides/checkout-bricks/configure-integration.es.md
@@ -134,7 +134,7 @@ El resultado de renderizar el brick debe ser como la imagen de abajo:
 >
 > Atención
 >
-> Para un control efectivo del Brick, la función enviada en `onSubmit` siempre debe devolver una Promise. Haz una llamada `resolve()` solo si el procesamiento de tu backend fue exitoso. Haz una llamada `reject()` en caso de que ocurra un error. Esto hará que el Brick te permita completar los campos nuevamente y haga posible un nuevo intento de pago. Además, al hacer una llamada `resolve()` dentro de la Promise de `onSubmit`, el brick no permite nuevos pagos. Si deseas realizar un nuevo pago, deberás crear una nueva instancia.
+> Para un control efectivo del Brick, la función enviada en `onSubmit` siempre debe devolver una Promise. Llame el método `resolve()` solo si el procesamiento de tu backend fue exitoso. Llame el método `reject()` en caso de que ocurra un error. Esto hará que el Brick te permita completar los campos nuevamente y haga posible un nuevo intento de pago. Al llamar el `resolve()` dentro de la Promise de `onSubmit`, el brick no permite nuevos pagos. Si deseas realizar un nuevo pago, deberás crear una nueva instancia del Brick.
 
 > PREV_STEP_CARD_ES
 >

--- a/guides/checkout-bricks/configure-integration.pt.md
+++ b/guides/checkout-bricks/configure-integration.pt.md
@@ -80,6 +80,7 @@ const bricksBuilder = mp.bricks();
 
 Uma vez instanciado, o brick pode ser renderizado e ter todas as suas configurações compiladas de modo que a estrutura final do brick seja gerada.
 
+
 Para renderizar o brick, insira o código abaixo após o passo anterior e preencha os atributos conforme os comentários destacados neste mesmo código.
 
 ```javascript
@@ -129,6 +130,12 @@ O resultado de renderizar o brick deve ser como na imagem abaixo:
 
 ![cardform](checkout-bricks/card-form-pt.png)
 
+> WARNING
+>
+> Atenção
+>
+> Para um controle eficaz do Brick, a função enviada no `onSubmit` deve sempre retornar uma Promise. Chame o `resolve()` apenas se o processamento em seu backend ocorreu com sucesso. Chame o `reject()` caso algum erro ocorra. Isso fará com que o brick permita o preenchimento dos campos novamente e viabilize uma nova tentativa de pagamento. Além disso, ao chamar o método `resolve()` dentro da Promise do `onSubmit`, o brick não permite novos pagamentos. Caso queira realizar um novo pagamento, deve-se criar uma nova instância.
+  
 > PREV_STEP_CARD_PT
 >
 > Pré-requisitos

--- a/guides/checkout-bricks/configure-integration.pt.md
+++ b/guides/checkout-bricks/configure-integration.pt.md
@@ -134,8 +134,8 @@ O resultado de renderizar o brick deve ser como na imagem abaixo:
 >
 > Atenção
 >
-> Para um controle eficaz do Brick, a função enviada no `onSubmit` deve sempre retornar uma Promise. Chame o `resolve()` apenas se o processamento em seu backend ocorreu com sucesso. Chame o `reject()` caso algum erro ocorra. Isso fará com que o brick permita o preenchimento dos campos novamente e viabilize uma nova tentativa de pagamento. Além disso, ao chamar o método `resolve()` dentro da Promise do `onSubmit`, o brick não permite novos pagamentos. Caso queira realizar um novo pagamento, deve-se criar uma nova instância.
-  
+> Para um controle eficaz do Brick, a função enviada no `onSubmit` deve sempre retornar uma Promise. Chame o `resolve()` apenas se o processamento em seu backend ocorreu com sucesso. Chame o `reject()` caso algum erro ocorra. Isso fará com que o brick permita o preenchimento dos campos novamente e viabilize uma nova tentativa de pagamento. Ao chamar o método `resolve()` dentro da Promise do `onSubmit`, o brick não permite novos pagamentos. Caso queira realizar um novo pagamento, deve-se criar uma nova instância do Brick.
+
 > PREV_STEP_CARD_PT
 >
 > Pré-requisitos

--- a/guides/checkout-bricks/landing.en.md
+++ b/guides/checkout-bricks/landing.en.md
@@ -19,7 +19,7 @@ bullet_section_with_media:
  - type: reversed
  - message: Know all Checkout Bricks modules and their availability.
  - benefit_title: Card Payment Brick - New
- - benefit_message: Offer credit and debit card payments with the ability to save card details for future purchases.
+ - benefit_message: Offer credit and debit card payments.
  - benefit_title: Payment Brick - Soon
  - benefit_message: Offer different payment methods from which your customers can choose.
  - benefit_title: Wallet Brick - Soon

--- a/guides/checkout-bricks/landing.es.md
+++ b/guides/checkout-bricks/landing.es.md
@@ -19,7 +19,7 @@ bullet_section_with_media:
  - type: reversed
  - message: Conoce todos los módulos de Checkout Bricks y su disponibilidad.
  - benefit_title: Card Payment Brick - Nuevo
- - benefit_message: Ofrece pagos con tarjeta de crédito y débito con la posibilidad de guardar los datos de la tarjeta para futuras compras.
+ - benefit_message: Ofrece pagos con tarjeta de crédito y débito.
  - benefit_title: Payment Brick - Muy pronto
  - benefit_message: Ofrece diferentes medios de pago entre los que podrán elegir tus clientes. 
  - benefit_title: Wallet Brick - Muy pronto

--- a/guides/checkout-bricks/landing.pt.md
+++ b/guides/checkout-bricks/landing.pt.md
@@ -19,7 +19,7 @@ bullet_section_with_media:
  - type: reversed
  - message: Conheça todos os módulos do Checkout Bricks e as suas disponibilidades.
  - benefit_title: Card Payment Brick - Novo
- - benefit_message: Ofereça pagamentos com cartão de crédito e débito com a capacidade de salvar detalhes do cartão para compras futuras. 
+ - benefit_message: Ofereça pagamentos com cartão de crédito e débito. 
  - benefit_title: Payment Brick - Em breve
  - benefit_message: Ofereça diferentes métodos de pagamento para os clientes escolherem.
  - benefit_title: Wallet Brick - Em breve


### PR DESCRIPTION
## Description

Alexandre Fossati, da equipe de Bricks, solicitou que adicionássemos uma nota na seção "Renderizar Brick" com a seguinte justificativa.

_Adicionar uma explicação mais detalhada sobre como usar o `reject` na função `onSubmit` que é enviada na inicialização.
**Contexto:** Tivemos um seller que estava dando `resolve()` nesse método, mesmo quando acontecia um erro do lado dele da integração. Porém quando erros ocorrem, o correto seria chamar o `reject()`  pra que a gente saiba que ele precisa tentar realizar outro pagamento._

Com base nisso, a nota foi adicionada utilizando como base sua sugestão de texto.