### PR TITLE
fix/added recomendations to use wallet connect

### DIFF
--- a/guides/wallet-connect/create-agreement.en.md
+++ b/guides/wallet-connect/create-agreement.en.md
@@ -17,18 +17,3 @@ To create an _agreement_, send a **POST** with the necessary attributes to the [
 >
 > A user can only have one active agreement per integration. If you want to create a new agreement, you must cancel the previous one. To cancel an agreement, send a DELETE to the endpoint [/v2/wallet_connect/agreements/{agreement_id}](/developers/en/reference/wallet_connect/_wallet_connect_agreements_agreement_id/delete) and execute the request.
 
-> PREV_STEP_CARD_EN
->
-> Prerequisites
->
-> Learn about the prerequisites needed to integrate Wallet Connect.
->
-> [Prerequisites](/developers/en/docs/wallet-connect/prerequisites)
-
-> NEXT_STEP_CARD_EN
->
-> Get approval
->
-> Learn how to get payer approval to use payment details.
->
-> [Get approval](/developers/en/docs/wallet-connect/integration-configuration/get-approval)

--- a/guides/wallet-connect/create-agreement.es.md
+++ b/guides/wallet-connect/create-agreement.es.md
@@ -15,20 +15,5 @@ Para crear un _agreement_, envía un **POST** con los atributos necesarios al en
 >
 > Importante
 >
-> Un usuario sólo puede tener un agreement activo por integración. Si quieres crear un nuevo agreement, debes cancelar el anterior. Para cancelar un agreement, envía un DELETE al endpoint [/v2/wallet_connect/agreements/{agreement_id}](/developers/es/reference/wallet_connect/_wallet_connect_agreements_agreement_id/delete) y ejecuta la solicitud.
+> Un usuario sólo puede tener un agreement activo por integración. Si quieres crear un nuevo agreement, debes cancelar el anterior. Para cancelar un agreement, envía un DELETE al endpoint [/v2/wallet_connect/agreements/{agreement_id}](/developers/es/reference/wallet_connect/_wallet_connect_agreements_agreement_id/delete) y ejecuta el request.
 
-> PREV_STEP_CARD_ES
->
-> Requisitos previos 
->
-> Conozca los requisitos previos necesarios para integrar Wallet Connect.
->
-> [Requisitos previos](/developers/es/docs/wallet-connect/prerequisites)
-
-> NEXT_STEP_CARD_ES
->
-> Obtener aprobación
->
-> Obtenga información sobre cómo obtener la aprobación del pagador para usar los datos de pago.
->
-> [Obtener aprobación](/developers/es/docs/wallet-connect/integration-configuration/get-approval)

--- a/guides/wallet-connect/create-agreement.pt.md
+++ b/guides/wallet-connect/create-agreement.pt.md
@@ -17,18 +17,3 @@ Para criar um _agreement_, envie um **POST** com os atributos necessários ao en
 >
 > Um usuário pode ter apenas um agreement ativo por integração. Caso queira criar um novo agreement, é preciso cancelar o anterior. Para cancelar um agreement, envie um DELETE ao endpoint [/v2/wallet_connect/agreements/{agreement_id}](/developers/pt/reference/wallet_connect/_wallet_connect_agreements_agreement_id/delete) e execute a requisição.
 
-> PREV_STEP_CARD_PT
->
-> Pré-requisitos 
->
-> Conheça os pré-requisitos necessários para integrar o Wallet Connect.
->
-> [Pré-requisitos](/developers/pt/docs/wallet-connect/prerequisites)
-
-> NEXT_STEP_CARD_PT
->
-> Obter aprovação
->
-> Saiba como obter a aprovação do pagador para utilização dos dados de pagamento.
->
-> [Obter aprovação](/developers/pt/docs/wallet-connect/integration-configuration/get-approval)

--- a/guides/wallet-connect/create-payer-token.en.md
+++ b/guides/wallet-connect/create-payer-token.en.md
@@ -11,18 +11,3 @@ To create a **payer token**, send a POST with all necessary attributes to the en
 
 With the creation of the payer token, the Wallet Connect integration will finish successfully. Therefore, we recommend you check the [Webhooks](/docs/wallet-connect/additional-content/notifications/webhooks) documentation to set notifications up and receive real-time information anytime an event occurs.
 
-> PREV_STEP_CARD_EN
->
-> Get approval
->
-> Learn how to get payer approval to use payment details.
->
-> [Get approval](/developers/en/docs/wallet-connect/integration-configuration/get-approval)
-
-> NEXT_STEP_CARD_EN
->
-> Notifications
->
-> Configure notifications to receive real-time information about events that happen.
->
-> [Notifications](/developers/en/docs/wallet-connect/additional-content/notifications/introduction)

--- a/guides/wallet-connect/create-payer-token.es.md
+++ b/guides/wallet-connect/create-payer-token.es.md
@@ -10,18 +10,3 @@ Para crear un _payer token_, envíe un POST con todos los atributos necesarios a
 
 Con la creación del payer token, la integración con Wallet Connect finalizará con éxito. Por tanto, te recomendamos que consultes la documentación [Webhooks](/docs/wallet-connect/additional-content/notifications/webhooks) para configurar las notificaciones y recibir información en tiempo real cada vez que se produzca un evento.
 
-> PREV_STEP_CARD_ES
->
-> Obtener aprobación
->
-> Obtenga información sobre cómo obtener la aprobación del pagador para usar los datos de pago.
->
-> [Obtener aprobación](/developers/es/docs/wallet-connect/integration-configuration/get-approval)
-
-> NEXT_STEP_CARD_ES
->
-> Notificaciones
->
-> Configura notificaciones para recibir información en tiempo real sobre los eventos que suceden.
->
-> [Notificaciones](/developers/es/docs/wallet-connect/additional-content/notifications/introduction)

--- a/guides/wallet-connect/create-payer-token.pt.md
+++ b/guides/wallet-connect/create-payer-token.pt.md
@@ -10,18 +10,3 @@ Para criar um _payer token_, envie um **POST** com todos os atributos necessári
 
 Com o payer token criado, a integração com o Wallet Connect terá sido concluída com sucesso. Dessa forma, recomendamos que veja a documentação [Webhooks](/docs/wallet-connect/additional-content/notifications/webhooks) para configurar as notificações e receber informações em tempo real sempre que um evento acontecer.
 
-> PREV_STEP_CARD_PT
->
-> Obter aprovação
->
-> Saiba como obter a aprovação do pagador para utilização dos dados de pagamento.
->
-> [Obter aprovação](/developers/pt/docs/wallet-connect/integration-configuration/get-approval)
-
-> NEXT_STEP_CARD_PT
->
-> Notificações
->
-> Configure as notificações para receber informações em tempo real sobre os eventos que acontecerem.
->
-> [Notificações](/developers/pt/docs/wallet-connect/additional-content/notifications/introduction)

--- a/guides/wallet-connect/get-approval.en.md
+++ b/guides/wallet-connect/get-approval.en.md
@@ -13,18 +13,3 @@ As indicated in the sequence diagram above, the buyer's approval occurs during t
 
 Once the connection is authorized, check the Create payer token section to complete the Wallet Connect integration.
 
-> PREV_STEP_CARD_EN
->
-> Create agreement
->
-> See the steps for creating an agreement necessary for Wallet Connect integration.
->
-> [Create agreement](/developers/en/docs/wallet-connect/integration-configuration/create-agreement)
-
-> NEXT_STEP_CARD_EN
->
-> Create payer token
->
-> Learn how to create a payer token and complete the Wallet Connect integration.
->
-> [Create payer token](/developers/en/docs/wallet-connect/integration-configuration/create-payer-token)

--- a/guides/wallet-connect/get-approval.es.md
+++ b/guides/wallet-connect/get-approval.es.md
@@ -13,18 +13,3 @@ Como se indica en el anterior diagrama de secuencia, la aprobación del comprado
 
 Con la conexión autorizada, consulta la sección Crear payer token para finalizar la integración de Wallet Connect.
 
-> PREV_STEP_CARD_ES
->
-> Crear agreement
->
-> Consulte los pasos para crear un acuerdo necesario para la integración de Wallet Connect.
->
-> [Crear agreement](/developers/es/docs/wallet-connect/integration-configuration/create-agreement)
-
-> NEXT_STEP_CARD_ES
->
-> Crear payer token
->
-> Aprenda a crear un payer token y completa la integración de Wallet Connect.
->
-> [Crear payer token](/developers/es/docs/wallet-connect/integration-configuration/create-payer-token)

--- a/guides/wallet-connect/get-approval.pt.md
+++ b/guides/wallet-connect/get-approval.pt.md
@@ -13,18 +13,3 @@ Conforme indicado no diagrama de sequência acima, a aprovação do comprador oc
 
 Com a conexão autorizada, veja a seção Criar payer token para concluir a integração do Wallet Connect.
 
-> PREV_STEP_CARD_PT
->
-> Criar agreement
->
-> Veja os passos para a criação de um agreement necessário para integração do Wallet Connect.
->
-> [Criar agreement](/developers/pt/docs/wallet-connect/integration-configuration/create-agreement)
-
-> NEXT_STEP_CARD_PT
->
-> Criar payer token
->
-> Saiba como criar um payer token e concluir a integração com Wallet Connect.
->
-> [Criar payer token](/developers/pt/docs/wallet-connect/integration-configuration/create-payer-token)

--- a/guides/wallet-connect/prerequisites.en.md
+++ b/guides/wallet-connect/prerequisites.en.md
@@ -6,7 +6,7 @@ To perform the Wallet Connect integration, you must meet the requirements descri
 >
 > Important
 >
-> Recommended for Sellers with an average ticket of less than 10 USD, an average of 2 transactions per week and more than 100 thousand users. If you are interested in the product, please contact us via email wallet-connect@mercadolibre.com
+> Recommended for sellers with recurring sales with an average ticket below 15 USD, more than 100 thousand users and at least 2 monthly transactions per user. Or for sellers with a monthly subscription, more than 100 thousand users and an average ticket of less than 40 USD. If you are interested in the product, please contact us via email **wallet-connect@mercadolibre.com**
 
 | Requisite | Description
 | --- | --- |

--- a/guides/wallet-connect/prerequisites.en.md
+++ b/guides/wallet-connect/prerequisites.en.md
@@ -2,6 +2,12 @@
 
 To perform the Wallet Connect integration, you must meet the requirements described below.
 
+> WARNING
+>
+> Important
+>
+> Recommended for Sellers with an average ticket of less than 10 USD, an average of 2 transactions per week and more than 100 thousand users. If you are interested in the product, please contact us via email wallet-connect@mercadolibre.com
+
 | Requisite | Description
 | --- | --- |
 | Application | Applications are the different integrations in one or more stores. You can create an application for each solution you implement to keep everything organized and on track for easier management. Check [Dashboard](/developers/en/docs/wallet-connect/additional-content/dashboard/introduction) for more information on how to create an application. |

--- a/guides/wallet-connect/prerequisites.en.md
+++ b/guides/wallet-connect/prerequisites.en.md
@@ -17,10 +17,3 @@ To perform the Wallet Connect integration, you must meet the requirements descri
 
 If all the prerequisites are met, you can perform the Wallet Connect integration.
 
-> NEXT_STEP_CARD_EN
->
-> Integration configuration
->
-> Learn how to perform the Wallet Connect integration.
->
-> [Create agreement](/developers/en/docs/wallet-connect/integration-configuration/create-agreement)

--- a/guides/wallet-connect/prerequisites.es.md
+++ b/guides/wallet-connect/prerequisites.es.md
@@ -20,7 +20,6 @@ Para integrarse con Wallet Connect, debe cumplir con los requisitos que se descr
 
 ------------
 
-
 | Requisito  | Descripción  |
 | --- | --- |
 | Aplicación  | Las aplicaciones son las diversas integraciones contenidas en una o varias tiendas. Puedes crear una aplicación para cada solución que implementes a fin de tener todo organizado y mantener un control que facilite la gestión. Consulta [Dashboard](/developers/es/docs/wallet-connect/additional-content/dashboard/introduction) para obtener más información sobre cómo crear una aplicación. |
@@ -30,10 +29,3 @@ Para integrarse con Wallet Connect, debe cumplir con los requisitos que se descr
 
 Si se cumplen todos los requisitos previos, puede realizar la integración de Wallet Connect.
 
-> NEXT_STEP_CARD_ES
->
-> Configuración de la integración
->
-> Aprenda cómo hacer la integración de Wallet Connect.
->
-> [Criar agreement](/developers/es/docs/wallet-connect/integration-configuration/create-agreement)

--- a/guides/wallet-connect/prerequisites.es.md
+++ b/guides/wallet-connect/prerequisites.es.md
@@ -2,6 +2,13 @@
 
 Para integrarse con Wallet Connect, debe cumplir con los requisitos que se describen a continuación.
 
+> WARNING
+>
+> Importante
+>
+> Recomendado para Sellers con ticket promedio menor a 10 USD, 2 transacciones en promedio por semana y más de 100 mil usuarios. Si está interesado en el producto, contáctenos a través del correo electrónico wallet-connect@mercadolibre.com
+
+
 | Requisito  | Descripción  |
 | --- | --- |
 | Aplicación  | Las aplicaciones son las diversas integraciones contenidas en una o varias tiendas. Puedes crear una aplicación para cada solución que implementes a fin de tener todo organizado y mantener un control que facilite la gestión. Consulta [Dashboard](/developers/es/docs/wallet-connect/additional-content/dashboard/introduction) para obtener más información sobre cómo crear una aplicación. |

--- a/guides/wallet-connect/prerequisites.es.md
+++ b/guides/wallet-connect/prerequisites.es.md
@@ -2,11 +2,23 @@
 
 Para integrarse con Wallet Connect, debe cumplir con los requisitos que se describen a continuación.
 
+----[mla]----
 > WARNING
 >
 > Importante
 >
-> Recomendado para Sellers con ticket promedio menor a 10 USD, 2 transacciones en promedio por semana y más de 100 mil usuarios. Si está interesado en el producto, contáctenos a través del correo electrónico wallet-connect@mercadolibre.com
+> Recomendado para sellers con ventas recurrentes de ticket promedio menor a 15 USD, más de 100 mil usuarios y al menos 2 transacciones mensuales por usuario, o para vendedores con formato suscripción mensual, con mas de 100 mil usuarios y un ticket promedio menor a 40 USD. Si tenés interés en el producto, contactanos a través del correo **wallet-connect@mercadolibre.com**
+
+------------
+
+----[mlb, mlc, mco, mlm, mpe, mlu]----
+> WARNING
+>
+> Importante
+>
+> Recomendado para sellers con ventas recurrentes de ticket promedio menor a 15 USD, más de 100 mil usuarios y al menos 2 transacciones mensuales por usuario, o para vendedores con formato suscripción mensual, con mas de 100 mil usuarios y un ticket promedio menor a 40 USD. Si tienes interés en el producto, contáctaneos a través del correo **wallet-connect@mercadolibre.com**
+
+------------
 
 
 | Requisito  | Descripción  |

--- a/guides/wallet-connect/prerequisites.pt.md
+++ b/guides/wallet-connect/prerequisites.pt.md
@@ -2,6 +2,12 @@
 
 Para realizar a integração com Wallet Connect, é preciso atender aos requisitos descritos abaixo.
 
+> WARNING
+>
+> Importante
+>
+> Wallet Connect é recomendado para Sellers com ticket médio inferior a 10 USD, média de 2 transações por semana e mais de 100 mil usuários. Caso tenha interesse no produto, entre em contato através do email wallet-connect@mercadolibre.com
+
 | Requisito  | Descrição  |
 | --- | --- |
 | Aplicação  | As aplicações são as diferentes integrações contidas em uma ou mais lojas. Você pode criar uma aplicação para cada solução que implementar, a fim de ter tudo organizado e manter um controle que facilite a gestão. Veja [Dashboard](/developers/pt/docs/wallet-connect/additional-content/dashboard/introduction) para mais informações sobre como criar uma aplicação.  |

--- a/guides/wallet-connect/prerequisites.pt.md
+++ b/guides/wallet-connect/prerequisites.pt.md
@@ -16,11 +16,3 @@ Para realizar a integração com Wallet Connect, é preciso atender aos requisit
 | Permissão Wallet Connect  | Para habilitar sua aplicação, consumir as APIs citadas na documentação e receber pagamentos através do Mercado Pago Wallet, entre em contato com seu gerente de conta.  |
 
 Se todos os pré-requisitos foram atendidos, você poderá realizar a integração com Wallet Connect.
-
-> NEXT_STEP_CARD_PT
->
-> Configuração da integração
->
-> Saiba como realizar a integração completa do Wallet Connect.
->
-> [Criar agreement](/developers/pt/docs/wallet-connect/integration-configuration/create-agreement)

--- a/guides/wallet-connect/prerequisites.pt.md
+++ b/guides/wallet-connect/prerequisites.pt.md
@@ -6,7 +6,7 @@ Para realizar a integração com Wallet Connect, é preciso atender aos requisit
 >
 > Importante
 >
-> Wallet Connect é recomendado para Sellers com ticket médio inferior a 10 USD, média de 2 transações por semana e mais de 100 mil usuários. Caso tenha interesse no produto, entre em contato através do email wallet-connect@mercadolibre.com
+> Recomendado para sellers com vendas recorrentes com ticket médio inferior a 15 USD, mais de 100 mil usuários e pelo menos 2 transações mensais por usuário, ou para vendedores com assinatura mensal, mais de 100 mil usuários e ticket médio inferior a 40 USD. Caso tenha interesse no produto, entre em contato conosco através do e-mail **wallet-connect@mercadolibre.com**
 
 | Requisito  | Descrição  |
 | --- | --- |


### PR DESCRIPTION
## Description

Para utilizar Wallet Connect é preciso ter determinadas características. Essas características foram adicionadas em forma de nota na documentação de Wallet Connect e descrevem o seguinte:

Wallet Connect é recomendado para Sellers com ticket médio inferior a 10 USD, média de 2 transações por semana e mais de 100 mil usuários. Caso tenha interesse no produto, entre em contato através do email wallet-connect@mercadolibre.com

