### PR TITLE
fix/tls doc update

### DIFF
--- a/guides/X-LEGACY (DON`T USE THIS FILE)/resources/pci-compliant-merchants/disabling-tls-10.en.md
+++ b/guides/X-LEGACY (DON`T USE THIS FILE)/resources/pci-compliant-merchants/disabling-tls-10.en.md
@@ -1,71 +1,79 @@
-# Apagado del cifrado TLS 1.0 en Mercado Pago
+# Shutting down TLS 1.1 encryption at Mercado Pago.
 
-En Mercado Pago siempre buscamos optimizar nuestra plataforma ofreciendo la mayor capacidad y seguridad en el procesamiento de pagos.
+At Mercado Pago we always seek to optimize our platform by offering the greatest capacity and security in payment processing.
 
-En esta ocasión, estamos trabajando en el apagado de TLS 1.0 para los dominios https://api.mercadopago.com y https://pagamento.mercadopago.com con el objetivo de mantener los más altos estándares de calidad y promover la seguridad de los datos de nuestros clientes.
+On this occasion, we are working on turning off TLS 1.1 for the domains https://api.mercadopago.com and https://pagamento.mercadopago.com, with the aim of maintaining the highest quality standards and promoting the security of the data of our clients.
 
-En consecuencia, Mercado Pago requerirá que sus conexiones a los dominios https://api.mercadopago.com y https://pagamento.mercadopago.com sean a través del protocolo de cifrado TLS 1.2 o superior.
-
-Una vez que desactivemos TLS 1.0, cualquier conexión que establezcas utilizando TLS 1.0 fallará.
-
-### Puntos a tener en cuenta:
-
-* Si operás sólo en Mercado Libre este cambio no te afectará.
-* Si operás sólo con botones de pago de Mercado Pago este cambio no te afectará.
-* Si operás sólo en Mercado Shops este cambio no te afectará.
-* Si operás sólo en VTEX este cambio no te afectará.
-* Si tenés **tu propio e-commerce consulta a tu soporte técnico**.
-* Si operas con alguna **plataforma de e-commerce** por ejemplo: Magento, Shopify u otros **consulta a su soporte técnico**.
-
-## Introducción
-
-### ¿Qué es TLS?
-
-TLS es el acrónimo de “Transport Layer Security” (Seguridad de la capa de transporte). Es un protocolo que proporciona privacidad e integridad de los datos entre dos aplicaciones que se comunican.
-
-Es el protocolo de seguridad más extendido que se utiliza en la actualidad, y se emplea para navegadores y otras aplicaciones que requieran que los datos se intercambien de forma segura en una red. TLS garantiza que una conexión con un extremo remoto se realiza en el extremo que se espera a través de cifrado y la verificación de la identidad del extremo. Las versiones de TLS hasta la fecha son TLS 1.0, 1.1 y 1.2.
-
-Las conexiones de Internet y de API de Mercado Pago utilizan TLS como componente clave de su seguridad.
-
-HTTPS (web) y STARTTLS SMTP (email) también utilizan TLS como componente de seguridad.
-
-### ¿Por qué se va a realizar este cambio?
-
-En Mercado Pago nos tomamos muy en serio la seguridad y ayudamos a nuestros clientes a mejorarla empleando los protocolos de seguridad más recientes.
+> WARNING
+>
+> Important
+>
+> Once we disable TLS 1.1, **any connection you establish using TLS 1.1 will fail**. In addition to it, Mercado Pago will require that your connections to the domains https://api.mercadopago.com and https://pagamento.mercadopago.com be through the encryption protocol TLS 1.2 or higher.   
 
 
-## Acción requerida para integraciones de API
+## Points to consider
 
-Si tus integraciones que utilizan conexiones entrantes con Mercado Pago no tiene el protocolo TLS 1.2 o superior activado tras realizar este cambio, empezarán a fallar
+* If you operate only in Mercado Libre, this change will not affect you.
+* If you operate only with the Mercado Pago payment buttons, this change will not affect you.
+* If you operate only in Mercado Shops, this change will not affect you.
+* If you operate only in VTEX this change will not affect you.
+* If you have your **own e-commerce consult your technical support**.
+* If you **operate with an e-commerce platform**, for example: Magento, Shopify or others, **consult their technical support**.
 
-Te recomendamos que empieces a planificar la inclusión del protocolo TLS 1.2 tan pronto como sea posible.
 
-Consulte las directrices de compatibilidad a continuación:
+## Introduction
 
-| Plataforma | Notas de Compatibilidad |
+
+TLS is the acronym for “Transport Layer Security”. It is a protocol that provides privacy and data integrity between two communicating applications.
+
+It is the most widespread security protocol in use today, and is used for browsers and other applications that require data to be exchanged securely over a network. TLS ensures that a connection to a remote endpoint is made at the expected endpoint through encryption and verification of the endpoint's identity. TLS versions to date are TLS 1.0, 1.1, 1.2, and 1.3.
+
+Mercado Pago's Internet and API connections use TLS as a key component of their security.
+
+HTTPS (web) and STARTTLS SMTP (email) also use TLS as a security component.
+
+
+## Why is this change being made?
+
+At Mercado Pago we take security very seriously and we help our customers improve it by using the latest security protocols.
+
+
+## Action required for API integrations
+
+If your integrations that use incoming connections with Mercado Pago do not have TLS 1.2 or higher enabled after making this change, they will start to fail.
+
+> WARNING
+>
+> Important
+>
+> We recommend that you opt-in to the TLS 1.2 protocol **before June 12, 2023**.
+
+See compatibility guidelines below:
+
+| Plataform | Compatibility notes  |
 | --- | --- |
