### PR TITLE
fix/preferences api expiration date parameter fix

### DIFF
--- a/reference/api/preferences.yaml
+++ b/reference/api/preferences.yaml
@@ -481,19 +481,19 @@ paths:
                 expiration_date_from:
                   type: string
                   format: date
-                  description: Date in YYYY-MM-DD-HH-MM-SS format which indicates the start of the preference`s validity period. This can be used, for instance, for limited sales, where sellers make an offer between certain dates.
+                  description: Date in "yyyy-MM-dd'T'HH:mm:ssz" format which indicates the start of the preference`s validity period. This can be used, for instance, for limited sales, where sellers make an offer between certain dates. For example - 2022-11-17T09:37:52.000-04:00.
                   x-description-i18n:
-                    eng: Date in YYYY-MM-DD-HH-MM-SS format which indicates the start of the preference`s validity period. This can be used, for instance, for limited sales, where sellers make an offer between certain dates.
-                    spa: Fecha en formato AAAA-MM-DD-HH-MM-SS que indica el inicio del período de validez de la preferencia. Esto se puede usar, por ejemplo, para ventas limitadas, donde los vendedores hacen una oferta entre ciertas fechas.
-                    por: Data no formato AAAA-MM-DD-HH-MM-SS que indica o início do período de validade da preferência. Isso pode ser usado, por exemplo, para vendas limitadas, onde os vendedores fazem uma oferta entre determinadas datas.
+                    eng: Date in "yyyy-MM-dd'T'HH:mm:ssz" format which indicates the start of the preference`s validity period. This can be used, for instance, for limited sales, where sellers make an offer between certain dates. For example - 2022-11-17T09:37:52.000-04:00.
+                    spa: Fecha en formato "yyyy-MM-dd'T'HH:mm:ssz" que indica el inicio del período de validez de la preferencia. Esto se puede usar, por ejemplo, para ventas limitadas, donde los vendedores hacen una oferta entre ciertas fechas. Por ejemplo - 2022-11-17T09:37:52.000-04:00.
+                    por: Data no formato "yyyy-MM-dd'T'HH:mm:ssz". que indica o início do período de validade da preferência. Isso pode ser usado, por exemplo, para vendas limitadas, onde os vendedores fazem uma oferta entre determinadas datas. Por exemplo - 2022-11-17T09:37:52.000-04:00. 
                 expiration_date_to:
                   type: string
                   format: date
-                  description: Date in YYYY-MM-DD-HH-MM-SS format which indicates the end of the preference`s validity period. This can be used, for instance, for limited sales, where sellers make an offer between certain dates.
+                  description: Date in "yyyy-MM-dd'T'HH:mm:ssz" format which indicates the end of the preference`s validity period. This can be used, for instance, for limited sales, where sellers make an offer between certain dates. For example - 2022-11-17T09:37:52.000-04:00.
                   x-description-i18n:
-                    eng: Date in YYYY-MM-DD-HH-MM-SS format which indicates the end of the preference`s validity period. This can be used, for instance, for limited sales, where sellers make an offer between certain dates.
-                    spa: Fecha en formato AAAA-MM-DD-HH-MM-SS que indica el final del período de validez de la preferencia. Esto se puede usar, por ejemplo, para ventas limitadas, donde los vendedores hacen una oferta entre ciertas fechas.
-                    por: Data no formato AAAA-MM-DD-HH-MM-SS que indica o início do período de validade da preferência. Isso pode ser usado, por exemplo, para vendas limitadas, onde os vendedores fazem uma oferta entre determinadas datas.
+                    eng: Date in "yyyy-MM-dd'T'HH:mm:ssz" format which indicates the end of the preference`s validity period. This can be used, for instance, for limited sales, where sellers make an offer between certain dates. For example - 2022-11-17T09:37:52.000-04:00.
+                    spa: Fecha en formato "yyyy-MM-dd'T'HH:mm:ssz" que indica el final del período de validez de la preferencia. Esto se puede usar, por ejemplo, para ventas limitadas, donde los vendedores hacen una oferta entre ciertas fechas. Por ejemplo - 2022-11-17T09:37:52.000-04:00.
+                    por: Data no formato "yyyy-MM-dd'T'HH:mm:ssz" que indica o início do período de validade da preferência. Isso pode ser usado, por exemplo, para vendas limitadas, onde os vendedores fazem uma oferta entre determinadas datas. Por exemplo - 2022-11-17T09:37:52.000-04:00.
                 marketplace:
                   type: string
                   description: Origin of the payment. This is an alphanumeric field whose default value is NONE. If the collector has their own marketplace, this is where the credentials to identify it are sent. As the marketplace is associated to the Application ID, the marketplace credentials must correspond to the credentials used to create the preference. Using the wrong credentials will result in an error.


### PR DESCRIPTION
## Description

Ajustamos o formato da data que estava descrito no parâmetro `expiration_date_to` e `expiration_date_from`. Agora, ambos seguem o padrão ISO 8601: yyyy-MM-dd'T'HH:mm:ssz.