### PR TITLE
fix/chargeback doc mlb text fix

### DIFF
--- a/guides/additional-content/chargebacks/how-to-manage.en.md
+++ b/guides/additional-content/chargebacks/how-to-manage.en.md
@@ -34,7 +34,18 @@ https://api.mercadopago.com/v1/chargebacks/ID/documentation
 >
 > Files can be `.jpg`, `.png` or `.pdf` and should not exceed 10mb overall.
 
+----[mla, mlm, mpe, mco, mlu, mlc]----
+
 If the documentation has been successfully uploaded, the API will answer with `200 OK`, and the `documentation_status` value will change to `review_pending`.
+
+------------
+
+----[mlb]----
+
+If the documentation is successfully uploaded to the site, the API will respond with status `200 OK` and keep the value of `documentation_status` as `pending`. After reviewing the documentation, this same value is changed to `valid` or `not supplied`.
+
+------------
+
 
 4. Upon resolution, a new IPN notification will be sent so that you can verify the case. Check the dispute using the [Get Chargeback](/developers/pt/reference/chargebacks/_chargebacks_id/get) method. The `coverage_applied` value could have taken on one of the possible values:
 

--- a/guides/additional-content/chargebacks/how-to-manage.es.md
+++ b/guides/additional-content/chargebacks/how-to-manage.es.md
@@ -34,7 +34,18 @@ https://api.mercadopago.com/v1/chargebacks/ID/documentation
 >
 > Los archivos pueden ser `.jpg`, `.png` o `.pdf` y no deben exceder los 10 MB en total.
 
+----[mla, mlm, mpe, mco, mlu, mlc]----
+
 Si la documentación se cargó correctamente, la API responderá con el estado `200 OK` y el valor de `documentation_status` cambiará a `review_pending`.
+
+------------
+
+----[mlb]----
+
+Si la documentación se cargó correctamente en el sitio, la API responderá con el status "200 OK" y mantendrá el valor de `documentation_status` como `pending`. Después de revisar la documentación, este mismo valor se cambia a `valid` o `not supplied`.
+
+------------
+
 
 4. Espera la notificación de IPN sobre la resolución. Vuelve a verificar la disputa usando el método [Obtener contracargo](/developers/pt/reference/chargebacks/_chargebacks_id/get). El valor de `coverage_applied` puede cambiar a uno de los siguientes valores:
 

--- a/guides/additional-content/chargebacks/how-to-manage.pt.md
+++ b/guides/additional-content/chargebacks/how-to-manage.pt.md
@@ -34,7 +34,18 @@ https://api.mercadopago.com/v1/chargebacks/ID/documentation
 >
 >Os arquivos poderão ser `.jpg`, `.png` ou `.pdf` e, no total, não poderão superar 10mb.
 
+----[mla, mlm, mpe, mco, mlu, mlc]----
+
 Se a documentação for carregada no site com sucesso, a API responderá com status `200 OK` e modificará o valor de `documentation_status` para `review_pending`.
+
+------------
+
+----[mlb]----
+
+Se a documentação for carregada no site com sucesso, a API responderá com status `200 OK` e manterá o valor de `documentation_status` como `pending`. Após da análise da documentação, este mesmo valor é alterado para `valid` ou `not supplied`.
+
+------------
+
 
 4. Aguarde a notificação IPN referente à resolução. Cheque novamente a contestação usando o método [Obter estorno](/developers/pt/reference/chargebacks/_chargebacks_id/get). O valor de `coverage_applied` pode ter assumido um dos possíveis valores:
 


### PR DESCRIPTION
## Description

Na nossa documentação temos uma informação incorreta:
"Se a documentação for carregada no site com sucesso, a API responderá com status 200 OK e modificará o valor de documentation_status para review_pending."

No Brasil (MLB) temos um comportamento diferente em que o "documentation_status" não muda para "review_pending" como nos outros países. Ele se mantém como "pending" e depois é alterado diretamente para "valid" ou "not_supplied".