-| Java (Oracle) | Compatible con la versión más reciente, sin que el sistema operativo sea relevante. |
-| Java 8 (1.8) y versiones posteriores | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada. |
-| Java 7 (1.7) | Active TLS 1.2 utilizando la propiedad del sistema Java https.protocols para HttpsURLConnection. Para activar TLS 1.2 en conexiones sin HttpsURLConnection, establezca los protocolos activados en las instancias creadas de SSLSocket y SSLEngine dentro del código fuente de la aplicación. Cambiar a IBM Java puede ser una solución efectiva si la actualización a una versión de Oracle Java más reciente no es posible. |
-| Java 8 | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada. Es posible que tenga que establecer com.ibm.jsse2.overrideDefaultTLS=true si su aplicación o una biblioteca que la llame utiliza SSLContext.getinstance("TLS"). |
-| Java 7 y versiones posteriores, la actualización de servicio 1 de Java 6.0.1 (J9 VM2.6) y versiones posteriores y la actualización de servicio 10 de Java 6 y versiones posteriores | Active TLS 1.2 empleando la propiedad del sistema de Java https.protocols para HttpsURLConnection y la propiedad del sistema de Java com.ibm.jsse2.overrideDefaultProtocol para conexiones SSLSocket y SSLEngine, según recomienda la documentación de IBM. Es posible que también tenga que establecer com.ibm.jsse2.overrideDefaultTLS=true. |
-.| NET | Compatible con la versión más reciente cuando se ejecuta en un sistema operativo que admita TLS 1.2 |
-| .NET 4.6 y versiones posteriores | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada. |
-| .NET 4.5 a 4.5.2 | .NET 4.5, 4.5.1 y 4.5.2 no activan TLS 1.2 de forma predeterminada. Existen dos opciones para activarlas, como se describe a continuación. |
-| .NET 4.0 | .NET 4.0 no activa TLS 1.2 de forma predeterminada. Para activar TLS 1.2 de forma predeterminada, es posible instalar .NET Framework 4.5 o una versión posterior, y establecer el valor DWORD de SchUseStrongCrypto en 1 en las siguientes dos entradas del registro del sistema, creándolas si no existen: "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\v4.0.30319" y "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319". No obstante, esas claves del registro del sistema pueden activar TLS 1.2 de forma predeterminada en todas las aplicaciones .NET 4.0, 4.5, 4.5.1 y 4.5.2 instaladas en ese sistema. Recomendamos probar este cambio antes de implementarlo en sus servidores de producción. Esto también está disponible como un archivo de importación para el registro del sistema.Sin embargo, estos valores del registro del sistema no afectarán a las aplicaciones .NET que establecen el valor System.Net.ServicePointManager.SecurityProtocol. |
-| .NET 3.5 y versiones anteriores | No son compatibles con el cifrado TLS 1.2 o versiones posteriores |
-| Python | Compatible con la versión más reciente cuando se ejecuta en un sistema operativo que admita TLS 1.2 |
-| Python 2.7.9 y versiones posteriores | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada. |
-| Python 2.7.8 y versiones anteriores | No son compatibles con el cifrado TLS 1.2 o versiones posteriores |
-| Ruby | Es compatible con la versión más reciente y estable cuando se vincula con OpenSSL 1.0.1 o versiones posteriores. |
-| Ruby 2.0.0 | TLS 1.2 se activa de forma predeterminada cuando se utiliza con OpenSSL 1.0.1 o versiones posteriores. El uso de los símbolos :TLSv1_2 con ssl_version de SSLContext ayuda a garantizar que se desactiva TLS 1.0 o versiones anteriores. |
-| Ruby 1.9.3 y versiones anteriores | El símbolo :TLSv1_2 no existe en la versión 1.9.3 y anteriores, pero es posible parchear Ruby para agregar ese símbolo y compilar Ruby con OpenSSL 1.0.1 o versiones posteriores. |
+| Java (Oracle)  | Compatible with the latest version, regardless of the operating system.  |
+| Java 8 (1.8) and later versions  | Supports TLS 1.2 or later encryption by default.  |
+| Java 7 (1.7)  | Enable TLS 1.2 by using the https.protocols Java system property for HttpsURLConnection. To enable TLS 1.2 on connections without HttpsURLConnection, set the enabled protocols on the created instances of SSLSocket and SSLEngine within the application source code. Switching to IBM Java can be an effective solution if upgrading to a newer version of Oracle Java is not possible.  |
+| Java 8  | Supports TLS 1.2 or later encryption by default. You might need to set com.ibm.jsse2.overrideDefaultTLS=true if your application or a library that calls it uses SSLContext.getinstance("TLS").  |
+| Java 7 and later, Java 6.0.1 (J9 VM2.6) Service Update 1 and later, and Java 6 Service Update 10 and later  | Enable TLS 1.2 using the https.protocols Java system property for HttpsURLConnection and the com.ibm.jsse2.overrideDefaultProtocol Java system property for SSLSocket and SSLEngine connections, as recommended by the IBM documentation. You might also need to set com.ibm.jsse2.overrideDefaultTLS=true.  |
+| .NET  | Compatible with the latest version when running on an operating system that supports TLS 1.2  |
+| .NET 4.6 and later versions  | Supports TLS 1.2 or later by default.  |
+| .NET 4.5 to 4.5.2  | .NET 4.5, 4.5.1, and 4.5.2 do not enable TLS 1.2 by default. There are two options to activate them, as described below.  |
+| .NET 4.0  | .NET 4.0 does not enable TLS 1.2 by default. To turn on TLS 1.2 by default, you can install the .NET Framework 4.5 or later, and set the SchUseStrongCrypto DWORD value to 1 in the following two system registry entries, creating them if they don't exist: "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft .NETFramework\v4.0.30319" and "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft.NETFramework\v4.0.30319". However, those system registry keys can enable TLS 1.2 by default in all .NET 4.0, 4.5, 4.5.1, and 4.5.2 applications installed on that system. We recommend testing this change before deploying it to your production servers. This is also available as an import file for the system registry. However, these system registry values will not affect .NET applications that set the System.Net.ServicePointManager.SecurityProtocol value.  |
+| .NET 3.5 and earlier versions  | They do not support TLS 1.2 or later  |
+| Python  | Compatible with the latest version when running on an operating system that supports TLS 1.2  |
+| Python 2.7.9 and later  | Supports TLS 1.2 or later encryption by default.  |
+| Python 2.7.8 and earlier versions  | They do not support TLS 1.2 or later versions  |
+| Ruby  | It is compatible with the latest and most stable version when linked with OpenSSL 1.0.1 or later.  |
+| Ruby 2.0.0  | TLS 1.2 is enabled by default when used with OpenSSL 1.0.1 or later. Using the :TLSv1_2 tokens with the ssl_version of the SSLContext helps ensure that TLS 1.0 or earlier is disabled.  |
+| Ruby 1.9.3 and earlier versions  | The :TLSv1_2 symbol does not exist in version 1.9.3 and earlier, but it is possible to patch Ruby to add that symbol and compile Ruby with OpenSSL 1.0.1 or later.  |
+| Android 5.x and higher  | TLS 1.2 is supported by default.  |
 
