### PR TITLE
fix/devsite doc fixes

### DIFF
--- a/guides/additional-content/notifications/webhooks/webhooks.en.md
+++ b/guides/additional-content/notifications/webhooks/webhooks.en.md
@@ -275,7 +275,6 @@ curl -X POST \
   "live_mode": true,
   "type": "payment",
   "date_created": "2015-03-25T10:04:58.396-04:00",
-  "application_id": 123123123,
   "user_id": 44444,
   "version": 1,
   "api_version": "v1",
@@ -293,7 +292,6 @@ This indicates that payment **999999999** was created for user **44444** in prod
 | **id** | Notification ID |
 | **live_mode** | Indicates if the URL entered is valid. |
 | **date_created** | Resorce (payments, mp-connect, subscription etc) creation date |
-| **application_id** | Application ID that received the resource (payments, merchant_order, subscription, preapproval, etc) |
 | **user_id** | Vendor UserID |
 | **version** | Number of times a notification was sent |
 | **api_version** | Indicates if it is a duplicate notification or not |

--- a/guides/additional-content/notifications/webhooks/webhooks.es.md
+++ b/guides/additional-content/notifications/webhooks/webhooks.es.md
@@ -275,7 +275,6 @@ curl -X POST \
   "live_mode": true,
   "type": "payment",
   "date_created": "2015-03-25T10:04:58.396-04:00",
-  "application_id": 123123123,
   "user_id": 44444,
   "version": 1,
   "api_version": "v1",
@@ -294,7 +293,6 @@ Esto indica que el pago **999999999** fue creado para el usuario **44444** en mo
 | **live_mode** | Indica si la URL ingresada es válida.|
 | **type** | Tipo de notificacion recebida (payments, mp-connect, subscription etc) |
 | **date_created** | Fecha de creación del recurso (payments, mp-connect, subscription etc) |
-| **application_id** | Application ID que recebió el recurso (payments, mp-connect, subscription etc) |
 | **user_id**| UserID del vendedor |
 | **version** | Cantidad de veces que se envió una notificación |
 | **api_version** | Indica si es una notificación duplicada o no|

--- a/guides/additional-content/notifications/webhooks/webhooks.pt.md
+++ b/guides/additional-content/notifications/webhooks/webhooks.pt.md
@@ -275,7 +275,6 @@ curl -X POST \
   "live_mode": true,
   "type": "payment",
   "date_created": "2015-03-25T10:04:58.396-04:00",
-  "application_id": 123123123,
   "user_id": 44444,
   "version": 1,
   "api_version": "v1",
@@ -293,7 +292,6 @@ Isso indica que foi criado o pagamento **999999999** para o usuário **44444** e
 | **live_mode** | Indica se a URL informada é valida |
 | **type** | Tipo de notificação recebida (payments, mp-connect, subscription, etc) |
 | **date_created** | Data de criação do recurso (payments, mp-connect, subscription etc) |
-| **application_id** | ID da aplicação que recebeu o recurso (payments, mp-connect, subscription etc) |
 | **user_id**| UserID de vendedor |
 | **version** | Número de vezes que uma notificação foi enviada |
 | **api_version** | Indica se é uma notificação duplicada ou não |

--- a/guides/additional-content/resources/industry-data/additional-info.en.md
+++ b/guides/additional-content/resources/industry-data/additional-info.en.md
@@ -286,7 +286,6 @@ Add all the additional information you want.
 | `category_id` | String | Category |
 | `quantity` | Integer | Quantity |
 | `unit_price` | Float | Unit price |
-| `event_date` | Date | Event date |
 
 #### About the buyer
 
@@ -343,7 +342,6 @@ curl --location --request POST 'https://api.mercadopago.com/checkout/preferences
             "category_id": "entertainment",
             "quantity": 1,
             "unit_price": 150,
-            "event_date": "2020-06-02T12:58:41.425-04:00",
         }
     ],
     "payer": {
@@ -781,7 +779,6 @@ Add all the additional information you want.
 | `category_id` | String | Category |
 | `quantity` | Integer | Quantity |
 | `unit_price` | Float | Unit price |
-| `event_date` | Date | Event date |
 
 #### About the buyer
 
@@ -840,7 +837,6 @@ curl --location --request POST 'https://api.mercadopago.com/checkout/preferences
             "category_id": "services",
             "quantity": 1,
             "unit_price": 150,
-            "event_date": "2020-06-02T12:58:41.425-04:00"
         }
     ],
     "payer": {
@@ -1043,7 +1039,6 @@ Add all the additional information you want.
 | `category_id` | String | Category |
 | `quantity` | Integer | Quantity |
 | `unit_price` | Float | Unit price |
-| `event_date` | Date | Event date |
 | `category_descriptor` | Object | Category description. |
 | `passenger` | Object | Additional passenger information. |
 | `first_name`| String | Name |
@@ -1104,7 +1099,6 @@ curl --location --request POST 'https://api.mercadopago.com/checkout/preferences
                 }
             },
             "quantity": 1,
