### PR TITLE
fix/cho api pix and sdk migration doc improvements

### DIFF
--- a/guides/checkout-api-v2/integrate-pix.en.md
+++ b/guides/checkout-api-v2/integrate-pix.en.md
@@ -384,7 +384,7 @@ With Pix, you can also choose the period that the customer will have to pay for 
 >
 > Important
 >
-> By default, the expiration date for payments with Pix is **24 hours**, but you can change it by submitting the `date_of_expiration` field in the payment creation request. The configured date must be between **30 minutes and 30 days** from the payment issue date.
+> By default, the expiration date for payments with Pix is **24 hours**, but you can change it by submitting the `date_of_expiration` field in the payment creation request. The configured date must be between **5 minutes and 30 days** from the payment issue date.
 
 
 ## Payment visualization

--- a/guides/checkout-api-v2/integrate-pix.en.md
+++ b/guides/checkout-api-v2/integrate-pix.en.md
@@ -386,7 +386,6 @@ With Pix, you can also choose the period that the customer will have to pay for 
 >
 > By default, the expiration date for payments with Pix is **24 hours**, but you can change it by submitting the `date_of_expiration` field in the payment creation request. The configured date must be between **5 minutes and 30 days** from the payment issue date.
 
-
 ## Payment visualization
 
 For the user to make the payment, you must choose the way to open it, which can be through a button or a QR code that must be rendered.

--- a/guides/checkout-api-v2/integrate-pix.en.md
+++ b/guides/checkout-api-v2/integrate-pix.en.md
@@ -380,7 +380,11 @@ The response will show the payment **pending status** and all the information yo
 
 With Pix, you can also choose the period that the customer will have to pay for the purchase, defining the expiration date of the payment code sent after the order is placed.
 
-By default, the expiration date for payments with Pix is **24 hours**, but you can change it by submitting the `date_of_expiration` field in the payment creation request.
+> NOTE
+>
+> Important
+>
+> By default, the expiration date for payments with Pix is **24 hours**, but you can change it by submitting the `date_of_expiration` field in the payment creation request. The configured date must be between **30 minutes and 30 days** from the payment issue date.
 
 
 ## Payment visualization

--- a/guides/checkout-api-v2/integrate-pix.es.md
+++ b/guides/checkout-api-v2/integrate-pix.es.md
@@ -386,7 +386,6 @@ Con Pix, también puedes elegir el plazo que el cliente tendrá para pagar la co
 >
 > Por defecto, la fecha de vencimiento para pagos con Pix es de **24 horas**, pero puedes modificarla enviando el campo `date_of_expiration` en el request de creación del pago. La fecha configurada debe estar entre **5 minutos y hasta 30 días** a partir de la fecha de emisión del pago.
 
-
 ## Visualización del pago
 
 Para que el usuario pueda efectuar el pago, debes elegir la forma de visualización del mismo, que puede ser a través de un botón o de un código QR que debe ser renderizado. 

--- a/guides/checkout-api-v2/integrate-pix.es.md
+++ b/guides/checkout-api-v2/integrate-pix.es.md
@@ -384,7 +384,7 @@ Con Pix, también puedes elegir el plazo que el cliente tendrá para pagar la co
 >
 > Importante
 >
-> Por defecto, la fecha de vencimiento para pagos con Pix es de **24 horas**, pero puedes modificarla enviando el campo `date_of_expiration` en el request de creación del pago. La fecha configurada debe estar entre **30 minutos y hasta 30 días** a partir de la fecha de emisión del pago.
+> Por defecto, la fecha de vencimiento para pagos con Pix es de **24 horas**, pero puedes modificarla enviando el campo `date_of_expiration` en el request de creación del pago. La fecha configurada debe estar entre **5 minutos y hasta 30 días** a partir de la fecha de emisión del pago.
 
 
 ## Visualización del pago