-En caso que requieras hacer adaptaciones, **es importante que recuerdes hacer este cambio en tiempo y forma, ya que de lo contrario es muy probable que tus conexiones con Mercado Pago comiencen a fallar.**
 
-## ¿Como puedo probar mi integración?
+## How can I check the current version of TLS?
 
-Para poder validar si tu integración mantiene una conexión usando un protocolo distinto a TLS 1.0, puedes usar el siguiente snippet dentro de tu aplicación para verificar que protocolo se esta usando por defecto para las conexiones.
+In order to validate if your integration maintains a connection using a protocol other than TLS 1.2, you can use the following snippet within your application to verify which protocol is being used by default for connections.
 
 [[[
 ```php
@@ -75,8 +83,8 @@ Para poder validar si tu integración mantiene una conexión usando un protocolo
 ?>
 ```
 ```java
-  SSLSocket ss = (SSLSocket) SSLSocketFactory.getDefault().createSocket("api.mercadopago.com", 443);
-  System.out.println("protocol: " + ss.getSession().getProtocol());
+SSLSocket ss = (SSLSocket) SSLSocketFactory.getDefault().createSocket("api.mercadopago.com", 443);
+System.out.println("protocol: " + ss.getSession().getProtocol());
 ```
 ```csharp
 string strWebsiteName = "api.mercadopago.com";
@@ -90,8 +98,3 @@ Console.WriteLine("protocol : " + _myStream.SslProtocol);
 ```
 ]]]
 
-
-
-Si tienes alguna duda o necesitas asistencia para completar exitosamente este cambio, puedes contactarnos a través del siguiente correo electrónico: soportemigraciones@mercadopago.com.
-
-El equipo de Mercado Pago.

--- a/guides/X-LEGACY (DON`T USE THIS FILE)/resources/pci-compliant-merchants/disabling-tls-10.es.md
+++ b/guides/X-LEGACY (DON`T USE THIS FILE)/resources/pci-compliant-merchants/disabling-tls-10.es.md
@@ -2,12 +2,17 @@
 
 En Mercado Pago siempre buscamos optimizar nuestra plataforma ofreciendo la mayor capacidad y seguridad en el procesamiento de pagos.
 
-En esta ocasión, estamos trabajando en el apagado de TLS 1.0 para los dominios https://api.mercadopago.com y https://pagamento.mercadopago.com con el objetivo de mantener los más altos estándares de calidad y promover la seguridad de los datos de nuestros clientes.
+En esta ocasión, estamos trabajando en el apagado de TLS 1.1 para los dominios https://api.mercadopago.com y https://pagamento.mercadopago.com con el objetivo de mantener los más altos estándares de calidad y promover la seguridad de los datos de nuestros clientes.
 
-En consecuencia, Mercado Pago requerirá que sus conexiones a los dominios https://api.mercadopago.com y https://pagamento.mercadopago.com sean a través del protocolo de cifrado TLS 1.2 o superior.
-Una vez que desactivemos TLS 1.0, cualquier conexión que establezcas utilizando TLS 1.0 fallará.
+> WARNING
+>
+> Importante
+>
+> Una vez que desactivemos TLS 1.1, **cualquier conexión que establezcas utilizando TLS 1.0 fallará**. Además, Mercado Pago requerirá que sus conexiones a los dominios https://api.mercadopago.com y https://pagamento.mercadopago.com sean a través del protocolo de cifrado TLS 1.2 o superior.
 
-### Puntos a tener en cuenta:
+
+
+## Puntos a tener en cuenta
 
 * Si operás sólo en Mercado Libre este cambio no te afectará.
 * Si operás sólo con botones de pago de Mercado Pago este cambio no te afectará.
@@ -18,17 +23,16 @@ Una vez que desactivemos TLS 1.0, cualquier conexión que establezcas utilizando
 
 ## Introducción
 
-### ¿Qué es TLS?
 
 TLS es el acrónimo de “Transport Layer Security” (Seguridad de la capa de transporte). Es un protocolo que proporciona privacidad e integridad de los datos entre dos aplicaciones que se comunican.
 
