### PR TITLE
fix/card token doc link correction

### DIFF
--- a/guides/checkout-api-v2/how-to-integrate-3ds.en.md
+++ b/guides/checkout-api-v2/how-to-integrate-3ds.en.md
@@ -26,7 +26,7 @@ For **low-risk transactions**, the information sent at checkout is sufficient an
 Below are the steps to integrate with 3DS.
 
 
-1. Use the Mercado Pago [SDK JS](https://www.mercadopago.com.br/developers/en/docs/sdks-library/client-side/mp-js-v2) at checkout to generate the [credit card token](/developers/en/docs/sdks-library/client-side/java/howto-migrate#bookmark_create_card_token).
+1. Use the Mercado Pago [SDK JS](https://www.mercadopago.com.br/developers/en/docs/sdks-library/client-side/mp-js-v2) at checkout to generate the [credit card token](/developers/en/docs/checkout-api/integration-configuration/card/integrate-via-cardform).
 
 [[[
 ```Javascript

--- a/guides/checkout-api-v2/how-to-integrate-3ds.es.md
+++ b/guides/checkout-api-v2/how-to-integrate-3ds.es.md
@@ -25,7 +25,7 @@ A continuación se presentan los pasos para realizar una integración con 3DS.
 
 
 
-1. Debes usar el [SDK JS](/developers/es/docs/sdks-library/client-side/mp-js-v2) de Mercado Pago en el checkout para generar el [token de la tarjeta de crédito](/developers/es/docs/sdks-library/client-side/java/howto-migrate#bookmark_criar_token_do_cartão). 
+1. Debes usar el [SDK JS](/developers/es/docs/sdks-library/client-side/mp-js-v2) de Mercado Pago en el checkout para generar el [token de la tarjeta de crédito](/developers/es/docs/checkout-api/integration-configuration/card/integrate-via-cardform). 
 
 [[[
 ```Javascript

--- a/guides/checkout-api-v2/how-to-integrate-3ds.pt.md
+++ b/guides/checkout-api-v2/how-to-integrate-3ds.pt.md
@@ -22,7 +22,7 @@ Para **transações de baixo risco**, as informações enviadas na finalização
 Abaixo estão as etapas para realizar uma integração com 3DS.
 
 
-1. Utilize o Mercado Pago [SDK JS](/developers/pt/docs/sdks-library/client-side/mp-js-v2) no checkout para gerar o [token do cartão de crédito](/developers/pt/docs/sdks-library/client-side/java/howto-migrate#bookmark_criar_token_do_cartão).
+1. Utilize o Mercado Pago [SDK JS](/developers/pt/docs/sdks-library/client-side/mp-js-v2) no checkout para gerar o [token do cartão de crédito](/developers/pt/docs/checkout-api/integration-configuration/card/integrate-via-cardform).
 
 [[[
 ```Javascript


### PR DESCRIPTION
## Description

Ajustamos, na doc de 3DS para CHO API, o link que redireciona para a criação do cardtoken.
