### PR TITLE
[Checkout Bricks] Enhancement: clarify email usage

### DIFF
--- a/guides/snippets/test-integration/bricks/bricks-test-payment-flow.en.md
+++ b/guides/snippets/test-integration/bricks/bricks-test-payment-flow.en.md
@@ -12,3 +12,9 @@ With the credentials in hand, follow the steps below to make the test purchase.
 3. Confirm the purchase.
 
 Done! Once these steps are finished, the integration will be complete and you will be able to use your production credentials to use the Checkout Bricks.
+
+> WARNING
+>
+> Attention
+>
+> Do not use test user email into the Brick email field (if applicable).

--- a/guides/snippets/test-integration/bricks/bricks-test-payment-flow.en.md
+++ b/guides/snippets/test-integration/bricks/bricks-test-payment-flow.en.md
@@ -7,7 +7,7 @@ To make a t purchase, you must use the **test credentials** of your **production
 With the credentials in hand, follow the steps below to make the test purchase.
 
 1. Start the integration configured with the **Test credentials**.
-2. Enter your e-mail (remembering that it must be different from the email you use on Mercado Pago).
+2. Enter any email as a paying user (remembering that it must be different from the email you use on Mercado Pago).
 4. Enter data from one of our [test cards](/developers/en/guides/additional-content/testing/test-cards).
 3. Confirm the purchase.
 

--- a/guides/snippets/test-integration/bricks/bricks-test-payment-flow.es.md
+++ b/guides/snippets/test-integration/bricks/bricks-test-payment-flow.es.md
@@ -7,7 +7,7 @@ Para realizar una compra de prueba, debe usar las **credenciales de prueba** de 
 Con las credenciales configuradas, siga los pasos a continuación para realizar la compra de prueba.
 
 1. Inicie la integración configurada con sus **Credenciales de prueba**.
-2. Ingresa tu correo (recordando que debe ser diferente al correo que usas en Mercado Pago).
+2. Ingrese cualquier correo electrónico como usuario pagador (recordando que debe ser diferente al correo que usas en Mercado Pago).
 4. Ingresa los datos de una de nuestras [tarjetas de prueba](/developers/es/guides/additional-content/testing/test-cards).
 3. Confirma la compra.
 

--- a/guides/snippets/test-integration/bricks/bricks-test-payment-flow.es.md
+++ b/guides/snippets/test-integration/bricks/bricks-test-payment-flow.es.md
@@ -12,3 +12,9 @@ Con las credenciales configuradas, siga los pasos a continuación para realizar 
 3. Confirma la compra.
 
 ¡Listo! Una vez que se completen estos pasos, la integración estará completa y podrá usar sus credenciales de producción para usar el Checkout Bricks.
+
+> WARNING
+>
+> Atención
+>
+> No use el correo electrónico de usuario de prueba en el campo de correo electrónico del Brick (si corresponde).

--- a/guides/snippets/test-integration/bricks/bricks-test-payment-flow.pt.md
+++ b/guides/snippets/test-integration/bricks/bricks-test-payment-flow.pt.md
@@ -12,3 +12,9 @@ Com as credenciais em mãos, siga os passos abaixo para realizar a compra teste.
 3. Confirme a compra.
 
 Pronto! Finalizadas essas etapas a integração terá sido concluída e você já poderá utilizar suas credenciais de produção para utilizar o Checkout Bricks.
+
+> WARNING
+>
+> Atenção
+>
+> Não utilize e-mail de usuário de teste no campo de e-mail do Brick (se aplicável).

--- a/guides/snippets/test-integration/bricks/bricks-test-payment-flow.pt.md
+++ b/guides/snippets/test-integration/bricks/bricks-test-payment-flow.pt.md
@@ -7,7 +7,7 @@ Para realizar uma compra teste é preciso utilizar as **credenciais de teste** d
 Com as credenciais em mãos, siga os passos abaixo para realizar a compra teste.
 
 1. Inicie a integração configurada com as **credenciais de teste**.
-2. Insira um e-mail (lembrando que deve ser diferente do e-mail que você utiliza no Mercado Pago).
+2. Insira qualquer e-mail como usuário pagador (lembrando que deve ser diferente do e-mail que você utiliza no Mercado Pago).
 4. Insira os dados de um dos nossos [cartões de teste](/developers/pt/guides/additional-content/testing/test-cards).
 3. Confirme a compra.
 


### PR DESCRIPTION
## Description

Clarifies that the integrator, when using test credentials from your personal account, can fill the email field in the brick with any email, **except test user emails.**
