### PR TITLE
Comunicaciones de N-Ledger para mla y mlm

### DIFF
--- a/guides/additional-content/reports/available-money/api.en.md
+++ b/guides/additional-content/reports/available-money/api.en.md
@@ -3,11 +3,13 @@
 
 Generate the Released money report manually as many times as you want or schedule it according to the desired frequency through our API.
 
+----[mco, mlc, mlu, mpe]----
 > WARNING
 >
-> The Available Balance report will be disabled from March 1st, 2022.
+> Important
 >
-> You can use the [Release report](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/additional-content/reports/released-money/introduction) to reconcile the transactions that affect the balance available in your account, including your bank withdrawals.
+> We have limited the use of this API to the consultation and manual download of historical files due to the deactivation of the "Money withdrawn" report in the coming months. Instead, we recommend [using the "Releases" report.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/23879?utm_source=faq_mp&utm_medium=faq&utm_campaign=bank_disable)
+------------
 
 ## Configurable attributes
 

--- a/guides/additional-content/reports/available-money/api.es.md
+++ b/guides/additional-content/reports/available-money/api.es.md
@@ -3,13 +3,6 @@
 
 Genera el informe de dinero liberado manualmente tantas veces como desees o prográmalo de acuerdo con la frecuencia que elijas a través de nuestra API.
 
-----[mlm, mlb, mla]----
-> WARNING
->
-> Importante
->
-> El reporte de Dinero retirado será deshabilitado desde el 1 de marzo de 2022. Usa el [Reporte de liberaciones](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/additional-content/reports/released-money/introduction) para conciliar las transacciones del dinero disponible en tu cuenta, incluidos tus retiros bancarios.
-------------
 ----[mco, mlc]----
 > WARNING
 >

--- a/guides/additional-content/reports/available-money/api.es.md
+++ b/guides/additional-content/reports/available-money/api.es.md
@@ -3,12 +3,19 @@
 
 Genera el informe de dinero liberado manualmente tantas veces como desees o prográmalo de acuerdo con la frecuencia que elijas a través de nuestra API.
 
-----[mlm, mlb, mlc, mco, mla]----
+----[mlm, mlb, mla]----
 > WARNING
 >
 > Importante
 >
 > El reporte de Dinero retirado será deshabilitado desde el 1 de marzo de 2022. Usa el [Reporte de liberaciones](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/additional-content/reports/released-money/introduction) para conciliar las transacciones del dinero disponible en tu cuenta, incluidos tus retiros bancarios.
+------------
+----[mco, mlc]----
+> WARNING
+>
+> Importante
+>
+> Limitamos el uso de esta API a la consulta y descarga manual de archivos históricos, como consecuencia del deprecado del reporte Dinero retirado en los próximos meses. En su lugar, te recomendamos [usar el reporte Liberaciones](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/23879?utm_source=faq_mp&utm_medium=faq&utm_campaign=bank_disable)
 ------------
 ----[mpe, mlu]----
 > WARNING

--- a/guides/additional-content/reports/available-money/api.pt.md
+++ b/guides/additional-content/reports/available-money/api.pt.md
@@ -3,11 +3,13 @@
 
 Gere manualmente o relatório de dinheiro ----[mla]----liquidado------------ ----[mlm, mlb, mlc, mco, mlu, mpe]----liberado------------ quantas vezes quiser ou programe-o de acordo com a frequência que você escolher por meio de nossa API.
 
->WARNING
+----[mco, mlc, mlu, mpe]----
+> WARNING
 >
-> A partir do dia 1º de março de 2022, o relatório Dinheiro disponível será desabilitado
+> Importante
 >
-> Você pode usar o [relatório de ----[mla]----Liquidações------------ ----[mlm, mlb, mlc, mco, mlu, mpe]----Liberações------------](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/additional-content/reports/released-money/introduction) para fazer a reconciliação das transações que afetem o saldo disponível na sua conta, incluindo seus saques bancários.
+> Limitamos o uso desta API à consulta e download manual de arquivos históricos devido à desativação do relatório "Dinheiro retirado" nos próximos meses. Recomendamos que você [use o relatório "Liberações"](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/23879?utm_source=faq_mp&utm_medium=faq&utm_campaign=bank_disable)
+------------
 
 ## Atributos configuráveis
 