-Es el protocolo de seguridad más extendido que se utiliza en la actualidad, y se emplea para navegadores y otras aplicaciones que requieran que los datos se intercambien de forma segura en una red. TLS garantiza que una conexión con un extremo remoto se realiza en el extremo que se espera a través de cifrado y la verificación de la identidad del extremo. Las versiones de TLS hasta la fecha son TLS 1.0, 1.1 y 1.2.
+Es el protocolo de seguridad más extendido que se utiliza en la actualidad, y se emplea para navegadores y otras aplicaciones que requieran que los datos se intercambien de forma segura en una red. TLS garantiza que una conexión con un extremo remoto se realiza en el extremo que se espera a través de cifrado y la verificación de la identidad del extremo. Las versiones de TLS hasta la fecha son TLS 1.0, 1.1 y 1.2 y 1.3.
 
 Las conexiones de Internet y de API de Mercado Pago utilizan TLS como componente clave de su seguridad.
 
 HTTPS (web) y STARTTLS SMTP (email) también utilizan TLS como componente de seguridad.
 
-### ¿Por qué se va a realizar este cambio?
+## ¿Por qué se va a realizar este cambio?
 
 En Mercado Pago nos tomamos muy en serio la seguridad y ayudamos a nuestros clientes a mejorarla empleando los protocolos de seguridad más recientes.
 
@@ -36,36 +40,39 @@ En Mercado Pago nos tomamos muy en serio la seguridad y ayudamos a nuestros clie
 
 Si tus integraciones que utilizan conexiones entrantes con Mercado Pago no tiene el protocolo TLS 1.2 o superior activado tras realizar este cambio, empezarán a fallar
 
-Te recomendamos que empieces a planificar la inclusión del protocolo TLS 1.2 tan pronto como sea posible.
+> WARNING
+>
+> Importante
+>
+> Te recomendamos que realices la inclusión del protocolo TLS 1.2 **antes del 12 de junio de 2023**.
 
 Consulte las directrices de compatibilidad a continuación:
 
-| Plataforma | Notas de Compatibilidad |
+| Plataforma  | Notas de Compatibilidad  |
 | --- | --- |
