### PR TITLE
Adição link direcionando para a página de 3DS em Cartões

### DIFF
--- a/guides/checkout-api-v2/integration-via-cardform.en.md
+++ b/guides/checkout-api-v2/integration-via-cardform.en.md
@@ -8,7 +8,8 @@ As the card data is entered, an automatic search takes place for the issuer info
 >
 > Important
 >
-> In addition to the options available in this documentation, it is also possible to integrate **card payments** using the **CardPayment Brick**. Check [Default rendering](/developers/en/docs/checkout-bricks/card-payment-brick/default-rendering#editor_2) documentation of CardPayment for more details.
+> In addition to the options available in this documentation, it is also possible to integrate **card payments** using the **CardPayment Brick**. Check [Default rendering](/developers/en/docs/checkout-bricks/card-payment-brick/default-rendering#editor_2) documentation of CardPayment for more details. We also recommend adopting the 3DS 2.0 protocol to increase the likelihood of your payments being approved. For more information, please refer to the documentation on [How to integrate 3DS with Checkout API](https://www.mercadopago.com.br/developers/en/docs/checkout-api/how-tos/integrate-3ds).
+
 
 Check below the diagram that illustrates the card payment process using the Card Form.
 

--- a/guides/checkout-api-v2/integration-via-cardform.es.md
+++ b/guides/checkout-api-v2/integration-via-cardform.es.md
@@ -8,7 +8,8 @@ A medida que se introducen los datos de la tarjeta, se realiza una búsqueda aut
 >
 > Importante
 >
-> Además de las opciones disponibles en esta documentación, también es posible integrar **pagos con tarjeta** utilizando el **Brick de CardPayment**. Consulta la documentación [Renderizado por defecto](/developers/es/docs/checkout-bricks/card-payment-brick/default-rendering#editor_2) de CardPayment para obtener más detalles.
+> Además de las opciones disponibles en esta documentación, también es posible integrar **pagos con tarjeta** utilizando el **Brick de CardPayment**. Consulta la documentación [Renderizado por defecto](/developers/es/docs/checkout-bricks/card-payment-brick/default-rendering#editor_2) de CardPayment para obtener más detalles. También recomendamos adoptar el protocolo 3DS 2.0 para aumentar la probabilidad de que se aprueben sus pagos. Para obtener más información, consulte la documentación sobre [Cómo integrar 3DS con Checkout API](https://www.mercadopago.com.br/developers/es/docs/checkout-api/how-tos/integrate-3ds).
+
 
 Consulta el siguiente diagrama que ilustra el proceso de pago con tarjeta utilizando Card Form.
 

--- a/guides/checkout-api-v2/integration-via-cardform.pt.md
+++ b/guides/checkout-api-v2/integration-via-cardform.pt.md
@@ -8,7 +8,7 @@ A integração de pagamentos via cartão é feita via cardform. Neste modo de in
 >
 > Importante
 >
-> Além das opções disponíveis nesta documentação, também é possível integrar **pagamentos com cartão** utilizando o **Brick de CardPayment**. Veja a documentação [Renderização padrão](/developers/pt/docs/checkout-bricks/card-payment-brick/default-rendering#editor_2) do CardPayment para mais detalhes. 
+> Além das opções disponíveis nesta documentação, também é possível integrar **pagamentos com cartão** utilizando o **Brick de CardPayment**. Veja a documentação [Renderização padrão](/developers/pt/docs/checkout-bricks/card-payment-brick/default-rendering#editor_2) do CardPayment para mais detalhes. Também recomendamos a adoção do protocolo 3DS 2.0 para aumentar a probabilidade de aprovação dos seus pagamentos. Para obter mais informações, consulte a documentação sobre [Como integrar 3DS com Checkout Transparente](https://www.mercadopago.com.br/developers/pt/docs/checkout-api/how-tos/integrate-3ds).
 
 Confira abaixo o diagrama que ilustra o processo de pagamento via cartão utilizando o Card Form.
 


### PR DESCRIPTION
Lançamos recentemente uma página explicando sobre 3DS ([Como integrar 3DS com Checkout Transparente - Checkout Transparente - Mercado Pago Developers](https://www.mercadopago.com.br/developers/pt/docs/checkout-api/how-tos/integrate-3ds) ) e adicionamos um link na página de pagamento com cartão ([Cartão - Configuração da integração - Mercado Pago Developers](https://www.mercadopago.com.br/developers/pt/docs/checkout-api/integration-configuration/card/integrate-via-cardform) ) que direcione o usuário para esta página.