### PR TITLE
fix/VTEX doc link correction

### DIFF
--- a/guides/vtex/logs.en.md
+++ b/guides/vtex/logs.en.md
@@ -25,7 +25,7 @@ To access the logs, access the administration panel of your VTEX store, and clic
 
 In case of a rejection, it is very important to check the `status_detail` that specifies the reason for it.
 
-For more information, access the link [Results of the creation of a position](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/en/guides/checkout-api/collection-creation-results).
+For more information, access the link [Results of the creation of a position](/developers/en/docs/checkout-api/response-handling/collection-results).
 
 > NEXT_STEP_CARD_EN
 >

--- a/guides/vtex/logs.es.md
+++ b/guides/vtex/logs.es.md
@@ -25,7 +25,7 @@ Para acceder a los logs, accede al panel de administración de tu tienda VTEX y 
 
 Ante un rechazo, es muy importante revisar el `status_detail` que especifica el motivo del mismo.
 
-Para obtener más información, accede al enlace [Resultados de la creación de un cobro](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/es/guides/checkout-api/collection-creation-results).
+Para obtener más información, accede al enlace [Resultados de la creación de un cobro](/developers/es/docs/checkout-api/response-handling/collection-results).
 
 > NEXT_STEP_CARD_ES
 >

--- a/guides/vtex/logs.pt.md
+++ b/guides/vtex/logs.pt.md
@@ -25,7 +25,7 @@ Para ter acesso aos logs, acesse o painel de administração de sua loja VTEX e 
 
 Caso um pagamento seja rejeitado, é  importante rever o `status_detail` que especifica o motivo da recusa.
 
-Para mais informações, acesse o link [Resultados da criação de uma cobrança](https://www.mercadopago[FAKER][URL][DOMAIN]/developers/pt/guides/checkout-api/collection-creation-results).
+Para mais informações, acesse o link [Resultados da criação de uma cobrança](/developers/pt/docs/checkout-api/response-handling/collection-results).
 
 > NEXT_STEP_CARD_PT
 >


### PR DESCRIPTION
## Description

Havia um link na seção `verificação de logs` que estava direcionando para um link quebrado. Este link foi corrigido e agora funciona corretamente.