--- a/guides/checkout-api-v2/integrate-pix.es.md
+++ b/guides/checkout-api-v2/integrate-pix.es.md
@@ -380,7 +380,11 @@ La respuesta mostrará el estado del pago pendiente y toda la información que n
 
 Con Pix, también puedes elegir el plazo que el cliente tendrá para pagar la compra, definiendo la validez del código de pago que se le envía después de realizar el pedido.
 
-Por defecto, la fecha de vencimiento para pagos con Pix es de **24 horas**, pero puedes modificarla enviando el campo `date_of_expiration` en la solicitud de creación del pago. 
+> NOTE
+>
+> Importante
+>
+> Por defecto, la fecha de vencimiento para pagos con Pix es de **24 horas**, pero puedes modificarla enviando el campo `date_of_expiration` en el request de creación del pago. La fecha configurada debe estar entre **30 minutos y hasta 30 días** a partir de la fecha de emisión del pago.
 
 
 ## Visualización del pago

--- a/guides/checkout-api-v2/integrate-pix.pt.md
+++ b/guides/checkout-api-v2/integrate-pix.pt.md
@@ -380,7 +380,11 @@ A resposta mostrará o estado pendente do pagamento e todas as informações que
 
 Com Pix, você também pode escolher o prazo que o cliente terá para pagar a compra, definindo a validade do código de pagamento enviado a ele após a realização do pedido.
 
-Por padrão, a data de vencimento para pagamentos com Pix é de **24 horas**, mas você pode alterá-la enviando o campo `date_of_expiration` na solicitação de criação de pagamento. 
+> NOTE
+>
+> Importante
+>
+> Por padrão, a data de vencimento para pagamentos com Pix é de **24 horas**, mas você pode alterá-la enviando o campo `date_of_expiration` na solicitação de criação de pagamento. A data configurada deve estar entre **30 minutos até 30 dias** a partir da data de emissão do pagamento.
 
 ## Visualização de pagamento
 

--- a/guides/checkout-api-v2/integrate-pix.pt.md
+++ b/guides/checkout-api-v2/integrate-pix.pt.md
@@ -384,7 +384,7 @@ Com Pix, você também pode escolher o prazo que o cliente terá para pagar a co
 >
 > Importante
 >
-> Por padrão, a data de vencimento para pagamentos com Pix é de **24 horas**, mas você pode alterá-la enviando o campo `date_of_expiration` na solicitação de criação de pagamento. A data configurada deve estar entre **30 minutos até 30 dias** a partir da data de emissão do pagamento.
+> Por padrão, a data de vencimento para pagamentos com Pix é de **24 horas**, mas você pode alterá-la enviando o campo `date_of_expiration` na solicitação de criação de pagamento. A data configurada deve estar entre **5 minutos até 30 dias** a partir da data de emissão do pagamento.
 
 ## Visualização de pagamento
 

--- a/guides/sdks-v2/official/java/howto-migrate.en.md
+++ b/guides/sdks-v2/official/java/howto-migrate.en.md
@@ -14,11 +14,25 @@ Below we show the main differences between the migration steps.
 * We will no longer use the callback functions of each method, but their return to work with the data;
 * The names of some methods have also undergone some minor changes and these have become clearer in the comparison snippets.
 
+----[mla, mlm, mpe, mlu, mlc, mlb]----
+
 > WARNING
 >
 > Attention
 >
 > The migration will not affect your backend in any way, the modifications are entirely on the frontend of the application.
+
+------------
+
+----[mco]----
+
+> WARNING
+>
+> Attention
+>
+> The migration will not affect your backend in any way, the modifications are entirely on the frontend of the application. In addition, this modification affects only the card and does not affect other payment methods, such as PSE.
+
+------------
 
 See below for a comparison of the diagrams.
 

--- a/guides/sdks-v2/official/java/howto-migrate.en.md
+++ b/guides/sdks-v2/official/java/howto-migrate.en.md
@@ -142,7 +142,7 @@ const securityCodeElement = mp.fields.create('securityCode', {
 }).mount('securityCode');
 ````
 
