### PR TITLE
Atualização de Adobe Commerce (Magento)

### DIFF
--- a/guides/adobe-commerce/installation-composer.en.md
+++ b/guides/adobe-commerce/installation-composer.en.md
@@ -2,25 +2,31 @@
 
 To install the Mercado Pago module in Adobe Commerce (Magento) via Composer, you must follow these steps:
 
-1. In your terminal, run this command to download the Adobe Commerce (Magento) module with Composer:
+1. In your terminal, execute this command to download the Adobe Commerce (Magento) module using Composer:
 
 ```
-composer require mercadopago/magento2-plugin:3.*
+composer require mercadopago/adb-payment
 ```
 
-2. Then run this command to update the list of Adobe Commerce (Magento) modules:
+2. Next, execute this command to install the module:
 
 ```
 bin/magento setup:upgrade
 ```
 
-3. Now you must run this command to clear the Adobe Commerce (Magento) cache:
+3. Execute this command to compile the module files:
+
+```
+bin/magento setup:di:compile
+```
+
+4. Now, you should run this command to clean the Adobe Commerce (Magento) cache:
 
 ```
 bin/magento cache:clean
 ```
 
-4. When the store is in **productive mode**, it will be necessary to generate the `static` files again. You can do it this way:
+5. When the store is in production mode, you will need to regenerate the static files. You can do it this way:
 
 ```
 bin/magento setup:static-content:deploy

--- a/guides/adobe-commerce/installation-composer.es.md
+++ b/guides/adobe-commerce/installation-composer.es.md
@@ -2,25 +2,31 @@
 
 Para instalar el módulo de Mercado Pago en Adobe Commerce (Magento) vía Composer, deberás seguir estos pasos:
 
-1. En tu terminal, ejecuta este comando para descargar el módulo de Adobe Commerce (Magento) con Composer:
+1. En tu terminal, ejecuta el siguiente comando para descargar el módulo de Adobe Commerce (Magento) utilizando Composer:
 
 ```
-composer require mercadopago/magento2-plugin:3.*
+composer require mercadopago/adb-payment
 ```
 
-2. Luego, ejecuta este comando para actualizar la lista de módulos de Adobe Commerce (Magento):
+2. A continuación, ejecuta el siguiente comando para instalar el módulo:
 
 ```
 bin/magento setup:upgrade
 ```
 
-3. Ahora deberás ejecutar este comando para limpiar el cache de Adobe Commerce (Magento):
+3. Ejecuta el siguiente comando para compilar los archivos del módulo:
+
+```
+bin/magento setup:di:compile
+```
+
+4. Ahora debes ejecutar este comando para limpiar la caché de Adobe Commerce (Magento):
 
 ```
 bin/magento cache:clean
 ```
 
-4. Cuando la tienda esté en **modo productivo**, será necesario generar los archivos `static` nuevamente. Puedes hacerlo de esta manera:
+5. Cuando la tienda esté en modo de producción, será necesario generar nuevamente los archivos estáticos. Puedes hacerlo de la siguiente manera:
 
 ```
 bin/magento setup:static-content:deploy

--- a/guides/adobe-commerce/installation-composer.pt.md
+++ b/guides/adobe-commerce/installation-composer.pt.md
@@ -5,22 +5,28 @@ Para instalar o módulo Mercado Pago no Adobe Commerce (Magento) via Composer, s
 1. Em seu terminal, execute este comando para baixar o módulo Adobe Commerce (Magento) com o Composer:
 
 ```
-composer require mercadopago/magento2-plugin:3.*
+composer require mercadopago/adb-payment
 ```
 
-2. Em seguida, execute este comando para atualizar a lista de módulos Adobe Commerce (Magento):
+2. Em seguida, execute este comando para instalar o módulo:
 
 ```
 bin/magento setup:upgrade
 ```
 
-3. Agora você deve executar este comando para limpar o cache do Adobe Commerce (Magento):
+3. Execute este comando para compilar os arquivos do módulo:
+
+```
+bin/magento setup:di:compile
+```
+
+4. Agora você deve executar este comando para limpar o cache do Adobe Commerce (Magento):
 
 ```
 bin/magento cache:clean
 ```
 
-4. Quando a loja estiver em **modo produção**, será necessário gerar novamente os arquivos `estáticos`. Você pode fazer desta maneira:
+5. Quando a loja estiver em modo produção, será necessário gerar novamente os arquivos estáticos. Você pode fazer desta maneira:
 
 ```
 bin/magento setup:static-content:deploy

--- a/guides/adobe-commerce/installation-ftp.en.md
+++ b/guides/adobe-commerce/installation-ftp.en.md
@@ -1,6 +1,8 @@
 # Installation via FTP 
 
-1. Download the **Mercado Pago module** available [on Github](https://github.com/mercadopago/cart-magento2).
+To install the Mercado Pago module on Adobe Commerce (Magento) via FTP, follow the steps below.
+
+1. Download the **Mercado Pago module** available [on Github](https://github.com/mercadopago/adb-payment).
 2. Create a folder with the name **code** inside the Magento **app** folder.
 3. To access the **MercadoPago** folder, it is necessary to unzip the *.zip* file.
 4. Copy the **MercadoPago** folder located in the **code / src** folder.

--- a/guides/adobe-commerce/installation-ftp.es.md
+++ b/guides/adobe-commerce/installation-ftp.es.md
@@ -1,6 +1,8 @@
 # Instalación vía FTP
 
-1. Descarga el **módulo Mercado Pago** disponible [en Github](https://github.com/mercadopago/cart-magento2).
+Para instalar el módulo de Mercado Pago en Adobe Commerce (Magento) a través de FTP, sigue los pasos a continuación.
+
+1. Descarga el **módulo Mercado Pago** disponible [en Github](https://github.com/mercadopago/adb-payment).
 2. Crea una carpeta con el nombre **code** dentro de la carpeta **app** de Magento.
 3. Para tener acceso a la carpeta **MercadoPago** es necesario descomprimir el archivo *.zip*.
 4. Copia la carpeta **MercadoPago** que se encuentra la carpeta **code/src**.

--- a/guides/adobe-commerce/installation-ftp.pt.md
+++ b/guides/adobe-commerce/installation-ftp.pt.md
@@ -2,7 +2,7 @@
 
 Para instalar o módulo Mercado Pago no Adobe Commerce (Magento) via FTP, siga os passos abaixo.
 
-1. Baixe o módulo **Mercado Pago** disponível [no Github](https://github.com/mercadopago/cart-magento2).
+1. Baixe o módulo **Mercado Pago** disponível [no Github](https://github.com/mercadopago/adb-payment).
 2. Crie uma pasta com o nome **code** dentro da pasta Magento **app**.
 3. Para acessar a pasta **MercadoPago**, é necessário descompactar o arquivo *.zip*.
 4. Copie a pasta **MercadoPago**, localizada na pasta **code/src**.


### PR DESCRIPTION
Atualização de Adobe Commerce (Magento)

O que mudou: link do GitHub e instruções do Composer.