-| Java (Oracle) | Compatible con la versión más reciente, sin que el sistema operativo sea relevante. |
-| Java 8 (1.8) y versiones posteriores | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada. |
-| Java 7 (1.7) | Active TLS 1.2 utilizando la propiedad del sistema Java https.protocols para HttpsURLConnection. Para activar  TLS 1.2 en conexiones sin HttpsURLConnection, establezca los protocolos activados en las instancias creadas de SSLSocket y SSLEngine dentro del código fuente de la aplicación. Cambiar a IBM Java puede ser una solución efectiva si la actualización a una versión de Oracle Java más reciente no es posible. |
-| Java 8 | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada. Es posible que tenga que establecer com.ibm.jsse2.overrideDefaultTLS=true si su aplicación o una biblioteca que la llame utiliza SSLContext.getinstance("TLS"). |
-| Java 7 y versiones posteriores, la actualización de servicio 1 de Java 6.0.1 (J9 VM2.6) y versiones posteriores y la actualización de servicio 10 de Java 6 y versiones posteriores | Active TLS 1.2 empleando la propiedad del sistema de Java https.protocols para HttpsURLConnection y la propiedad del sistema de Java com.ibm.jsse2.overrideDefaultProtocol para conexiones SSLSocket y SSLEngine, según recomienda la documentación de IBM. Es posible que también tenga que establecer com.ibm.jsse2.overrideDefaultTLS=true. |
-| .NET | Compatible con la versión más reciente cuando se ejecuta en un sistema operativo que admita TLS 1.2 |
-| .NET 4.6 y versiones posteriores | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada. |
-| .NET 4.5 a 4.5.2 | .NET 4.5, 4.5.1 y 4.5.2 no activan TLS 1.2 de forma predeterminada. Existen dos opciones para activarlas, como se describe a continuación. |
-| .NET 4.0 | .NET 4.0 no activa TLS 1.2 de forma predeterminada. Para activar TLS 1.2 de forma predeterminada, es posible instalar .NET Framework 4.5 o una versión posterior, y establecer el valor DWORD de SchUseStrongCrypto en 1 en las siguientes dos entradas del registro del sistema, creándolas si no existen: "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\v4.0.30319" y "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319". No obstante, esas claves del registro del sistema pueden activar TLS 1.2 de forma predeterminada en todas las aplicaciones .NET 4.0, 4.5, 4.5.1 y 4.5.2 instaladas en ese sistema. Recomendamos probar este cambio antes de implementarlo en sus servidores de producción. Esto también está disponible como un archivo de importación para el registro del sistema.Sin embargo, estos valores del registro del sistema no afectarán a las aplicaciones .NET que establecen el valor System.Net.ServicePointManager.SecurityProtocol. |
-| .NET 3.5 y versiones anteriores | No son compatibles con el cifrado TLS 1.2 o versiones posteriores |
-| Python | Compatible con la versión más reciente cuando se ejecuta en un sistema operativo que admita TLS 1.2 |
-| Python 2.7.9 y versiones posteriores | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada. |
-| Python 2.7.8 y versiones anteriores | No son compatibles con el cifrado TLS 1.2 o versiones posteriores |
-| Ruby | Es compatible con la versión más reciente y estable cuando se vincula con OpenSSL 1.0.1 o versiones posteriores. |
-| Ruby 2.0.0 | TLS 1.2 se activa de forma predeterminada cuando se utiliza con OpenSSL 1.0.1 o versiones posteriores. El uso de los símbolos :TLSv1_2 con ssl_version de SSLContext ayuda a garantizar que se desactiva TLS 1.0 o versiones anteriores. |
-| Ruby 1.9.3 y versiones anteriores | El símbolo :TLSv1_2 no existe en la versión 1.9.3 y anteriores, pero es posible parchear Ruby para agregar ese símbolo y compilar Ruby con OpenSSL 1.0.1 o versiones posteriores. |
-| Android 4.x | Es necesario forzar el uso de TLS 1.2 para ello usar [este snippet de código](https://gist.github.com/zehemz/fdf777a64a173a58beb6f9132eb7655c). |
-| Android 5.x | TLS 1.2 Es soportado de forma predeterminada. |
+| Java (Oracle)  | Compatible con la versión más reciente, sin que el sistema operativo sea relevante.  |
+| Java 8 (1.8) y versiones posteriores  | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada.  |
+| Java 7 (1.7)  | Active TLS 1.2 utilizando la propiedad del sistema Java https.protocols para HttpsURLConnection. Para activar TLS 1.2 en conexiones sin HttpsURLConnection, establezca los protocolos activados en las instancias creadas de SSLSocket y SSLEngine dentro del código fuente de la aplicación. Cambiar a IBM Java puede ser una solución efectiva si la actualización a una versión de Oracle Java más reciente no es posible.  |
+| Java 8  | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada. Es posible que tenga que establecer com.ibm.jsse2.overrideDefaultTLS=true si su aplicación o una biblioteca que la llame utiliza SSLContext.getinstance("TLS").  |
+| Java 7 y versiones posteriores, la actualización de servicio 1 de Java 6.0.1 (J9 VM2.6) y versiones posteriores y la actualización de servicio 10 de Java 6 y versiones posteriores  | Active TLS 1.2 empleando la propiedad del sistema de Java https.protocols para HttpsURLConnection y la propiedad del sistema de Java com.ibm.jsse2.overrideDefaultProtocol para conexiones SSLSocket y SSLEngine, según recomienda la documentación de IBM. Es posible que también tenga que establecer com.ibm.jsse2.overrideDefaultTLS=true.  |
+| .NET  | Compatible con la versión más reciente cuando se ejecuta en un sistema operativo que admita TLS 1.2  |
+| .NET 4.6 y versiones posteriores  | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada.  |
+| .NET 4.5 a 4.5.2  | .NET 4.5, 4.5.1 y 4.5.2 no activan TLS 1.2 de forma predeterminada. Existen dos opciones para activarlas, como se describe a continuación.  |
+| .NET 4.0  | .NET 4.0 no activa TLS 1.2 de forma predeterminada. Para activar TLS 1.2 de forma predeterminada, es posible instalar .NET Framework 4.5 o una versión posterior, y establecer el valor DWORD de SchUseStrongCrypto en 1 en las siguientes dos entradas del registro del sistema, creándolas si no existen: "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft.NETFramework\v4.0.30319" y "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft.NETFramework\v4.0.30319". No obstante, esas claves del registro del sistema pueden activar TLS 1.2 de forma predeterminada en todas las aplicaciones .NET 4.0, 4.5, 4.5.1 y 4.5.2 instaladas en ese sistema. Recomendamos probar este cambio antes de implementarlo en sus servidores de producción. Esto también está disponible como un archivo de importación para el registro del sistema.Sin embargo, estos valores del registro del sistema no afectarán a las aplicaciones .NET que establecen el valor System.Net.ServicePointManager.SecurityProtocol.  |
+| .NET 3.5 y versiones anteriores  | No son compatibles con el cifrado TLS 1.2 o versiones posteriores  |
+| Python  | Compatible con la versión más reciente cuando se ejecuta en un sistema operativo que admita TLS 1.2  |
+| Python 2.7.9 y versiones posteriores  | Compatible con el cifrado TLS 1.2 o versiones posteriores de forma predeterminada.  |
+| Python 2.7.8 y versiones anteriores  | No son compatibles con el cifrado TLS 1.2 o versiones posteriores  |
+| Ruby  | Es compatible con la versión más reciente y estable cuando se vincula con OpenSSL 1.0.1 o versiones posteriores.  |
+| Ruby 2.0.0  | TLS 1.2 se activa de forma predeterminada cuando se utiliza con OpenSSL 1.0.1 o versiones posteriores. El uso de los símbolos :TLSv1_2 con ssl_version de SSLContext ayuda a garantizar que se desactiva TLS 1.0 o versiones anteriores.  |
+| Ruby 1.9.3 y versiones anteriores  | El símbolo :TLSv1_2 no existe en la versión 1.9.3 y anteriores, pero es posible parchear Ruby para agregar ese símbolo y compilar Ruby con OpenSSL 1.0.1 o versiones posteriores.  |
+| Android 5.x y superior  | TLS 1.2 Está soportado de forma predeterminada.  |
 
 En caso que requieras hacer adaptaciones, **es importante que recuerdes hacer este cambio en tiempo y forma, ya que de lo contrario es muy probable que tus conexiones con Mercado Pago comiencen a fallar.**
 
-## ¿Como puedo probar mi integración?
+## ¿Cómo verificar la versión actual de TLS integración?
 
-Para poder validar si tu integración mantiene una conexión usando un protocolo distinto a TLS 1.0, puedes usar el siguiente snippet dentro de tu aplicación para verificar que protocolo se esta usando por defecto para las conexiones.
+Para poder validar si tu integración mantiene una conexión usando un protocolo distinto a TLS 1.0, puedes usar el siguiente snippet dentro de tu aplicación para verificar que protocolo se está usando por defecto para las conexiones.
 
 [[[
 ```php
@@ -75,8 +82,8 @@ Para poder validar si tu integración mantiene una conexión usando un protocolo
 ?>
 ```
 ```java
-  SSLSocket ss = (SSLSocket) SSLSocketFactory.getDefault().createSocket("api.mercadopago.com", 443);
-  System.out.println("protocol: " + ss.getSession().getProtocol());
+SSLSocket ss = (SSLSocket) SSLSocketFactory.getDefault().createSocket("api.mercadopago.com", 443);
+System.out.println("protocol: " + ss.getSession().getProtocol());
 ```
 ```csharp
 string strWebsiteName = "api.mercadopago.com";
@@ -89,9 +96,3 @@ _myStream.AuthenticateAsClient(strWebsiteName);
 Console.WriteLine("protocol : " + _myStream.SslProtocol);
 ```
 ]]]
-
-
-
-Si tienes alguna duda o necesitas asistencia para completar exitosamente este cambio, puedes contactarnos a través del siguiente correo electrónico: soportemigraciones@mercadopago.com.
-
-El equipo de Mercado Pago.

--- a/guides/X-LEGACY (DON`T USE THIS FILE)/resources/pci-compliant-merchants/disabling-tls-10.pt.md
+++ b/guides/X-LEGACY (DON`T USE THIS FILE)/resources/pci-compliant-merchants/disabling-tls-10.pt.md
@@ -2,12 +2,15 @@
 
 No Mercado Pago procuramos sempre otimizar nossa plataforma oferecendo a mais alta eficiência e segurança no processamento de pagamentos.
 
-No momento, estamos trabalhando no desligamento do protocolo de criptografia TLS 1.0 para os domínios https://api.mercadopago.com e https://pagamento.mercadopago.com com o objetivo de manter os mais altos padrões de qualidade e promover a segurança de dados de nossos clientes.
-Consequentemente, o Mercado Pago exigirá que suas conexões com os domínios https://api.mercadopago.com e https://pagamento.mercadopago.com sejam realizados utilizando o protocolo TLS 1.2 ou superior.
+No momento, estamos trabalhando no desligamento do protocolo de criptografia TLS 1.1 para os domínios https://api.mercadopago.com e https://pagamento.mercadopago.com com o objetivo de manter os mais altos padrões de qualidade e promover a segurança de dados de nossos clientes.
 
-Depois desse prazo, o protocolo TLS 1.0 estará desativado e qualquer tentativa de conexão utilizando o TLS 1.0, falhará.
+> WARNING
+>
+> Importante
+>
+> Uma vez desativado o protocolo TLS 1.1, **qualquer tentativa de conexão utilizando o TLS 1.1, falhará**. Além disso, o Mercado Pago exigirá que suas conexões com os domínios https://api.mercadopago.com e https://pagamento.mercadopago.com sejam realizados utilizando o protocolo TLS 1.2 ou superior.
 
-### Pontos para serem levados em conta
+## Pontos para serem levados em conta
 
 * Se você usa apenas Mercado Livre, essa alteração não afetará você.
 * Se você usa apenas os botões de pagamento de Mercado Pago, essa alteração não afetará você.
@@ -19,54 +22,78 @@ Depois desse prazo, o protocolo TLS 1.0 estará desativado e qualquer tentativa 
 
 ## Introdução
 
-### O que é o TLS?
-
 TLS é o acrônimo para "Transport Layer Security". É um protocolo que garante privacidade e integridade de dados entre dois aplicativos que se comunicam pela rede.
 
-É o protocolo de segurança mais utilizado atualmente e é usado em navegadores e outros aplicativos que exigem que os dados sejam trocados com segurança em uma rede. O TLS garante que uma conexão entre dois pontos finais se realize através de criptografia e que os pontos de origem e destino tenham sua identidade verificada. As versões do TLS até o momento são TLS 1.0, 1.1 e 1.2.
+É o protocolo de segurança mais utilizado atualmente e é usado em navegadores e outros aplicativos que exigem que os dados sejam trocados com segurança em uma rede. O TLS garante que uma conexão entre dois pontos finais se realize através de criptografia e que os pontos de origem e destino tenham sua identidade verificada. As versões do TLS até o momento são TLS 1.0, 1.1 e 1.2 e 1.3.
 
 As conexões de Internet e das APIs do Mercado Pago utilizam o protocolo TLS como um componente chave de sua segurança.
 
 HTTPS (web) e STARTTLS SMTP (email), também usam o TLS como um componente de segurança.
 
-### Por que essa mudança será feita?
+## Por que essa mudança será feita?
 
 No Mercado Pago levamos a segurança muito a sério e ajudamos nossos clientes a melhorá-la usando os protocolos de segurança mais recentes.
 
 
-## Ação necessária para a integrações da API
+## Ação necessária para integrações via API
 
 Se suas integrações que usam conexões de entrada com o Mercado Pago, não tiverem os protocolos TLS 1.1 e/ou TLS 1.2 ativados após essa alteração, elas começarão a falhar
 
-Recomendamos que você comece a planejar a inclusão do protocolo TLS 1.2 o mais rápido possível.
+> WARNING
+>
+> Importante
+>
+> Recomendamos que você atualize para o protocolo TLS 1.2 **antes de 12 de junho de 2023**.
 
 Veja as diretrizes de compatibilidade abaixo:
 
-| Plataforma | Notas de Compatibilidade |
+| Plataforma  | Notas de Compatibilidade  |
 | --- | --- |
-| Java (Oracle) | Compatível com a versão mais recente, independente do sistema operacional.  |
-| Java 8 (1.8) y versões posteriores | Compatível com a criptografia TLS 1.1 ou versões posteriores, por padrão. |
-| Java 7 (1.7) | Ative o TLS 1.1 e o TLS 1.2 usando a propriedade do sistema Java https.protocols para HttpsURLConnection. Para ativar o TLS 1.1 e o TLS 1.2 em conexões sem HttpsURLConnection, defina os protocolos ativos nas instâncias criadas de SSLSocket e SSLEngine, no código-fonte do aplicativo. A mudança para o IBM Java, pode ser uma solução eficaz caso a atualização para uma versão mais recente do Oracle Java, não seja possível. |
-| Java 6 (1.6) atualização 111 e posteriores | Ative o TLS 1.1 usando a propriedade do sistema Java https.protocols para HttpsURLConnection. Para ativar o TLS 1.1 em conexões sem HttpsURLConnection, defina os protocolos ativados nas instâncias criadas de SSLSocket e SSLEngine, no código-fonte do aplicativo. Esta atualização do Java 6 e as atualizações posteriores não estão publicamente disponíveis e exigem um contrato de suporte para o Java 6 da Oracle. |
-| Java 6 (1.6) e versões anteriores (versões disponíveis publicamente) | Não são compatíveis com criptografia TLS 1.1 ou versões posteriores. A mudança para o IBM Java pode ser uma solução eficaz, caso a atualização para uma versão mais recente do Oracle Java não seja possível. |
-| Java 8 |	Compatível com a criptografia TLS 1.1 ou versões posteriores por padrão. Você pode ter que configurar com.ibm.jsse2.overrideDefaultTLS = true, caso seu aplicativo ou uma biblioteca de chamadas use SSLContext.getinstance (TLS). |
-| Java 7 e versões posteriores; atualização de serviço 1 do Java 6.0.1 (J9 VM2.6) e versões posteriores; e a atualização de serviço 10 do Java 6 e versões posteriores. | Ative o TLS 1.2 usando a propriedade do sistema Java https.protocols para HttpsURLConnection e a propriedade do sistema Java com.ibm.jsse2.overrideDefaultProtocol para conexões SSLSocket e SSLEngine, conforme recomendado pela documentação da IBM. Você também pode ter que configurar com.ibm.jsse2.overrideDefaultTLS = true. |
-| .NET | Compatível com a versão mais recente quando executado em um sistema operacional que suporte o TLS 1.1 ou o TLS 1.2 |
-| .NET 4.6 e versões posteriores | Compatível com criptografia TLS 1.1 ou versões posteriores por padrão. |
-| .NET 4.5 à 4.5.2 | O .NET 4.5, 4.5.1 e 4.5.2 não ativam o TLS 1.1 e o TLS 1.2 por padrão. Existem duas opções para ativá-las, conforme descrito abaixo. |
-| .NET 4.0 | O .NET 4.0 não ativa o TLS 1.2 por padrão. Para configurar o TLS 1.2 como padrão, é possível instalar o .NET Framework 4.5 ou posterior e definir o valor DWORD de SchUseStrongCrypto como 1 nas duas seguintes chaves do registro do sistema. Caso essas chaves não existam, é necessário criá-las: HKEY_LOCAL_MACHINE \ SOFTWARE \ Microsoft \ .NETFramework \ v4.0.30319 e HKEY_LOCAL_MACHINE \ SOFTWARE \ Wow6432Node \ Microsoft \ .NETFramework \ v4.0.30319. Essas chaves de registro podem ativar o TLS 1.2 por padrão em todos os aplicativos .NET 4.0, 4.5, 4.5.1 e 4.5.2 instalados nesse sistema. Recomendamos testar essa alteração antes de implementá-la em seus servidores de produção. Isso também está disponível como um arquivo de importação para o registro do sistema, porém essas configurações de registro do sistema não afetarão os aplicativos .NET que definem o valor System.Net.ServicePointManager.SecurityProtocol. |
-| .NET 3.5 e versões anteriores | Não são compatíveis com criptografia TLS 1.1 ou versões posteriores |
-| Python | Compatível com a versão mais recente, quando executado em um sistema operacional que suporte o TLS 1.1 ou o TLS 1.2 |
-| Python 2.7.9 e versões posteriores | Compatível com criptografia TLS 1.1 ou versões posteriores por padrão. |
-| Python 2.7.8 e versões anteriores | Não são compatíveis com criptografia TLS 1.1 ou versões posteriores. |
-| Ruby | Compatível com a versão mais recente e estável quando está vinculado ao OpenSSL 1.0.1 ou versões posteriores. |
-| Ruby 2.0.0 | O TLS 1.2 é ativado por padrão quando usado com o OpenSSL 1.0.1 ou posterior. O uso dos símbolos: TLSv1_2 (preferencial) ou TLSv1_1 com ssl_version do SSLContext, ajuda a garantir que o TLS 1.0 ou versões anteriores sejam desativadas. |
-| Ruby 1.9.3 e versões anteriores | O símbolo: TLSv1_2 não existe na versão 1.9.3 nem anteriores, mas é possível corrigir o Ruby para adicionar esse símbolo e compilar o Ruby com o OpenSSL 1.0.1 ou posterior. |
-| Android 4.x | Necessário forçar o uso do TLS 1.2, veja o exemplo [neste snippet de código](https://gist.github.com/zehemz/fdf777a64a173a58beb6f9132eb7655c). |
-| Android 5.x | TLS 1.2 é suportado por padrão. |
+| Java (Oracle)  | Compatível com a versão mais recente, independente do sistema operacional.  |
+| Java 8 (1.8) y versões posteriores  | Compatível com a criptografia TLS 1.2 ou versões posteriores, por padrão.  |
+| Java 7 (1.7)  | Ative TLS 1.2 usando a propriedade do sistema Java https.protocols para HttpsURLConnection. Para ativar o TLS 1.2 em conexões sem HttpsURLConnection, defina os protocolos ativos nas instâncias criadas de SSLSocket e SSLEngine, no código-fonte do aplicativo. A mudança para o IBM Java, pode ser uma solução eficaz caso a atualização para uma versão mais recente do Oracle Java, não seja possível.  |
+| Java 8  | Compatível com a criptografia TLS 1.2 ou versões posteriores por padrão. Você pode ter que configurar com.ibm.jsse2.overrideDefaultTLS = true, caso seu aplicativo ou uma biblioteca de chamadas use SSLContext.getinstance (TLS).  |
+| Java 7 e versões posteriores; atualização de serviço 1 do Java 6.0.1 (J9 VM2.6) e versões posteriores; e a atualização de serviço 10 do Java 6 e versões posteriores.  | Ative o TLS 1.2 usando a propriedade do sistema Java https.protocols para HttpsURLConnection e a propriedade do sistema Java com.ibm.jsse2.overrideDefaultProtocol para conexões SSLSocket e SSLEngine, conforme recomendado pela documentação da IBM. Você também pode ter que configurar com.ibm.jsse2.overrideDefaultTLS = true.  |
+| .NET  | Compatível com a versão mais recente quando executado em um sistema operacional que suporte TLS 1.2  |
+| .NET 4.6 e versões posteriores  | Compatível com criptografia TLS 1.2 ou versões posteriores por padrão.  |
+| .NET 4.5 à 4.5.2  | O .NET 4.5, 4.5.1 e 4.5.2 não ativam TLS 1.2 por padrão. Existem duas opções para ativá-las, conforme descrito abaixo.  |
+| .NET 4.0  | O .NET 4.0 não ativa o TLS 1.2 por padrão. Para configurar o TLS 1.2 como padrão, é possível instalar o .NET Framework 4.5 ou posterior e definir o valor DWORD de SchUseStrongCrypto como 1 nas duas seguintes chaves do registro do sistema. Caso essas chaves não existam, é necessário criá-las: HKEY_LOCAL_MACHINE \ SOFTWARE \ Microsoft \ .NETFramework \ v4.0.30319 e HKEY_LOCAL_MACHINE \ SOFTWARE \ Wow6432Node \ Microsoft \ .NETFramework \ v4.0.30319. Essas chaves de registro podem ativar o TLS 1.2 por padrão em todos os aplicativos .NET 4.0, 4.5, 4.5.1 e 4.5.2 instalados nesse sistema. Recomendamos testar essa alteração antes de implementá-la em seus servidores de produção. Isso também está disponível como um arquivo de importação para o registro do sistema, porém essas configurações de registro do sistema não afetarão os aplicativos .NET que definem o valor System.Net.ServicePointManager.SecurityProtocol.  |
+| .NET 3.5 e versões anteriores  | Não são compatíveis com criptografia TLS 1.2 ou versões posteriores  |
+| Python  | Compatível com a versão mais recente, quando executado em um sistema operacional que suporte TLS 1.2  |
+| Python 2.7.9 e versões posteriores  | Compatível com criptografia TLS 1.2 ou versões posteriores por padrão.  |
+| Python 2.7.8 e versões anteriores  | Não são compatíveis com criptografia TLS 1.1 ou versões posteriores.  |
+| Ruby  | Compatível com a versão mais recente e estável quando está vinculado ao OpenSSL 1.0.1 ou versões posteriores.  |
+| Ruby 2.0.0  | O TLS 1.2 é ativado por padrão quando usado com o OpenSSL 1.0.1 ou posterior. O uso dos símbolos: TLSv1_2 com ssl_version do SSLContext, ajuda a garantir que o TLS 1.1 ou versões anteriores sejam desativadas.  |
+| Ruby 1.9.3 e versões anteriores  | O símbolo: TLSv1_2 não existe na versão 1.9.3 nem anteriores, mas é possível corrigir o Ruby para adicionar esse símbolo e compilar o Ruby com o OpenSSL 1.0.1 ou posterior.  |
+| Android 5.x e versões posteriores  | TLS 1.2 é suportado por padrão.  |
 
-Caso você precise fazer adaptações, **é importante que você se lembre de fazer essa alteração em tempo hábil, porque caso contrário, é muito provável que suas conexões com o Mercado Pago comecem a falhar.**
+## Como verificar a versão atual do TLS?
 
-Se você tiver alguma dúvida ou precisar de ajuda para concluir com êxito essa mudança, entre em contato conosco através do seguinte e-mail: soportemigraciones@mercadopago.com.
 
-Equipe do Mercado Pago.
+Para validar se sua integração está mantendo uma conexão usando um protocolo diferente do TLS 1.2, utilize um dos seguintes trechos dentro de seu aplicativo para verificar qual protocolo é usado por padrão para conexões.
+
+[[[
+```php
+<?php
+  $curl_info = curl_version();
+  echo "protocol: " . $curl_info['ssl_version'];
+?>
+
+```
+```java
+SSLSocket ss = (SSLSocket) SSLSocketFactory.getDefault().createSocket("api.mercadopago.com", 443);
+System.out.println("protocol: " + ss.getSession().getProtocol());
+
+```
+```csharp
+string strWebsiteName = "api.mercadopago.com";
+TcpClient _myClient = new TcpClient();
+SslStream _myStream;
+_myClient.Connect(strWebsiteName, 443);
+_myStream = new SslStream(_myClient.GetStream());
+_myStream.AuthenticateAsClient(strWebsiteName);
+
+Console.WriteLine("protocol : " + _myStream.SslProtocol);
+
+```
+]]]


### PR DESCRIPTION
## Description

Atualizamos uma doc legacy sobre o deprecado de TLS. Foi identificado que alguns usuários ainda estão utilizando uma versão já deprecada e precisam fazer a atualização. 

Essa doc se manterá oculta e independente de qualquer guia, uma vez que a atualizamos por exceção para auxiliar na migração.
