### PR TITLE
fix/snippet-testusers-credentials

### DIFF
--- a/guides/snippets/test-integration/create-test-users.en.md
+++ b/guides/snippets/test-integration/create-test-users.en.md
@@ -19,6 +19,12 @@ To create accounts and test how the integrations work, follow the steps below.
 
 > WARNING
 >
+> Use of credentials
+>
+> Always use the **production credentials** when working with a test user.
+
+> WARNING
+>
 > Attention
 >
 > You can generate up to 15 test user accounts simultaneously, and for now, it is not possible to delete them.
@@ -35,4 +41,4 @@ Done! The test account has been created and will be displayed in the table with 
 >
 > Important
 >
-> To edit the **account identification** or **add more fictional money** to test your applications, click on the **vertical ellipsis** (three dots) at the end of the table row and select the **Edit data** option.
+> To edit the **account identification** or **add more fictional money** to test your applications, click on the **vertical ellipsis** (three dots) at the end of the table row and select the **Edit data** option.<br> <br> You can generate **up to 15 test user accounts** simultaneously, and for now, it is not possible to delete them.

--- a/guides/snippets/test-integration/create-test-users.es.md
+++ b/guides/snippets/test-integration/create-test-users.es.md
@@ -16,14 +16,15 @@ Para crear cuentas y probar el funcionamiento de las integraciones, sigue los si
 3. En la pantalla "Crear nueva cuenta", ingresa una descripción para identificar la cuenta. Por ejemplo: "Vendedor - tienda 1".
 4. A continuación, selecciona el **país de operación** de la cuenta. Esta información **no se podrá editar más adelante**, y además, los usuarios Comprador y Vendedor deben ser del mismo país.
 5. Ingresa un **valor ficticio en dinero** que servirá como referencia para probar tus aplicaciones. Este valor aparecerá como saldo en la cuenta de Mercado Pago del usuario de prueba y se podrá utilizar para simular pagos, al igual que con las [tarjetas de prueba](/developers/es/guides/additional-content/your-integrations/test-cards).
-6. Autoriza el uso de tus datos personales de acuerdo con la [Declaración de Privacidad](https://www.mercadopago.com.br/privacidade) y asegúrate de que tu cuenta utiliza las herramientas de Mercado Pago según los [Términos y Condiciones](https://www.mercadopago.com.br/developers/pt/docs/resources/legal/terms-and-conditions) marcando la casilla de selección.
+6. Autoriza el uso de tus datos personales de acuerdo con la [Declaración de Privacidad](https://www.mercadopago.com.br/privacidade) y asegúrate de que tu cuenta utiliza las herramientas de Mercado Pago según los [Términos y Condiciones](/developers/es/docs/resources/legal/terms-and-conditions) marcando la casilla de selección.
 7. Haz clic en **Crear cuenta de prueba**.
 
 > WARNING
 >
-> Aviso
+> Uso de credenciales
 >
-> Puedes generar hasta 15 cuentas de usuarios de prueba al mismo tiempo y, por ahora, no es posible eliminarlas.
+> Siempre que utilices un usuario de prueba, deberás usar sus **credenciales de producción**.
+
 
 ¡Listo! La cuenta de prueba se ha creado y se mostrará en la tabla con la siguiente información:
 
@@ -37,4 +38,4 @@ Para crear cuentas y probar el funcionamiento de las integraciones, sigue los si
 >
 > Importante
 >
-> Para editar la **identificación de la cuenta** o **agregar más dinero ficticio** para probar tus aplicaciones, haz clic en los **3 puntos verticales** al final de la línea de la tabla y selecciona la opción **Editar datos**.
+> Para editar la **identificación de la cuenta** o **agregar más dinero ficticio** para probar tus aplicaciones, haz clic en los **3 puntos verticales** al final de la línea de la tabla y selecciona la opción **Editar datos**.<br> <br> Puedes generar hasta **15 cuentas** de usuarios de prueba al mismo tiempo y, por ahora, **no es posible eliminarlas**.

--- a/guides/snippets/test-integration/create-test-users.pt.md
+++ b/guides/snippets/test-integration/create-test-users.pt.md
@@ -23,7 +23,7 @@ Para criar contas e testar o funcionamento das integrações, siga os passos aba
 >
 > Atenção
 >
-> Você pode gerar até 15 contas de usuários de teste ao mesmo tempo e, por enquanto, ainda não é possível deletá-las.
+> Sempre que utilizar um usuário de teste, você deve usar suas **credenciais de produção**.
 
 Pronto! A conta de teste foi criada e será exibida na tabela com as seguintes informações:
 
@@ -37,4 +37,4 @@ Pronto! A conta de teste foi criada e será exibida na tabela com as seguintes i
 >
 > Importante
 >
-> Para editar a **identificação da conta** ou **adicionar mais dinheiro fictício** para testar suas aplicações, clique nos **3 pontos verticais** ao final da linha da tabela e selecione a opção **Editar dados**.
+> Para editar a **identificação da conta** ou **adicionar mais dinheiro fictício** para testar suas aplicações, clique nos **3 pontos verticais** ao final da linha da tabela e selecione a opção **Editar dados**.<br> <br> Você pode gerar **até 15 contas** de usuários de teste ao mesmo tempo e, por enquanto, ainda não é possível deletá-las.


### PR DESCRIPTION
## Description

Se edita el text snippet de usuarios de prueba para que sume la aclaración de que se deben utilizar las credenciales de producción de los test users.


