### PR TITLE
[Bricks] Fix pix payment submission

### DIFF
--- a/guides/checkout-bricks/payment-brick/payment-submission-pix.en.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission-pix.en.md
@@ -11,66 +11,36 @@ To configure payment with Pix, send a **POST** to the endpoint [/v1/payments](/d
 [[[
 ```php
 <?php
-require_once 'vendor/autoload.php';
+ require_once 'vendor/autoload.php';
 
-MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
+ MercadoPago\SDK::setAccessToken("ENV_ACCESS_TOKEN");
 
-$payment = new MercadoPago\Payment();
-$payment->transaction_amount = 100;
-$payment->description = "Product title";
-$payment->payment_method_id = "pix";
-$payment->payer = array(
-"email" => "test@test.com",
-"first_name" => "Test",
-"last_name" => "User",
-"identification" => array(
-"type" => "CPF",
-"number" => "19119119100"
-),
-"address"=> array(
-"zip_code" => "06233200",
-"street_name" => "Avenida das Nações Unidas",
-"street_number" => "3003",
-"neighborhood" => "Bonfim",
-"city" => "Osasco",
-"federal_unit" => "SP"
-)
-);
+ $payment = new MercadoPago\Payment();
+ $payment->transaction_amount = 100;
+ $payment->payment_method_id = "pix";
+ $payment->payer = array(
+    "email" => "PAYER_EMAIL_HERE",
+  );
 
-$payment->save();
+ $payment->save();
 
 ?>
 ```
 ```node
-var Mercadopago = require('mercadopago');
-Mercadopago.configurations.setAccessToken(config.access_token);
+var mercadopago = require('mercadopago');
+mercadopago.configurations.setAccessToken(config.access_token);
 
 var payment_data = {
-transaction_amount: 100,
-description: 'Product title',
-payment_method_id: 'pix',
-payer: {
-email: 'test@test.com',
-first_name: 'Test',
-last_name: 'User',
-identification: {
-type: 'CPF',
-number: '19119119100'
-},
-address: {
-zip_code: '06233200',
-street_name: '"Avenida das Nações Unidas"',
-street_number: '3003',
-neighborhood: 'Bonfim',
-city: 'Osasco',
-federal_unit: 'SP'
-}
-}
+  transaction_amount: 100,
+  payment_method_id: 'pix',
+  payer: {
+    email: 'PAYER_EMAIL_HERE',
+  }
 };
 
-Mercadopago.payment.create(payment_data).then(function (data) {
+mercadopago.payment.create(payment_data).then(function (data) {
 
-}).catch(function(error) {
+}).catch(function (error) {
 
 });
 
@@ -81,19 +51,14 @@ MercadoPagoConfig.setAccessToken("ENV_ACCESS_TOKEN");
 PaymentClient client = new PaymentClient();
 
 PaymentCreateRequest paymentCreateRequest =
-PaymentCreateRequest.builder()
-.transactionAmount(new BigDecimal("100"))
-.description("Product Title")
-.paymentMethodId("pix")
-.dateOfExpiration(OffsetDateTime.of(2023, 1, 10, 10, 10, 10, 0, ZoneOffset.UTC))
-.payer(
-PaymentPayerRequest.builder()
-.email("test@test.com")
-.firstName("Test")
-.identification(
-IdentificationRequest.builder().type("CPF").number("19119119100").build())
-.build())
-.build();
+   PaymentCreateRequest.builder()
+       .transactionAmount(new BigDecimal("100"))
+       .paymentMethodId("pix")
+       .payer(
+           PaymentPayerRequest.builder()
+               .email("PAYER_EMAIL_HERE")
+               .build())
+       .build();
 
 client.create(paymentCreateRequest);
 ```
@@ -102,16 +67,11 @@ require 'mercadopago'
 sdk = Mercadopago::SDK.new('ENV_ACCESS_TOKEN')
 
 payment_request = {
-transaction_amount: 100,
-description: 'Product title',
-payment_method_id: 'pix',
-payer: {
-email: 'test@test.com',
-identification: {
-type: 'CPF',
-number: '19119119100',
-}
-}
+  transaction_amount: 100,
+  payment_method_id: 'pix',
+  payer: {
+    email: 'PAYER_EMAIL_HERE',
+  }
 }
 
 payment_response = sdk.payment.create(payment_request)
@@ -129,20 +89,12 @@ MercadoPagoConfig.AccessToken = "ENV_ACCESS_TOKEN";
 
 var request = new PaymentCreateRequest
 {
-TransactionAmount = 105,
-Description = "Product Title",
-PaymentMethodId = "pix",
-Payer = new PaymentPayerRequest
-{
-Email = "test@test.com",
-FirstName = "Test",
-LastName = "User",
-Identification = new IdentificationRequest
-{
-Type = "CPF",
-Number = "191191191-00",
-},
-},
+    TransactionAmount = 105,
+    PaymentMethodId = "pix",
+    Payer = new PaymentPayerRequest
+    {
+        Email = "PAYER_EMAIL_HERE",
+    },
 };
 
 var client = new PaymentClient();
@@ -150,30 +102,15 @@ Payment payment = await client.CreateAsync(request);
 
 ```
 ```python
-import market
-sdk = Mercadopago.SDK("ENV_ACCESS_TOKEN")
+import mercadopago
+sdk = mercadopago.SDK("ENV_ACCESS_TOKEN")
 
 payment_data = {
-"transaction_amount": 100,
-"description": "Product title",
-"payment_method_id": "pix",
-"payer": {
-"email": "test@test.com",
-"first_name": "Test",
-"last_name": "User",
-"identification": {
-"type": "CPF",
-"number": "191191191-00"
-},
-"address": {
-"zip_code": "06233-200",
-"street_name": "Avenida das Nações Unidas",
-"street_number": "3003",
-"neighborhood": "Bonfim",
-"city": "Osasco",
-"federal_unit": "SP"
-}
-}
+    "transaction_amount": 100,
+    "payment_method_id": "pix",
+    "payer": {
+        "email": "PAYER_EMAIL_HERE",
+    }
 }
 
 payment_response = sdk.payment().create(payment_data)
@@ -181,32 +118,17 @@ payment = payment_response["response"]
 ```
 ```curl
 curl -X POST \
--H 'accept: application/json' \
--H 'content-type: application/json' \
--H 'Authorization: Bearer ENV_ACCESS_TOKEN' \
-'https://api.mercadopago.com/v1/payments' \
--d '{
-"transaction_amount": 100,
-"description": "Product title",
-"payment_method_id": "pix",
-"payer": {
-"email": "PAYER_EMAIL_HERE",
-"first_name": "Test",
-"last_name": "User",
-"identification": {
-"type": "CPF",
-"number": "19119119100"
-},
-"address": {
-"zip_code": "06233200",
-"street_name": "Avenida das Nações Unidas",
-"street_number": "3003",
-"neighborhood": "Bonfim",
-"city": "Osasco",
-"federal_unit": "SP"
-}
-}
-}'
+    -H 'accept: application/json' \
+    -H 'content-type: application/json' \
+    -H 'Authorization: Bearer ENV_ACCESS_TOKEN' \
+    'https://api.mercadopago.com/v1/payments' \
+    -d '{
+      "transaction_amount": 100,
+      "payment_method_id": "pix",
+      "payer": {
+        "email": "PAYER_EMAIL_HERE"
+      }
+    }'
 ```
 ]]]
 

--- a/guides/checkout-bricks/payment-brick/payment-submission-pix.es.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission-pix.es.md
@@ -17,25 +17,10 @@ Para configurar los pagos con Pix, envía un **POST** al endpoint [/v1/payments]
 
  $payment = new MercadoPago\Payment();
  $payment->transaction_amount = 100;
- $payment->description = "Título del producto";
  $payment->payment_method_id = "pix";
  $payment->payer = array(
-     "email" => "test@test.com",
-     "first_name" => "Test",
-     "last_name" => "User",
-     "identification" => array(
-         "type" => "CPF",
-         "number" => "19119119100"
-      ),
-     "address"=>  array(
-         "zip_code" => "06233200",
-         "street_name" => "Av. das Nações Unidas",
-         "street_number" => "3003",
-         "neighborhood" => "Bonfim",
-         "city" => "Osasco",
-         "federal_unit" => "SP"
-      )
-   );
+    "email" => "PAYER_EMAIL_HERE",
+  );
 
  $payment->save();
 
@@ -47,24 +32,9 @@ mercadopago.configurations.setAccessToken(config.access_token);
 
 var payment_data = {
   transaction_amount: 100,
-  description: 'Título del producto',
   payment_method_id: 'pix',
   payer: {
-    email: 'test@test.com',
-    first_name: 'Test',
-    last_name: 'User',
-    identification: {
-        type: 'CPF',
-        number: '19119119100'
-    },
-    address:  {
-        zip_code: '06233200',
-        street_name: 'Av. das Nações Unidas',
-        street_number: '3003',
-        neighborhood: 'Bonfim',
-        city: 'Osasco',
-        federal_unit: 'SP'
-    }
+    email: 'PAYER_EMAIL_HERE',
   }
 };
 
@@ -83,15 +53,10 @@ PaymentClient client = new PaymentClient();
 PaymentCreateRequest paymentCreateRequest =
    PaymentCreateRequest.builder()
        .transactionAmount(new BigDecimal("100"))
-       .description("Título del producto")
        .paymentMethodId("pix")
-       .dateOfExpiration(OffsetDateTime.of(2023, 1, 10, 10, 10, 10, 0, ZoneOffset.UTC))
        .payer(
            PaymentPayerRequest.builder()
-               .email("test@test.com")
-               .firstName("Test")
-               .identification(
-                   IdentificationRequest.builder().type("CPF").number("19119119100").build())
+               .email("PAYER_EMAIL_HERE")
                .build())
        .build();
 
@@ -103,14 +68,9 @@ sdk = Mercadopago::SDK.new('ENV_ACCESS_TOKEN')
 
 payment_request = {
   transaction_amount: 100,
-  description: 'Título del producto',
   payment_method_id: 'pix',
   payer: {
-    email: 'test@test.com',
-    identification: {
-      type: 'CPF',
-      number: '19119119100',
-    }
+    email: 'PAYER_EMAIL_HERE',
   }
 }
 
@@ -130,18 +90,10 @@ MercadoPagoConfig.AccessToken = "ENV_ACCESS_TOKEN";
 var request = new PaymentCreateRequest
 {
     TransactionAmount = 105,
-    Description = "Título del producto",
     PaymentMethodId = "pix",
     Payer = new PaymentPayerRequest
     {
-        Email = "test@test.com",
-        FirstName = "Test",
-        LastName = "User",
-        Identification = new IdentificationRequest
-        {
-            Type = "CPF",
-            Number = "191191191-00",
-        },
+        Email = "PAYER_EMAIL_HERE",
     },
 };
 
@@ -155,24 +107,9 @@ sdk = mercadopago.SDK("ENV_ACCESS_TOKEN")
 
 payment_data = {
     "transaction_amount": 100,
-    "description": "Título del producto",
     "payment_method_id": "pix",
     "payer": {
-        "email": "test@test.com",
-        "first_name": "Test",
-        "last_name": "User",
-        "identification": {
-            "type": "CPF",
-            "number": "191191191-00"
-        },
-        "address": {
-            "zip_code": "06233-200",
-            "street_name": "Av. das Nações Unidas",
-            "street_number": "3003",
-            "neighborhood": "Bonfim",
-            "city": "Osasco",
-            "federal_unit": "SP"
-        }
+        "email": "PAYER_EMAIL_HERE",
     }
 }
 
@@ -187,24 +124,9 @@ curl -X POST \
     'https://api.mercadopago.com/v1/payments' \
     -d '{
       "transaction_amount": 100,
-      "description": "Título del producto",
       "payment_method_id": "pix",
       "payer": {
-        "email": "PAYER_EMAIL_HERE",
-        "first_name": "Test",
-        "last_name": "User",
-        "identification": {
-            "type": "CPF",
-            "number": "19119119100"
-        },
-        "address": {
-            "zip_code": "06233200",
-            "street_name": "Av. das Nações Unidas",
-            "street_number": "3003",
-            "neighborhood": "Bonfim",
-            "city": "Osasco",
-            "federal_unit": "SP"
-        }
+        "email": "PAYER_EMAIL_HERE"
       }
     }'
 ```

--- a/guides/checkout-bricks/payment-brick/payment-submission-pix.pt.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission-pix.pt.md
@@ -17,25 +17,10 @@ Para configurar pagamento com Pix, envie um POST ao endpoint [/v1/payments](/dev
 
  $payment = new MercadoPago\Payment();
  $payment->transaction_amount = 100;
- $payment->description = "Título do produto";
  $payment->payment_method_id = "pix";
  $payment->payer = array(
-     "email" => "test@test.com",
-     "first_name" => "Test",
-     "last_name" => "User",
-     "identification" => array(
-         "type" => "CPF",
-         "number" => "19119119100"
-      ),
-     "address"=>  array(
-         "zip_code" => "06233200",
-         "street_name" => "Av. das Nações Unidas",
-         "street_number" => "3003",
-         "neighborhood" => "Bonfim",
-         "city" => "Osasco",
-         "federal_unit" => "SP"
-      )
-   );
+    "email" => "PAYER_EMAIL_HERE",
+  );
 
  $payment->save();
 
@@ -47,24 +32,9 @@ mercadopago.configurations.setAccessToken(config.access_token);
 
 var payment_data = {
   transaction_amount: 100,
-  description: 'Título do produto',
   payment_method_id: 'pix',
   payer: {
-    email: 'test@test.com',
-    first_name: 'Test',
-    last_name: 'User',
-    identification: {
-        type: 'CPF',
-        number: '19119119100'
-    },
-    address:  {
-        zip_code: '06233200',
-        street_name: 'Av. das Nações Unidas',
-        street_number: '3003',
-        neighborhood: 'Bonfim',
-        city: 'Osasco',
-        federal_unit: 'SP'
-    }
+    email: 'PAYER_EMAIL_HERE',
   }
 };
 
@@ -83,15 +53,10 @@ PaymentClient client = new PaymentClient();
 PaymentCreateRequest paymentCreateRequest =
    PaymentCreateRequest.builder()
        .transactionAmount(new BigDecimal("100"))
-       .description("Título do produto")
        .paymentMethodId("pix")
-       .dateOfExpiration(OffsetDateTime.of(2023, 1, 10, 10, 10, 10, 0, ZoneOffset.UTC))
        .payer(
            PaymentPayerRequest.builder()
-               .email("test@test.com")
-               .firstName("Test")
-               .identification(
-                   IdentificationRequest.builder().type("CPF").number("19119119100").build())
+               .email("PAYER_EMAIL_HERE")
                .build())
        .build();
 
@@ -103,14 +68,9 @@ sdk = Mercadopago::SDK.new('ENV_ACCESS_TOKEN')
 
 payment_request = {
   transaction_amount: 100,
-  description: 'Título do produto',
   payment_method_id: 'pix',
   payer: {
-    email: 'test@test.com',
-    identification: {
-      type: 'CPF',
-      number: '19119119100',
-    }
+    email: 'PAYER_EMAIL_HERE',
   }
 }
 
@@ -130,18 +90,10 @@ MercadoPagoConfig.AccessToken = "ENV_ACCESS_TOKEN";
 var request = new PaymentCreateRequest
 {
     TransactionAmount = 105,
-    Description = "Título do produto",
     PaymentMethodId = "pix",
     Payer = new PaymentPayerRequest
     {
-        Email = "test@test.com",
-        FirstName = "Test",
-        LastName = "User",
-        Identification = new IdentificationRequest
-        {
-            Type = "CPF",
-            Number = "191191191-00",
-        },
+        Email = "PAYER_EMAIL_HERE",
     },
 };
 
@@ -155,24 +107,9 @@ sdk = mercadopago.SDK("ENV_ACCESS_TOKEN")
 
 payment_data = {
     "transaction_amount": 100,
-    "description": "Título do produto",
     "payment_method_id": "pix",
     "payer": {
-        "email": "test@test.com",
-        "first_name": "Test",
-        "last_name": "User",
-        "identification": {
-            "type": "CPF",
-            "number": "191191191-00"
-        },
-        "address": {
-            "zip_code": "06233-200",
-            "street_name": "Av. das Nações Unidas",
-            "street_number": "3003",
-            "neighborhood": "Bonfim",
-            "city": "Osasco",
-            "federal_unit": "SP"
-        }
+        "email": "PAYER_EMAIL_HERE",
     }
 }
 
@@ -187,24 +124,9 @@ curl -X POST \
     'https://api.mercadopago.com/v1/payments' \
     -d '{
       "transaction_amount": 100,
-      "description": "Título do produto",
       "payment_method_id": "pix",
       "payer": {
-        "email": "PAYER_EMAIL_HERE",
-        "first_name": "Test",
-        "last_name": "User",
-        "identification": {
-            "type": "CPF",
-            "number": "19119119100"
-        },
-        "address": {
-            "zip_code": "06233200",
-            "street_name": "Av. das Nações Unidas",
-            "street_number": "3003",
-            "neighborhood": "Bonfim",
-            "city": "Osasco",
-            "federal_unit": "SP"
-        }
+        "email": "PAYER_EMAIL_HERE"
       }
     }'
 ```


### PR DESCRIPTION
## Description

This PR is a fix to the Bricks PIX payment submission. Today, the devsite shows a lot of properties, but in fact the bricks only returns `transaction_amount`, `payment_method_id` and `payer.email`.

With this change, we are fixing the code snippet to only show this 3 properties.