-            "event_date": "2020-06-02T12:58:41.425-04:00",
             "unit_price": 150
         }
     ],

--- a/guides/additional-content/resources/industry-data/additional-info.es.md
+++ b/guides/additional-content/resources/industry-data/additional-info.es.md
@@ -286,7 +286,7 @@ Agrega toda la información adicional que quieras.
 | `category_id` | String | Categoría |
 | `quantity` | Integer | Cantidad |
 | `unit_price` | Float | Precio unitario |
-| `event_date` | Date | Fecha del evento |
+
 
 #### Sobre el comprador
 
@@ -343,7 +343,7 @@ curl --location --request POST 'https://api.mercadopago.com/checkout/preferences
             "category_id": "entertainment",
             "quantity": 1,
             "unit_price": 150,
-            "event_date": "2020-06-02T12:58:41.425-04:00",
+
         }
     ],
     "payer": {
@@ -781,7 +781,7 @@ Agrega toda la información adicional que quieras.
 | `category_id` | String | Categoría |
 | `quantity` | Integer | Cantidad |
 | `unit_price` | Float | Precio unitario |
-| `event_date` | Date | Fecha del evento |
+
 
 #### Sobre el comprador
 
@@ -840,7 +840,6 @@ curl --location --request POST 'https://api.mercadopago.com/checkout/preferences
             "category_id": "services",
             "quantity": 1,
             "unit_price": 150,
-            "event_date": "2020-06-02T12:58:41.425-04:00"
         }
     ],
     "payer": {
@@ -1043,7 +1042,6 @@ Agrega toda la información adicional que quieras.
 | `category_id` | String | Categoría |
 | `quantity` | Integer | Cantidad |
 | `unit_price` | Float | Precio unitario |
-| `event_date` | Date | Fecha del evento |
 | `category_descriptor` | Object | Descripción de la categoría. |
 | `passenger` | Object | Información adicional del pasajero. |
 | `first_name`| String | Nombre |
@@ -1104,7 +1102,6 @@ curl --location --request POST 'https://api.mercadopago.com/checkout/preferences
                 }
             },
             "quantity": 1,
-            "event_date": "2020-06-02T12:58:41.425-04:00",
             "unit_price": 150
         }
     ],

--- a/guides/additional-content/resources/industry-data/additional-info.pt.md
+++ b/guides/additional-content/resources/industry-data/additional-info.pt.md
@@ -286,7 +286,6 @@ Adicione todas as informações adicionais que você deseja.
 | `category_id` | String | Categoria |
 | `quantity` | Integer | Quantidade |
 | `unit_price` | Float | Preço unitário |
-| `event_date` | Date |Data do evento |
 
 #### Sobre o comprador
 
@@ -343,7 +342,7 @@ curl --location --request POST 'https://api.mercadopago.com/checkout/preferences
             "category_id": "entertainment",
             "quantity": 1,
             "unit_price": 150,
-            "event_date": "2020-06-02T12:58:41.425-04:00",
+
         }
     ],
     "payer": {
@@ -781,7 +780,6 @@ Adicione todas as informações adicionais que você deseja.
 | `category_id` | String | Categoria |
 | `quantity` | Integer | Quantidade |
 | `unit_price` | Float | Preço unitário |
-| `event_date` | Date |Data do evento |
 
 #### Sobre o comprador
 
@@ -840,7 +838,7 @@ curl --location --request POST 'https://api.mercadopago.com/checkout/preferences
             "category_id": "services",
             "quantity": 1,
             "unit_price": 150,
-            "event_date": "2020-06-02T12:58:41.425-04:00"
+
         }
     ],
     "payer": {
@@ -1043,7 +1041,6 @@ Adicione todas as informações adicionais que você deseja.
 | `category_id` | String | Categoria |
 | `quantity` | Integer | Quantidade |
 | `unit_price` | Float | Preço unitário |
-| `event_date` | Date |Data do evento |
 | `category_descriptor` | Object | Descrição de la categoría. |
 | `passenger` | Object |Informações adicionais sobre passageiros. |
 | `first_name`| String | Nome |
@@ -1104,7 +1101,6 @@ curl --location --request POST 'https://api.mercadopago.com/checkout/preferences
                 }
             },
             "quantity": 1,
-            "event_date": "2020-06-02T12:58:41.425-04:00",
             "unit_price": 150
         }
     ],

