### PR TITLE
fix/added 'point' tags to qr code cross apis

### DIFF
--- a/reference/api/pos.yaml
+++ b/reference/api/pos.yaml
@@ -9,6 +9,7 @@ paths:
     post:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Create POS
       x-summary-i18n:
         eng: Create POS
@@ -231,6 +232,7 @@ paths:
     get:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Search POS
       x-summary-i18n:
         eng: Search POS
@@ -379,6 +381,7 @@ paths:
     get:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Get POS
       x-summary-i18n:
         eng: Get POS
@@ -504,6 +507,7 @@ paths:
     put:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Update POS
       x-summary-i18n:
         eng: Update POS
@@ -733,6 +737,7 @@ paths:
     delete:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Delete POS
       x-summary-i18n:
         eng: Delete POS

--- a/reference/api/stores.yaml
+++ b/reference/api/stores.yaml
@@ -9,6 +9,7 @@ paths:
     get:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Get store
       x-summary-i18n:
         eng: Get store
@@ -141,6 +142,7 @@ paths:
     post:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Create store
       x-summary-i18n:
         eng: Create store
@@ -392,6 +394,7 @@ paths:
     get:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Search stores
       x-summary-i18n:
         eng: Search stores
@@ -563,6 +566,7 @@ paths:
     put:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Update store
       x-summary-i18n:
         eng: Update store
@@ -812,6 +816,7 @@ paths:
     delete:
       tags:
         - $ref: '#/tags/qr-code'
+        - $ref: '#/tags/mp-point'
       summary: Delete store
       x-summary-i18n:
         eng: Delete store

--- a/reference/base.yaml
+++ b/reference/base.yaml
@@ -48,7 +48,7 @@ tags:
       en: 'Mercado Pago Point'
       es: 'Mercado Pago Point'
     externalDocs: 
-      url: '/guides/in-person-payments/mp-point/introduction'
+      url: '/docs/mp-point/introduction'
   checkout-api:
     description:
       pt: 'Checkout Transparente'


### PR DESCRIPTION
## Description

Devido à nova reestruturação dos menus da API Reference tivemos que migrar as APIs de Caixas e Lojas Físicas (que antes estavam somente em QR Code) para o novo divisor ONLINE PAYMENTS, uma vez que essas APIs se aplicam tanto para QR quanto para POINT.

Frente à essa mudança, inserimos as tags de MP Point nas APIs de Caixas e Lojas Físicas.