-With that, we now have our secure PCI fields inside the form.
+With that, we now have our secure PCI fields inside the form. For more information on how to configure iframes, please visit our [Github](https://github.com/mercadopago/sdk-js/blob/main/API/fields.md).
 
 ## Get document types
 

--- a/guides/sdks-v2/official/java/howto-migrate.es.md
+++ b/guides/sdks-v2/official/java/howto-migrate.es.md
@@ -144,7 +144,7 @@ const securityCodeElement = mp.fields.create('securityCode', {
 }).mount('securityCode');
 ````
 
-Con eso tenemos nuestros campos PCI seguros dentro del formulario.
+Con eso tenemos nuestros campos PCI seguros dentro del formulario. Para obtener más información sobre cómo configurar los iframes, visite nuestro [Github](https://github.com/mercadopago/sdk-js/blob/main/API/fields.md).
 
 ## Obtener tipos de documentos
 

--- a/guides/sdks-v2/official/java/howto-migrate.es.md
+++ b/guides/sdks-v2/official/java/howto-migrate.es.md
@@ -14,11 +14,27 @@ A continuación mostramos las principales diferencias entre los pasos de migraci
 * Ya no usaremos las funciones de callback de cada método, sino su retorno para trabajar con los datos;
 * Los nombres de algunos métodos también han sufrido algunos cambios menores y se han vuelto más claros en los snippets comparativos.
 
+----[mla, mlm, mpe, mlu, mlc, mlb]----
+
 > WARNING
 >
 > Atención
 >
 > La migración no afectará su backend de ninguna manera, las modificaciones están completamente en la interfaz de la aplicación.
+
+------------
+
+----[mco]----
+
+> WARNING
+>
+> Atención
+>
+> La migración no afectará su backend de ninguna manera, las modificaciones están completamente en la interfaz de la aplicación. Además, esta modificación afecta únicamente a la tarjeta y no afecta a otros medios de pago, cómo, por ejemplo, PSE.
+
+------------
+
+
 
 Vea a continuación una comparación de los diagramas.
 

--- a/guides/sdks-v2/official/java/howto-migrate.pt.md
+++ b/guides/sdks-v2/official/java/howto-migrate.pt.md
@@ -142,7 +142,7 @@ const securityCodeElement = mp.fields.create('securityCode', {
 }).mount('securityCode');
 ````
 
-Com isso, agora temos os nossos campos PCI seguros dentro do formulário.
+Com isso, agora temos os nossos campos PCI seguros dentro do formulário. Para mais informações sobre como configurar os iframes, acesse nosso [Github](https://github.com/mercadopago/sdk-js/blob/main/API/fields.md).
 
 ## Obter tipos de documento
 

--- a/guides/sdks-v2/official/java/howto-migrate.pt.md
+++ b/guides/sdks-v2/official/java/howto-migrate.pt.md
@@ -14,11 +14,25 @@ Abaixo mostramos as principais diferenças entre as etapas de migração.
 * Não utilizaremos mais as funções de callback de cada método, mas sim o retorno deles para trabalhar com os dados;
 * Os nomes de alguns métodos também sofreram algumas pequenas alterações e estas ficaram mais claras nos snippets comparativos.
 
+----[mla, mlm, mpe, mlu, mlc, mlb]----
+
 > WARNING
 >
 > Atenção
 >
 > A migração não afetará em nada o seu backend, as modificações são inteiramente no frontend da aplicação.
+
+------------
+
+----[mco]----
+
+> WARNING
+>
+> Atenção
+>
+> A migração não afetará em nada o seu backend, as modificações são inteiramente no frontend da aplicação. Além disso, essa modificação afeta somente cartão e não influencia em outros meios de pagamento, como, por exemplo, PSE.
+
+------------
 
 Veja abaixo um comparativo dos diagramas. 
 


### PR DESCRIPTION
## Description

Fizemos pequenos ajustes na documentação de Pix para CHO API, na qual agora informamos corretamente o prazo de validade do Pix e como alterá-lo.

Além disso, adicionamos uma nota para MCO na doc de migração de SDK informando que a modificação não afeta outros tipos de pagamento (somente cartão), além de adicionarmos um link para um github.