--- a/guides/additional-content/sales-processing/chargebacks.en.md
+++ b/guides/additional-content/sales-processing/chargebacks.en.md
@@ -68,7 +68,7 @@ Find more information about each attribute in [API References](https://www.merca
 
 ### Return suspicious payments
 
-When we detect an irregular behavior or are notified that a stolen credit card was used, we will contact via e-mail to let you know what happened. We recommend you to [cancel the purchase](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/manage-account/account/cancellations-and-refunds) and refund the money to the buyer so that you can avoid a chargeback.
+When we detect an irregular behavior or are notified that a stolen credit card was used, we will contact via e-mail to let you know what happened. We recommend you to cancel the purchase and refund the money to the buyer so that you can avoid a chargeback.
 
 ### Check data when collecting with Point
 

--- a/guides/additional-content/sales-processing/chargebacks.es.md
+++ b/guides/additional-content/sales-processing/chargebacks.es.md
@@ -68,7 +68,7 @@ Puedes obtener más información sobre cada atributo en las [Referencias de API]
 
 ### Devuelve los pagos sospechosos
 
-Cuando detectamos un comportamiento irregular o recibimos una notificación de que la tarjeta usada fue robada, nos contactaremos vía e-mail para avisarte. Te recomendamos que [canceles la compra](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/manage-account/account/cancellations-and-refunds) y le devuelvas el dinero al comprador para evitar el contracargo.
+Cuando detectamos un comportamiento irregular o recibimos una notificación de que la tarjeta usada fue robada, nos contactaremos vía e-mail para avisarte. Te recomendamos que canceles la compra y le devuelvas el dinero al comprador para evitar el contracargo.
 
 ### Revisa los datos al cobrar con Point
 

--- a/guides/additional-content/sales-processing/chargebacks.pt.md
+++ b/guides/additional-content/sales-processing/chargebacks.pt.md
@@ -68,7 +68,7 @@ Você pode obter mais informações sobre cada atributo nas [Referências de API
 
 ### Faça a devolução de pagamentos suspeitos
 
-Se detectarmos um comportamento irregular ou recebermos uma notificação de que o cartão utilizado foi roubado, entraremos em contato via email para avisar você dessa ocorrência. Recomendamos que [cancele a compra](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/manage-account/account/cancellations-and-refunds) e faça a devolução do dinheiro ao comprador para evitar a contestação do pagamento.
+Se detectarmos um comportamento irregular ou recebermos uma notificação de que o cartão utilizado foi roubado, entraremos em contato via email para avisar você dessa ocorrência. Recomendamos que cancele a compra e faça a devolução do dinheiro ao comprador para evitar a contestação do pagamento.
 
 ### Revise os dados ao cobrar com Point
 

--- a/reference/api/payments.yaml
+++ b/reference/api/payments.yaml
@@ -1975,29 +1975,19 @@ paths:
               properties:
                 capture:
                   type: boolean
-                  description: 
-                    Determines if the payment should be captured (true, default
-                    value) or just reserved (false).
+                  description: Determines if the payment should be captured (true, default value) or just reserved (false).
+                  x-description-i18n:
+                    eng: Determines if the payment should be captured (true, default value) or just reserved (false).
+                    spa: Determina si el pago debe capturarse (true, es el valor default) o reservarse solo (false).
+                    por: Determina se o pagamento deve ser capturado (true, é o valor padrão) ou apenas reservado (false).                  
                   example: true
-                date_of_expiration:
-                  type: string
-                  format: date
-                  description: Payment’s expiration date.
-                  x-description-i18n:
-                    eng: Payment’s expiration date.
-                    spa: Fecha de expiración del pago
-                    por: Data de expiração do pagamento
-                metadata:
-                  type: object
-                  description: The metadata object shows (if used in the integration) the JSON sent by the client containing additional information that needs to be recorded in the payment.
-                  x-description-i18n:
-                    eng: The metadata object shows (if used in the integration) the JSON sent by the client containing additional information that needs to be recorded in the payment.
-                    spa: En el objeto metadata se muestra (en caso de ser utilizado en la integración) el JSON enviado por el cliente con información complementaria que necesite mantener registrada en el pago.
-                    por: O objeto de metadata mostra (se usado na integração) o JSON enviado pelo cliente com informações adicionais que precisam ser registradas no pagamento.
                 status:
                   type: string
-                  description: 
-                    Determines if the payment should be cancelled
+                  description: Determines if the payment should be cancelled
+                  x-description-i18n:
+                    eng: Determines if the payment should be cancelled
+                    spa: Determina si el pago debe ser cancelado
+                    por: Determina se o pagamento deve ser cancelado
                   example: "cancelled"
                 transaction_amount:
                   type: number


### PR DESCRIPTION
## Description

Alguns fixes em documentações específicas foram realizados. Abaixo segue o detalhe de cada uma delas:

**Webhooks:** Eduardo Telles Serrano nos contatou via #devsite-bugs dizendo que na resposta à requisição de um Webhook, o atributo `application_id` não retornava. Dessa forma, optamos por removê-lo da documentação.

**Payments API:** Não é possível realizar PUT dos atributos `metadata` e `date_of_expiration`. Ao fazer, retorna-se um erro e confunde o usuário no momento de consumir a API. Por este motivo, realizamos a remoção dos parâmetros.

**Industry data:** Removemos o campo `event_data` da documentação.
