### PR TITLE
fix/boleto bancário section improvement

### DIFF
--- a/guides/subscriptions/boleto-bancario.en.md
+++ b/guides/subscriptions/boleto-bancario.en.md
@@ -3,13 +3,13 @@
 
 It is possible to allow the subscriber to pay the subscription with a boleto bancário. When opting for this payment method, the invoice sent will be valid for seven days, and it is going to remain valid until three days after expiration. If the subscriber fails to pay more than two consecutive boletos, the subscription is canceled. 
 
-To offer subscriptions with payments via boleto bancário, send a POST with the `payment_methods_allowed` parameter informing the payment method to be displayed on the checkout, such as `bolbradesco`, to the[/preapproval_plan](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/reference/subscriptions/_preapproval_plan/post) endpoint, and execute the request.
+To offer payment for subscriptions via boleto bancário, send a **POST** with the `payment_methods_allowed` parameter informing the payment method that should appear at checkout, for example, `bolbradesco` and the `status` parameter as "pending" to the endpoint [/preapproval_plan](/developers/en/reference/subscriptions/_preapproval_plan/post) and execute the request.
 
 > NOTE
 >
 > Important
 >
-> Boleto bancário as a payment method is only available for subscriptions created on the Checkout Pro, where the seller must redirect the buyer to the URL generated in the `init_point` parameter.
+> The payment of subscriptions by boleto bancário is only available for subscriptions created through the endpoint [/preapproval_plan](/developers/en/reference/subscriptions/_preapproval_plan/post), where the seller must redirect the buyer to the URL generated in the parameter `init_point`
 
 > PREV_STEP_CARD_PT
 >

--- a/guides/subscriptions/boleto-bancario.es.md
+++ b/guides/subscriptions/boleto-bancario.es.md
@@ -3,13 +3,13 @@
 
 Es posible poner a disposición del suscriptor la opción de pagar la suscripción con boleto bancário. Al optar por este medio de cobro, la factura enviada tendrá una validez de 7 días y permanecerá vigente hasta 3 días después de su vencimiento. Si el suscriptor no paga más de 2 boletos consecutivos, la suscripción será cancelada.
 
-Para ofrecer el pago de suscripciones a través de boleto bancario, envía un POST con el parámetro `payment_methods_allowed` informando el método de pago que aparecerá al finalizar la compra, por ejemplo, `bolbradesco` al endpoint [/preapproval_plan](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/reference/subscriptions/_preapproval_plan/post) y ejecute la solicitud. 
+Para ofrecer el pago de suscripciones a través de boleto bancario, envíe un **POST** con el parámetro `payment_methods_allowed` informando el medio de pago que debe aparecer en el checkout, por ejemplo, `bolbradesco` y el parámetro `status` como "pending" al endpoint [/preapproval_plan](/developers/es/reference/subscriptions/_preapproval_plan/post) y ejecuta la solicitud.
 
 > NOTE
 >
 > Importante
 >
-> El pago de suscripciones con boleto bancário solo está disponible para suscripciones creadas por Checkout Pro, donde el vendedor debe redirigir al comprador a la URL generada en el parámetro `init_point`. 
+> El pago de suscripciones mediante boleto bancario solo está disponible para las suscripciones creadas a través del endpoint [/preapproval_plan](/developers/es/reference/subscriptions/_preapproval_plan/post), donde el vendedor debe redirigir al comprador a la URL generada en el parámetro `init_point `.
 
 > PREV_STEP_CARD_PT
 >

--- a/guides/subscriptions/boleto-bancario.pt.md
+++ b/guides/subscriptions/boleto-bancario.pt.md
@@ -3,13 +3,14 @@
 
 É possível disponibilizar para o assinante a opção de pagar a assinatura com boleto bancário. Ao optar por esse meio de cobrança, o boleto enviado terá validade de 7 dias e continuará válido até 3 dias após o vencimento. Caso o assinante deixe de pagar mais de 2 boletos consecutivos, a assinatura será cancelada.
 
-Para oferecer pagamento de assinaturas via boleto bancário, envie um POST com o parâmetro `payment_methods_allowed` informando o meio de pagamento que deverá aparecerá no checkout, por exemplo, `bolbradesco` ao endpoint [/preapproval_plan](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/reference/subscriptions/_preapproval_plan/post) e execute a requisição. 
+Para oferecer pagamento de assinaturas via boleto bancário, envie um **POST** com o parâmetro `payment_methods_allowed` informando o meio de pagamento que deverá aparecerá no checkout, por exemplo, `bolbradesco` e o parâmetro `status` como "pending" ao endpoint [/preapproval_plan](/developers/pt/reference/subscriptions/_preapproval_plan/post) e execute a requisição.
 
->NOTE
+> NOTE
 >
 > Importante
 >
-> O pagamento de assinaturas por boleto bancário está disponível somente para assinaturas criadas pelo Checkout Pro, onde o vendedor deverá redirecionar o comprador para a URL  gerada no parâmetro `init_point`. 
+> O pagamento de assinaturas por boleto bancário está disponível somente para assinaturas criadas por meio do endpoint [/preapproval_plan](/developers/pt/reference/subscriptions/_preapproval_plan/post), onde o vendedor deverá redirecionar o comprador para a URL gerada no parâmetro `init_point`.
+
 
 > PREV_STEP_CARD_PT
 >


### PR DESCRIPTION
## Description

Recebemos o contato do Adriano Almeida solicitando um pequeno ajuste na seção de pagamentos de assinaturas com boleto bancário.

A solicitação foi:

Teríamos como melhorar esse ponto [nessa documentação](https://www.mercadopago.com.br/developers/pt/docs/subscriptions/integration-customization/payment-methods/boleto-bancario)? Esclarecendo que o método de pagamento de boleto (bolbradesco)  não está disponível para o endpoint: preapproval e que na criação do plano, na API de [/preapproval_plan](https://www.mercadopago.com.br/developers/pt/reference/subscriptions/_preapproval_plan/post), deve-se passar o status como "pending".

A informação foi alterada e está pronta para ir à produção.
