### PR TITLE
[Checkout Bricks] Add warning message to Pix QR Code ticket URL

### DIFF
--- a/guides/checkout-bricks/payment-brick/payment-submission-pix.en.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission-pix.en.md
@@ -249,4 +249,10 @@ The response will show the payment **pending status** and all the information yo
 After the payment creation in the backend using the Mercado Pago SDK, use the **id** received in the response to instantiate the Status Screen Brick and show it to the buyer.
 In addition to displaying the payment status, Status Screen Brick will also display the Pix code to copy and paste and the QRCode for the buyer to scan and pay. Learn how simple it is to integrate [click here](/developers/en/docs/checkout-bricks/status-screen-brick/configure-integration).
 
+> WARNING
+>
+> Important
+>
+> If you used production credentials from a test user to generate the Pix payment, an error will occur when clicking the button that takes you to the QR Code page. To view correctly, just remove `/sandbox` from the URL of the opened page.
+
 ![payment-submission-pix-status](checkout-bricks/payment-submission-pix-status-en.jpg)

--- a/guides/checkout-bricks/payment-brick/payment-submission-pix.es.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission-pix.es.md
@@ -249,4 +249,10 @@ La respuesta mostrará el estado del pago pendiente y toda la información que n
 Después de crear el pago desde backend con el SDK de Mercado Pago, use el **id** recibido en la respuesta para crear una instancia del Status Screen Brick y mostrárselo al comprador.
 Además de mostrar el estado del pago, Status Screen Brick también mostrará el código Pix para copiar y pegar y el QRCode para que el comprador lo escanee y pague. Descubra lo sencillo que es integrar [haga clic aquí](/developers/es/docs/checkout-bricks/status-screen-brick/configure-integration).
 
+> WARNING
+>
+> Importante
+>
+> Si usó las credenciales de producción de un usuario de prueba para generar el pago Pix, se producirá un error al hacer clic en el botón que lo lleva a la página del QR Code. Para verlo correctamente, simplemente elimine el fragmento `/sandbox` de la URL de la página abierta.
+
 ![payment-submission-pix-status](checkout-bricks/payment-submission-pix-status-es.jpg)

--- a/guides/checkout-bricks/payment-brick/payment-submission-pix.pt.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission-pix.pt.md
@@ -253,6 +253,6 @@ Além de exibir o status do pagamento, o Status Screen Brick também exibirá o 
 >
 > Importante
 >
-> Caso você tenha usado credenciais de produção de um usuário de teste para gerar o pagamento com Pix, ocorrerá um erro de visualização ao clicar no botão que leva a página do QR Code. Para visualizar corretamente, apenas remova o trecho `/sandbox` da URL da página aberta.
+> Caso você tenha utilizado as credenciais de produção de um usuário de teste para gerar o pagamento com Pix, ocorrerá um erro de visualização ao clicar no botão que leva a página do QR Code. Para visualizá-la corretamente, remova o trecho `/sandbox` da URL da página aberta.
 
 ![payment-submission-pix-status](checkout-bricks/payment-submission-pix-status-pt.jpg)

--- a/guides/checkout-bricks/payment-brick/payment-submission-pix.pt.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission-pix.pt.md
@@ -249,4 +249,10 @@ A resposta mostrará o estado pendente do pagamento e todas as informações que
 Após criar o pagamento pelo backend utilizando a SDK do Mercado Pago, utilize o **id** recebido na resposta para instanciar o Status Screen Brick e mostrar para o comprador.
 Além de exibir o status do pagamento, o Status Screen Brick também exibirá o código Pix para copiar e colar e o QRCode para o comprador escanear e pagar. Saiba como é simples integrar [clicando aqui](/developers/pt/docs/checkout-bricks/status-screen-brick/configure-integration).
 
+> WARNING
+>
+> Importante
+>
+> Caso você tenha usado credenciais de produção de um usuário de teste para gerar o pagamento com Pix, ocorrerá um erro de visualização ao clicar no botão que leva a página do QR Code. Para visualizar corretamente, apenas remova o trecho `/sandbox` da URL da página aberta.
+
 ![payment-submission-pix-status](checkout-bricks/payment-submission-pix-status-pt.jpg)


### PR DESCRIPTION
## Description
While Checkout Bricks Q3 demo, we received feedback that we should advise the user about the error that occurs when opening Pix ticket (QR Code) when the Pix payment is generated with production credentials from a test user.