--- a/guides/additional-content/reports/available-money/generate.en.md
+++ b/guides/additional-content/reports/available-money/generate.en.md
@@ -1,12 +1,13 @@
 
 # How to generate your Available Balance report?
 
+----[mlm]----
 > WARNING
 >
-> The Available Balance report will be disabled from March 1st, 2022
+> Important
 >
-> You can use the [Releases report](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/additional-content/reports/released-money/introduction) to reconcile the transactions that affect the balance available in your account, including your bank withdrawals.
-
+> As of December 5th, you will no longer be able to create new "Money withdrawn" reports. In order to keep tracking all the transfers, withdrawals and movements of your available money [please use the "Releases" report.](https://bit.ly/3QiCD2f)
+---------
 
 ## Generating channels
 

--- a/guides/additional-content/reports/available-money/generate.en.md
+++ b/guides/additional-content/reports/available-money/generate.en.md
@@ -6,7 +6,7 @@
 >
 > Important
 >
-> As of December 5th, you will no longer be able to create new "Money withdrawn" reports. In order to keep tracking all the transfers, withdrawals and movements of your available money [please use the "Releases" report.](https://bit.ly/3QiCD2f)
+> As of December 12th, you will no longer be able to create new "Money withdrawn" reports. In order to keep tracking all the transfers, withdrawals and movements of your available money [please use the "Releases" report.](https://bit.ly/3QiCD2f)
 ---------
 
 ## Generating channels
@@ -16,7 +16,7 @@ There are three ways to generate an Available Balance report:
 | Channels | Description |
 | --- | --- |
 | Mercado Pago panel | <br/>It's very simple and fast. To generate it from your Mercado Pago account, go to [your reports](https://www.mercadopago.com.ar/balance/reports) and choose the *Reports* option.<br/><br/>Follow the step by step to [generate reports from this panel](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/additional-content/reports/available-money/panel).<br/><br/> |
-| API integration | <br/>Schedule the frequency of your report according to your needs. It can be both manually and on a scheduled basis.<br/><br/>Read the documentation to [generate reports through API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/additional-content/reports/available-money/api).<br/><br/>|
+| API integration | <br/>----[mla, mlb, mlm]---- Schedule the frequency of your report according to your needs. It can be both manually and on a scheduled basis.<br/><br/>Read the documentation to [generate reports through API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/additional-content/reports/available-money/api). ------------ ----[mpe, mlu, mco, mlc]---- This integration can only be used to consult and download the reports manual and does not allow generating new reports. ------------<br/><br/>|
 | Con el retiro de dinero | <br/>Generate a report automatically each time you withdraw your available balance to a bank account.<br/><br/>Follow the step by step to [generate reports for each withdrawal](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/additional-content/reports/available-money/withdrawal).<br/><br/> |
 
 

--- a/guides/additional-content/reports/available-money/generate.es.md
+++ b/guides/additional-content/reports/available-money/generate.es.md
@@ -1,13 +1,6 @@
 
 # ¿Cómo generar tu reporte de Dinero retirado?
 
-----[mlm, mlb, mla]----
-> WARNING
->
-> Importante
->
-> El reporte de Dinero retirado será deshabilitado desde el 1 de marzo de 2022. Usa el [reporte de Liberaciones](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/additional-content/reports/released-money/introduction) para conciliar las transacciones del dinero disponible en tu cuenta, incluidos tus retiros bancarios.
-------------
 ----[mpe, mlu]----
 > WARNING
 >
@@ -20,7 +13,21 @@
 >
 > Importante
 >
-> A partir del 1 de agosto no podrás crear nuevos reportes **Dinero retirado**. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usa el reporte Liberaciones.](https://vendedores.mercadolibre[FAKER][URL][DOMAIN]/lleva-el-control-de-tu-dinero-con-el-reporte-de-liberaciones)
+> **A partir del 1 de agosto no podrás crear nuevos reportes Dinero retirado. **. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usa el reporte Liberaciones.](https://vendedores.mercadolibre[FAKER][URL][DOMAIN]/lleva-el-control-de-tu-dinero-con-el-reporte-de-liberaciones)
+------------
+----[mla]----
+> WARNING
+>
+> Importante
+>
+> A partir del 28 de noviembre no podrás crear nuevos reportes Dinero retirado. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usá el reporte Liberaciones](https://bit.ly/3JzFPEG)
+------------
+----[mlm]----
+> WARNING
+>
+> Importante
+>
+> A partir del 5 de diciembre no podrás crear nuevos reportes Dinero retirado. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usa el reporte Liberaciones](https://bit.ly/3QiCD2f)
 ------------
 
 ## Canales de generación
@@ -30,7 +37,7 @@ Existen tres formas de generar un reporte de Dinero retirado:
 | Canales | Descripción |
 | --- | --- |
 | Panel de Mercado Pago | <br/>Es muy simple y rápido. Para generarlo desde tu cuenta de Mercado Pago, ve a [tus Informes](https://www.mercadopago.com.ar/balance/reports) y elige la opción de Reportes.<br/><br/>Sigue el paso a paso para [generar reportes desde el panel](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/additional-content/reports/available-money/panel).<br/><br/> |
-| Integración vía API | <br/>----[mco, mla, mlb, mlc, mlm]---- Programa la frecuencia de tu reporte según tus necesidades. Puede ser tanto de forma manual como de forma programada.<br/><br/>Lee la documentación para [generar reportes por API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/additional-content/reports/available-money/api). ------------ ----[mpe, mlu]---- El uso de esta integración está restringida a la consulta y descarga manual de reportes y no permite generar nuevos reportes. ------------ <br/><br/> |
+| Integración vía API | <br/>----[mla, mlb, mlm]---- Programa la frecuencia de tu reporte según tus necesidades. Puede ser tanto de forma manual como de forma programada.<br/><br/>Lee la documentación para [generar reportes por API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/additional-content/reports/available-money/api). ------------ ----[mpe, mlu, mco, mlc]---- El uso de esta integración está restringida a la consulta y descarga manual de reportes y no permite generar nuevos reportes. ------------ <br/><br/> |
 | Por retiro | <br/>Genera un reporte automáticamente cada vez que retires tu dinero a una cuenta bancaria.<br/><br/>Sigue el paso a paso para [generar reportes por cada retiro de dinero](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/additional-content/reports/available-money/withdrawal).<br/><br/> |
 
 

--- a/guides/additional-content/reports/available-money/generate.es.md
+++ b/guides/additional-content/reports/available-money/generate.es.md
@@ -20,14 +20,14 @@
 >
 > Importante
 >
-> A partir del 28 de noviembre no podrás crear nuevos reportes Dinero retirado. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usá el reporte Liberaciones](https://bit.ly/3JzFPEG)
+> A partir del 5 de diciembre no podrás crear nuevos reportes Dinero retirado. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usá el reporte Liberaciones](https://bit.ly/3JzFPEG)
 ------------
 ----[mlm]----
 > WARNING
 >
 > Importante
 >
-> A partir del 5 de diciembre no podrás crear nuevos reportes Dinero retirado. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usa el reporte Liberaciones](https://bit.ly/3QiCD2f)
+> A partir del 12 de diciembre no podrás crear nuevos reportes Dinero retirado. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usa el reporte Liberaciones](https://bit.ly/3QiCD2f)
 ------------
 
 ## Canales de generación

--- a/guides/additional-content/reports/available-money/generate.pt.md
+++ b/guides/additional-content/reports/available-money/generate.pt.md
@@ -24,7 +24,7 @@ Há três formas de gerar um relatório de Dinheiro disponível:
 | Canais | Descrição |
 | --- | --- |
 | Painel do Mercado Pago | <br/>É muito rápido e simples. Para gerar a partir da sua conta do Mercado Pago, vá até [Relatórios](https://www.mercadopago.com.br/balance/reports) e selecione uma opção de *Relatórios*.<br/><br/>Siga o passo a passo para [gerar relatórios a partir do painel](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/additional-content/reports/available-money/panel).<br/><br/> |
-| Integração via API | <br/>Programa a frequência do seu relatório de acordo com as suas necessidades. Pode ser tanto de forma manual como de forma programada.<br/><br/>Leia a documentação para [gerar relatórios por API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/additional-content/reports/available-money/api). <br/><br/>|
+| Integração via API | <br/> ----[mla, mlb, mlm]---- Programa a frequência do seu relatório de acordo com as suas necessidades. Pode ser tanto de forma manual como de forma programada.<br/><br/>Leia a documentação para [gerar relatórios por API](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/additional-content/reports/available-money/api). ------------ ----[mpe, mlu, mco, mlc]---- Esta integração só pode ser usada para consultar a baixar o manual de relatórios e não permite gerar novos relatórios. ------------<br/><br/>|
 | Com retirada de dinheiro | <br/>Gere um relatório automaticamente cada vez que retirar seu dinheiro disponível para uma conta bancária. <br/><br/>Siga o passo a passo para [gerar relatórios para cada retirada de dinheiro](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/additional-content/reports/available-money/withdrawal).<br/><br/> |
 
 

--- a/guides/additional-content/reports/available-money/generate.pt.md
+++ b/guides/additional-content/reports/available-money/generate.pt.md
@@ -1,12 +1,21 @@
 
 # Como gerar o seu relatório de Dinheiro disponível?
 
+----[mlb, mlc, mco, mlu, mpe]----
 > WARNING
 >
 > A partir do dia 1º de março de 2022, o relatório Dinheiro disponível será desabilitado
 >
 > Você pode usar o [relatório de ----[mla]----Liquidações------------ ----[mlm, mlb, mlc, mco, mlu, mpe]----Liberações------------](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/additional-content/reports/released-money/introduction) para fazer a reconciliação das transações que afetem o saldo disponível na sua conta, incluindo seus saques bancários.
+---------
 
+----[mla, mlm]----
+> WARNING
+>
+> Importante
+>
+> A partir de 5 de dezembro, não será mais possível criar novos relatórios de "Dinheiro retirado". Para continuar controlando as transferências, saques e movimentações do seu saldo disponível, por favor,  [use o relatório "Liberações".](https://bit.ly/3QiCD2f)
+---------
 
 ## Canais de geração
 

--- a/guides/additional-content/reports/available-money/introduction.en.md
+++ b/guides/additional-content/reports/available-money/introduction.en.md
@@ -3,12 +3,27 @@
 
 
 The Available Balance report is a **downloadable report that allows you to know the liquidity of your business**, that is, how much money you have to use. It contains the **detail of the released payments** that are ready to withdraw to a bank account, invest in Mercado Pago or use as balance in the Mercado Pago prepaid card.
-
+----[mpe, mlu]----
 > WARNING
 >
 > The Available Balance report will be disabled from March 1st, 2022.
 >
 > You can use the [Releases report](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/additional-content/reports/released-money/introduction) to reconcile the transactions that affect the balance available in your account, including your bank withdrawals.
+------------
+----[mlm]----
+> WARNING
+>
+> Important
+>
+> As of December 5th, you will no longer be able to create new "Money withdrawn" reports. In order to keep tracking all the transfers, withdrawals and movements of your available money, [please use the "Releases" report.](https://bit.ly/3QiCD2f)
+------------
+----[mla]----
+> WARNING
+>
+> Important
+>fechas
+> As of November 28th, you will no longer be able to create new "Money withdrawn" reports. In order to keep tracking all the transfers, withdrawals and movements of your available money,  [usá el reporte Liberaciones.](https://bit.ly/3JzFPEG)
+------------
 
 ## How do I download the report?
 

--- a/guides/additional-content/reports/available-money/introduction.es.md
+++ b/guides/additional-content/reports/available-money/introduction.es.md
@@ -3,12 +3,19 @@
 
 El reporte de Dinero retirado es un **informe descargable que te permite conocer cómo está compuesto el dinero que retiraste de Mercado Pago.** Contiene el **detalle de todos los fondos involucrados en dicho retiro,** tanto para casos de liberación de dinero como para bloqueos o desbloqueos.
 
-----[mlm, mlb, mla]----
+----[mlm]----
 > WARNING
 >
 > Importante
 >
-> El reporte de Dinero retirado será deshabilitado desde el 1 de marzo de 2022. Usa el [reporte de Liberaciones](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/additional-content/reports/released-money/introduction) para conciliar las transacciones del dinero disponible en tu cuenta, incluidos tus retiros bancarios.
+> A partir del 5 de diciembre no podrás crear nuevos reportes Dinero retirado. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usa el reporte Liberaciones.](https://bit.ly/3QiCD2f)
+------------
+----[mla]----
+> WARNING
+>
+> Importante
+>
+> A partir del 28 de noviembre no podrás crear nuevos reportes Dinero retirado. Para seguir llevando el control de todos los retiros y movimientos de tu dinero disponible [usá el reporte Liberaciones.](https://bit.ly/3JzFPEG)
 ------------
 ----[mpe, mlu]----
 > WARNING

--- a/guides/additional-content/reports/available-money/introduction.pt.md
+++ b/guides/additional-content/reports/available-money/introduction.pt.md
@@ -3,13 +3,21 @@
 
 
 O relatório de Dinheiro disponível é um **relatório para ser baixado que te permite saber a liquidez do seu negócio**, ou seja, quanto você tem para usar. Ele contém **detalhes dos pagamentos liberados** que estão prontos para serem retirados para uma conta bancária, render no Mercado Pago ou para usar saldo no cartão pré-pago Cartão Mercado Pago.
-
+----[mpe, mlu, mlc, mco]----
 > WARNING
 >
 > A partir do dia 1º de março de 2022, o relatório Dinheiro disponível será desabilitado
 >
 > Use o [relatório de ----[mla]----Liquidações------------ ----[mlm, mlb, mlc, mco, mlu, mpe]----Liberações------------](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/additional-content/reports/released-money/introduction) para fazer a reconciliação das transações que afetem o saldo disponível na sua conta, incluindo seus saques bancários.
+------------
 
+----[mlm, mla]----
+> WARNING
+>
+> Importante
+>
+> A partir de 5 de dezembro, não será mais possível criar novos relatórios de "Dinheiro retirado". Para continuar controlando as transferências, saques e movimentações do seu saldo disponível, por favor,[use o relatório "Liberações".](https://bit.ly/3QiCD2f)
+------------
 ## Como baixar o relatório?
 
 Lembre-se de que a geração deste relatório leva alguns minutos, dependendo de quantas informações você queira incluir nele. Nem sempre ele estará pronto de imediato e, enquanto estiver sendo gerado, você verá na tela o status Em preparação. 

--- a/guides/additional-content/reports/released-money/introduction.en.md
+++ b/guides/additional-content/reports/released-money/introduction.en.md
@@ -8,7 +8,7 @@ Releases report is a **downloadable report that allows you to know the liquidity
 >
 > Important
 >
-> The reports you generate from October 3rd onwards will show your money movements in chronological order, so you will be able to identify them more easily and better control your business finances.[Learn how to use it.](https://bit.ly/3zCb1ye)
+> The reports you generate from October 12th onwards will show your money movements in chronological order, so you will be able to identify them more easily and better control your business finances.[Learn how to use it.](https://bit.ly/3zCb1ye)
 ------------
 
 ## How do I download the report?

--- a/guides/additional-content/reports/released-money/introduction.en.md
+++ b/guides/additional-content/reports/released-money/introduction.en.md
@@ -3,6 +3,14 @@
 
 Releases report is a **downloadable report that allows you to know the liquidity of your business and to know how your available money is composed in Mercado Pago.** It contains the **detail of all funds involved in a date period,** and includes money release cases as well as blockings and unblockings.
 
+----[cbt]----
+> WARNING
+>
+> Important
+>
+> The reports you generate from October 3rd onwards will show your money movements in chronological order, so you will be able to identify them more easily and better control your business finances.[Learn how to use it.](https://bit.ly/3zCb1ye)
+------------
+
 ## How do I download the report?
 
 Keep in mind that the report generation takes a few minutes depending on how much information you want it to include. It will not always be ready instantly and, until it is, you will see the status *In preparation* on the screen.

--- a/guides/additional-content/reports/released-money/introduction.es.md
+++ b/guides/additional-content/reports/released-money/introduction.es.md
@@ -9,6 +9,21 @@
 
 El reporte de ----[mla]---- Liquidaciones ------------ ----[mlm, mlb, mlc, mco, mlu, mpe]---- Liberaciones ------------ es un **informe descargable que te permite conocer cómo está compuesto tu dinero disponible en Mercado Pago.** Contiene el **detalle de todos los fondos involucrados en un período de fechas,** e incluye los casos de ----[mla]---- liquidación ------------ ----[mlm, mlb, mlc, mco, mlu, mpe]---- liberación ------------ de dinero como de bloqueos y desbloqueos.
 
+----[mla]----
+> WARNING
+>
+> Importante
+>
+> Los reportes que generes a partir del 28 de septiembre presentarán tus movimientos en orden cronológico para que puedas identificarlos más fácil y controlar mejor las finanzas de tu negocio. [Conocé la nueva anatomía del reporte.](https://bit.ly/3JzFPEG)
+------------
+----[mlm]----
+> WARNING
+>
+> Importante
+>
+> Los reportes que generes a partir del 3 de octubre presentarán tus movimientos en orden cronológico para que puedas identificarlos más facilmente y controlar mejor las finanzas de tu negocio. [Conoce la nueva anatomía del reporte.](https://bit.ly/3QiCD2f)
+------------
+
 ## ¿Cómo descargo el reporte?
 
 Ten en cuenta que la generación del reporte lleva unos minutos dependiendo de cuánta información quieras que incluya. No siempre estará listo al instante y, hasta que lo esté, verás el estado *En preparación* en la pantalla.

--- a/guides/additional-content/reports/released-money/introduction.es.md
+++ b/guides/additional-content/reports/released-money/introduction.es.md
@@ -14,14 +14,14 @@ El reporte de ----[mla]---- Liquidaciones ------------ ----[mlm, mlb, mlc, mco, 
 >
 > Importante
 >
-> Los reportes que generes a partir del 5 de octubre presentarán tus movimientos en orden cronológico para que puedas identificarlos más fácil y controlar mejor las finanzas de tu negocio. [Conocé la nueva anatomía del reporte.](https://bit.ly/3JzFPEG)
+> Los reportes que generes a partir del 5 de octubre presentarán tus movimientos en orden cronológico para que puedas identificarlos más fácil y controlar mejor las finanzas de tu negocio. [Confira o novo formato do relatório](https://bit.ly/3JzFPEG)
 ------------
 ----[mlm]----
 > WARNING
 >
 > Importante
 >
-> Los reportes que generes a partir del 12 de octubre presentarán tus movimientos en orden cronológico para que puedas identificarlos más facilmente y controlar mejor las finanzas de tu negocio. [Conoce la nueva anatomía del reporte.](https://bit.ly/3QiCD2f)
+> Los reportes que generes a partir del 12 de octubre presentarán tus movimientos en orden cronológico para que puedas identificarlos más facilmente y controlar mejor las finanzas de tu negocio. [Confira o novo formato do relatório](https://bit.ly/3QiCD2f)
 ------------
 
 ## ¿Cómo descargo el reporte?

--- a/guides/additional-content/reports/released-money/introduction.es.md
+++ b/guides/additional-content/reports/released-money/introduction.es.md
@@ -14,14 +14,14 @@ El reporte de ----[mla]---- Liquidaciones ------------ ----[mlm, mlb, mlc, mco, 
 >
 > Importante
 >
-> Los reportes que generes a partir del 28 de septiembre presentarán tus movimientos en orden cronológico para que puedas identificarlos más fácil y controlar mejor las finanzas de tu negocio. [Conocé la nueva anatomía del reporte.](https://bit.ly/3JzFPEG)
+> Los reportes que generes a partir del 5 de octubre presentarán tus movimientos en orden cronológico para que puedas identificarlos más fácil y controlar mejor las finanzas de tu negocio. [Conocé la nueva anatomía del reporte.](https://bit.ly/3JzFPEG)
 ------------
 ----[mlm]----
 > WARNING
 >
 > Importante
 >
-> Los reportes que generes a partir del 3 de octubre presentarán tus movimientos en orden cronológico para que puedas identificarlos más facilmente y controlar mejor las finanzas de tu negocio. [Conoce la nueva anatomía del reporte.](https://bit.ly/3QiCD2f)
+> Los reportes que generes a partir del 12 de octubre presentarán tus movimientos en orden cronológico para que puedas identificarlos más facilmente y controlar mejor las finanzas de tu negocio. [Conoce la nueva anatomía del reporte.](https://bit.ly/3QiCD2f)
 ------------
 
 ## ¿Cómo descargo el reporte?

--- a/guides/additional-content/reports/released-money/introduction.pt.md
+++ b/guides/additional-content/reports/released-money/introduction.pt.md
@@ -13,7 +13,7 @@ O relatório de ----[mla]---- Liquidações ------------ ----[mlm, mlb, mlc, mco
 >
 > Importante
 >
-> Os relatórios gerados a partir de 5 de outubro vão apresentar suas movimentações em ordem cronológica, assim, você pode identificá-las mais facilmente e controlar ainda melhor as finanças dos seus negócios. [Conocé la nueva anatomía del reporte.](https://bit.ly/3JzFPEG)
+> Os relatórios gerados a partir de 5 de outubro vão apresentar suas movimentações em ordem cronológica, assim, você pode identificá-las mais facilmente e controlar ainda melhor as finanças dos seus negócios. [Conheça a nova anatomia do relatório.](https://bit.ly/3JzFPEG)
 ------------
 ----[mlm]----
 > WARNING

--- a/guides/additional-content/reports/released-money/introduction.pt.md
+++ b/guides/additional-content/reports/released-money/introduction.pt.md
@@ -20,7 +20,7 @@ O relatório de ----[mla]---- Liquidações ------------ ----[mlm, mlb, mlc, mco
 >
 > Importante
 >
-> Os relatórios gerados a partir de 12 de outubro vão apresentar suas movimentações em ordem cronológica, assim, você pode identificá-las mais facilmente e controlar ainda melhor as finanças dos seus negócios. [Conoce la nueva anatomía del reporte.](https://bit.ly/3QiCD2f)
+> Os relatórios gerados a partir de 12 de outubro vão apresentar suas movimentações em ordem cronológica, assim, você pode identificá-las mais facilmente e controlar ainda melhor as finanças dos seus negócios. [Conheça a nova anatomia do relatório.](https://bit.ly/3QiCD2f)
 ------------
 
 ## Como baixar o relatório?

--- a/guides/additional-content/reports/released-money/introduction.pt.md
+++ b/guides/additional-content/reports/released-money/introduction.pt.md
@@ -8,6 +8,21 @@
 
 O relatório de ----[mla]---- Liquidações ------------ ----[mlm, mlb, mlc, mco, mlu, mpe]---- Liberações ------------ e um **relatório para ser baixado que te permite saber como seu saldo disponível está composto no Mercado Pago. Ou seja, quanto você tem para usar**. Ele contém **detalhes de todos os valores envolvidos em um período de tempo,** e inclui os casos de ----[mla]---- liquidaçao ------------ ----[mlm, mlb, mlc, mco, mlu, mpe]---- liberação ------------ de dinheiro, como de bloqueios e desbloqueios.
 
+----[mla]----
+> WARNING
+>
+> Importante
+>
+> Os relatórios gerados a partir de 5 de outubro vão apresentar suas movimentações em ordem cronológica, assim, você pode identificá-las mais facilmente e controlar ainda melhor as finanças dos seus negócios. [Conocé la nueva anatomía del reporte.](https://bit.ly/3JzFPEG)
+------------
+----[mlm]----
+> WARNING
+>
+> Importante
+>
+> Os relatórios gerados a partir de 12 de outubro vão apresentar suas movimentações em ordem cronológica, assim, você pode identificá-las mais facilmente e controlar ainda melhor as finanças dos seus negócios. [Conoce la nueva anatomía del reporte.](https://bit.ly/3QiCD2f)
+------------
+
 ## Como baixar o relatório?
 
 Lembre-se de que a geração deste relatório leva alguns minutos, dependendo de quantas informações você queira incluir nele. Nem sempre ele estará pronto de imediato e, enquanto estiver sendo gerado, você verá na tela o status *Em preparação*.


### PR DESCRIPTION
## Description

Para los site de MLA y MLM van a salir dos campañas, la primera en el encendido de N-Ledger para la generación  de reportes de liberaciones y la segunda el apagado del reporte de dinero retirado, para cada site en especifico.
Se adiciono los mensajes de cada campaña a los site pertinentes y también  se actualizo la campaña de apagado del bank-report para MLC y MCO.

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->

### Issue involved

Fixes #<issue>
