### PR TITLE
Feature/shopify-warning-migration

### DIFF
--- a/guides/shopify/integration-configuration-cho-api.en.md
+++ b/guides/shopify/integration-configuration-cho-api.en.md
@@ -6,7 +6,7 @@ With the [Checkout Transparente](/developers/en/docs/checkout-api/landing), the 
 >
 > Attention
 >
-> To integrate Checkout Transparente you must have Checkout Pro in your Shopify store. To learn how to integrate it, go to the [documentation.](/developers/en/docs/shopify/integration-configuration/checkout-pro)
+> To integrate Checkout Transparente you must have Checkout Pro ("**Checkout Mercado Pago**") in your Shopify store. To learn how to integrate it, go to the [documentation.](/developers/en/docs/shopify/integration-configuration/checkout-pro)
 
 To install Checkout Transparente in a Shopify store, follow the steps below:
 

--- a/guides/shopify/integration-configuration-cho-api.es.md
+++ b/guides/shopify/integration-configuration-cho-api.es.md
@@ -6,7 +6,7 @@ Con el [Checkout Transparente](/developers/es/docs/checkout-api/landing), todo e
 >
 > Atención
 >
-> Para integrar Checkout Transparente deberás contar con Checkout Pro en tu tienda de Shopify. Para saber cómo integrarlo, ve a la [documentación.](/developers/es/docs/shopify/integration-configuration/checkout-pro)
+> Para integrar Checkout Transparente deberás contar con Checkout Pro ("**Checkout Mercado Pago**") en tu tienda de Shopify. Para saber cómo integrarlo, ve a la [documentación.](/developers/es/docs/shopify/integration-configuration/checkout-pro)
 
 Para instalar Checkout Transparente en una tienda Shopify, sigue los pasos a continuación:
 

--- a/guides/shopify/integration-configuration-cho-api.pt.md
+++ b/guides/shopify/integration-configuration-cho-api.pt.md
@@ -6,7 +6,7 @@ Com o [Checkout Transparente](/developers/pt/docs/checkout-api/landing), todo o 
 >
 > Atenção
 >
-> Para integrar o Checkout Transparente, você deve ter o Checkout Pro na sua loja da Shopify. Para saber como integrá-lo, consulte a [documentação.](/developers/pt/docs/shopify/integration-configuration/checkout-pro)
+> Para integrar o Checkout Transparente, você deve ter o Checkout Pro ("**Checkout Mercado Pago**") na sua loja da Shopify. Para saber como integrá-lo, consulte a [documentação.](/developers/pt/docs/shopify/integration-configuration/checkout-pro)
 
 Para instalar o Checkout Transparente em uma loja Shopify, siga os passos abaixo:
 

--- a/guides/shopify/integration-configuration-cho-pro.en.md
+++ b/guides/shopify/integration-configuration-cho-pro.en.md
@@ -1,8 +1,8 @@
 # Checkout Pro
 
+----[mlb]----
 When installing [Checkout Pro](/developers/en/docs/checkout-pro/landing), there may be an **increase in the approval rate of online store sales**. This happens because buyers will be able to pay using a Mercado Pago account and the entire purchase process will be done in our environment, which facilitates payment. At the end of the transaction, these buyers are redirected to the store environment.
 
-----[mlb]----
 To configure Checkout Pro in a Shopify store, follow the steps below:
 
 1. Go to your [Shopify](https://accounts.shopify.com/store-login) store.
@@ -17,14 +17,41 @@ To configure Checkout Pro in a Shopify store, follow the steps below:
 > In case of renewing your credentials, remember to replace both the production and test credentials in your integration.
 
 ------------
-----[mla, mlm, mpe, mco, mlu, mlc]----
+----[mco]----
+When installing [Checkout Pro](/developers/en/docs/checkout-pro/landing) ("**Checkout Mercado Pago**"), there may be an **increase in the approval rate of online store sales**. This happens because buyers will be able to pay using a Mercado Pago account and the entire purchase process will be done in our environment, which facilitates payment. At the end of the transaction, these buyers are redirected to the store environment.
+
 > WARNING
 >
 > Attention
 >
-> If you are using the old Mercado Pago app ("Mercado Pago"), [click here](/developers/en/docs/shopify/how-tos/migration) to find out how to migrate to the current version ("Checkout Mercado Pago" ).
+> If you are using the old Mercado Pago app ("**Mercado Pago**"), [click here](/developers/en/docs/shopify/how-tos/migration) to find out how to migrate to the current version ("**Checkout Mercado Pago**").
 
-To install Checkout Pro in a Shopify store, follow the steps below:
+To install Checkout Pro ("**Checkout Mercado Pago**") in a Shopify store, follow the steps below:
+
+1. Go to your [Shopify](https://accounts.shopify.com/store-login) store.
+2. In the store's administrative panel, click on **Settings**.
+3. Once there, select the **Payments** option. 
+4. In "Additional payment methods", click on the **Add payment methods** option.
+5. Go to the **Search by provider** tab and look for the new app with the name "Checkout Mercado Pago".
+6. Once you have found it, select it and click **Activate** and then **Connect**.
+7. Select **Install App** and then **Manage**.
+8. Put your **production credentials** (`public key` and `access token`) in the fields that request it and click **Save**. Remember to keep your [credentials](/developers/en/docs/shopify/additional-content/your-integrations/credentials) handy.
+9. To finish the installation, select **Activate Checkout Mercado Pago**.
+
+> In this step, you can select the images of the means of payment that you want to show in your store for illustrative purposes. Also, if you wish, you can enable [test mode.](/developers/en/docs/shopify/sales-processing/integration-test)
+> <br/><br/>
+> In case of renewing your credentials, remember to replace both the production and test credentials in your integration.
+
+----[mla, mlm, mpe, mco, mlu, mlc]----
+When installing [Checkout Pro](/developers/en/docs/checkout-pro/landing) ("**Checkout Mercado Pago**"), there may be an **increase in the approval rate of online store sales**. This happens because buyers will be able to pay using a Mercado Pago account and the entire purchase process will be done in our environment, which facilitates payment. At the end of the transaction, these buyers are redirected to the store environment.
+
+> WARNING
+>
+> Attention
+>
+> If you were using the old Mercado Pago app ("**Mercado Pago**") and you stopped receiving payments in your store, don't worry. To sell again, install our new app ("**Checkout Mercado Pago**") following the steps below.
+
+To install Checkout Pro ("**Checkout Mercado Pago**") in a Shopify store, follow these steps:
 
 1. Go to your [Shopify](https://accounts.shopify.com/store-login) store.
 2. In the store's administrative panel, click on **Settings**.

--- a/guides/shopify/integration-configuration-cho-pro.es.md
+++ b/guides/shopify/integration-configuration-cho-pro.es.md
@@ -1,8 +1,8 @@
 # Checkout Pro
 
+----[mlb]----
 Al instalar [Checkout Pro](/developers/es/docs/checkout-pro/landing), puede haber un **aumento en la tasa de aprobación de las ventas en la tienda en línea**. Esto sucede porque los compradores podrán pagar con una cuenta de Mercado Pago y todo el proceso de compra se realizará en nuestro entorno, lo que facilita el pago. Al final de la transacción, estos compradores son redirigidos al entorno de la tienda.
 
-----[mlb]----
 Para configurar el Checkout Pro en una tienda Shopify, sigue los pasos a continuación:
 
 1. Ve a tu tienda [Shopify](https://accounts.shopify.com/store-login).
@@ -17,14 +17,55 @@ Para configurar el Checkout Pro en una tienda Shopify, sigue los pasos a continu
 > En caso de renovar tus credenciales, recuerda reemplazar tanto las de producción como las de pruba en tu integración.
 
 ------------
-----[mla, mlm, mpe, mco, mlu, mlc]----
+----[mco]----
+Al instalar [Checkout Pro](/developers/es/docs/checkout-pro/landing) ("**Checkout Mercado Pago**"), puede haber un **aumento en la tasa de aprobación de las ventas en la tienda en línea**. Esto sucede porque los compradores podrán pagar con una cuenta de Mercado Pago y todo el proceso de compra se realizará en nuestro entorno, lo que facilita el pago. Al final de la transacción, estos compradores son redirigidos al entorno de la tienda.
+
 > WARNING
 >
 > Atención
 >
-> Si estás usando la app antigua de Mercado Pago ("Mercado Pago"), [haz clic aquí](/developers/es/docs/shopify/how-tos/migration) para saber cómo migrar a la versión actual ("Checkout Mercado Pago").
+> Si estás usando la app antigua de Mercado Pago ("**Mercado Pago**"), [haz clic aquí](/developers/es/docs/shopify/how-tos/migration) para saber cómo migrar a la versión actual ("**Checkout Mercado Pago**").
 
-Para instalar Checkout Pro en una tienda Shopify, sigue los pasos a continuación:
+Para instalar Checkout Pro ("**Checkout Mercado Pago**") en una tienda Shopify, sigue los pasos a continuación:
+
+1. Ve a tu tienda [Shopify](https://accounts.shopify.com/store-login).
+2. Dentro del panel administrativo de la tienda, haz clic en **Configuración**.
+3. Una vez allí, selecciona la opción **Pagos**. 
+4. En "Formas de pago adicionales", haz clic en **Agregar formas de pago**.
+5. Dirígete a la pestaña **Buscar por proveedor** y busca la nueva app con el nombre "Checkout Mercado Pago". 
+6. Una vez que la hayas encontrado, selecciónala y haz clic en **Activar”** y luego **Conectar**.
+
+<center>
+
+![migracion a](/images/shopify/migration-a-es.gif)
+
+</center>
+
+7. Selecciona **Instalar aplicación** y luego **Gestionar**.
+8. Coloca tus **credenciales de producción** (`public key` y `access token`) en los campos que lo solicitan y haz clic en **Guardar**. Recuerda tener a mano tus [credenciales](/developers/es/docs/shopify/additional-content/your-integrations/credentials).
+9. Para terminar la instalación, selecciona **Activar Checkout Mercado Pago**.
+
+> En este paso, podrás seleccionar las imágenes de los medios de pago que quieras mostrar en tu tienda a modo ilustrativo. También, en caso que lo desees, podrás habilitar el [modo de prueba.](/developers/pt/docs/shopify/sales-processing/integration-test)
+> <br/><br/>
+> En caso de renovar tus credenciales, recuerda reemplazar tanto las de producción como las de pruba en tu integración.
+
+<center>
+
+![migracion b](/images/shopify/migration-b-es.gif)
+
+</center>
+
+------------
+----[mla, mlm, mpe, mlu, mlc]----
+Al instalar [Checkout Pro](/developers/es/docs/checkout-pro/landing) ("**Checkout Mercado Pago**"), puede haber un **aumento en la tasa de aprobación de las ventas en la tienda en línea**. Esto sucede porque los compradores podrán pagar con una cuenta de Mercado Pago y todo el proceso de compra se realizará en nuestro entorno, lo que facilita el pago. Al final de la transacción, estos compradores son redirigidos al entorno de la tienda.
+
+> WARNING
+>
+> Atención
+>
+> Si estabas usando la app antigua de Mercado Pago ("**Mercado Pago**") y dejaste de recibir pagos en tu tienda, no te preocupes. Para volver a vender instala nuestra nueva app ("**Checkout Mercado Pago**") siguiendo los pasos a continuación.
+
+Para instalar Checkout Pro ("**Checkout Mercado Pago**") en una tienda Shopify, sigue los siguientes pasos:
 
 1. Ve a tu tienda [Shopify](https://accounts.shopify.com/store-login).
 2. Dentro del panel administrativo de la tienda, haz clic en **Configuración**.

--- a/guides/shopify/integration-configuration-cho-pro.pt.md
+++ b/guides/shopify/integration-configuration-cho-pro.pt.md
@@ -1,8 +1,8 @@
 # Checkout Pro
 
+----[mlb]----
 Ao instalar o [Checkout Pro](/developers/pt/docs/checkout-pro/landing), é possível que haja um **aumento na taxa de aprovação das vendas da loja on-line**. Isso acontece porque os compradores poderão pagar usando uma conta Mercado Pago e todo o processo de compra será feito em nosso ambiente, o que facilita o pagamento. Ao final da transação, esses compradores são redirecionados ao ambiente da loja.
 
-----[mlb]----
 Para configurar o Checkout Pro em uma loja Shopify, siga os passos abaixo:
 
 1. Vá para a sua loja [Shopify](https://accounts.shopify.com/store-login).
@@ -17,14 +17,42 @@ Para configurar o Checkout Pro em uma loja Shopify, siga os passos abaixo:
 > No caso de renovar suas credenciais, lembre-se de substituir as credenciais de produção e de teste em sua integração.
 
 ------------
-----[mla, mlm, mpe, mco, mlu, mlc]----
+----[mco]----
+Ao instalar o [Checkout Pro](/developers/pt/docs/checkout-pro/landing) ("**Checkout Mercado Pago**"), é possível que haja um **aumento na taxa de aprovação das vendas da loja on-line**. Isso acontece porque os compradores poderão pagar usando uma conta Mercado Pago e todo o processo de compra será feito em nosso ambiente, o que facilita o pagamento. Ao final da transação, esses compradores são redirecionados ao ambiente da loja.
+
 > WARNING
 >
 > Atenção
 >
-> Caso esteja utilizando a versão antiga do app Mercado Pago ("Mercado Pago"), [clique aqui](/developers/pt/docs/shopify/how-tos/migration) para saber como migrar para a versão atual ("Checkout Mercado Pago").
+> Caso esteja utilizando a versão antiga do app Mercado Pago ("**Mercado Pago**"), [clique aqui](/developers/pt/docs/shopify/how-tos/migration) para saber como migrar para a versão atual ("**Checkout Mercado Pago**").
 
-Para instalar o Checkout Pro em sua loja Shopify, siga os passos abaixo:
+Para instalar o Checkout Pro ("**Checkout Mercado Pago**") em sua loja Shopify, siga os passos abaixo:
+
+1. Vá para a sua loja [Shopify](https://accounts.shopify.com/store-login).
+2. No painel administrativo da loja, clique em **Configurações**.
+3. Uma vez lá, selecione a opção **Pagamentos**. 
+4. Em "Formas de pagamento adicionais", clique em **Adicionar formas de pagamento**.
+5. Acesse a aba **Pesquisar por fornecedor** e procure o novo app com o nome "Checkout Mercado Pago".
+6. Após localizá-lo, selecione-o, clique em **Ativar** e, por fim, em **Conectar**.
+7. Selecione **Instalar app** e, depois, clique em **Gerenciar**.
+8. Insira as suas **credenciais de produção** (`public key` e `access token`) nos campos solicitados e clique em **Salvar**. Lembre-se de ter suas [credenciais](/developers/pt/docs/shopify/additional-content/your-integrations/credentials) à mão.
+9. Para finalizar a instalação, clique em **Ativar Checkout Mercado Pago**.
+
+> Nesta etapa, você pode selecionar as imagens dos meios de pagamento que deseja exibir em sua loja para fins ilustrativos. Além disso, se desejar, você pode ativar o [modo de teste.](/developers/pt/docs/shopify/sales-processing/integration-test)
+> <br/><br/>
+> No caso de renovar suas credenciais, lembre-se de substituir as credenciais de produção e de teste em sua integração.
+
+------------
+----[mla, mlm, mpe, mlu, mlc]----
+Ao instalar o [Checkout Pro](/developers/pt/docs/checkout-pro/landing) ("**Checkout Mercado Pago**"), é possível que haja um **aumento na taxa de aprovação das vendas da loja on-line**. Isso acontece porque os compradores poderão pagar usando uma conta Mercado Pago e todo o processo de compra será feito em nosso ambiente, o que facilita o pagamento. Ao final da transação, esses compradores são redirecionados ao ambiente da loja.
+
+> WARNING
+>
+> Atenção
+>
+> Se estava utilizando o antigo app do Mercado Pago (“**Mercado Pago**”) e deixou de receber pagamentos em sua loja, não se preocupe. Para voltar a vender, instale nosso novo app (“**Checkout Mercado Pago**”) seguindo os passos abaixo.
+
+Para instalar o Checkout Pro ("**Checkout Mercado Pago**") em sua loja Shopify, siga os seguintes passos:
 
 1. Vá para a sua loja [Shopify](https://accounts.shopify.com/store-login).
 2. No painel administrativo da loja, clique em **Configurações**.


### PR DESCRIPTION
## Description

A partir de 30/09 o antigo app do Mercado Pago ("Mercado Pago") será deprecado e, a pessoa usuária que não fez a migração, deixará de receber pagamentos. Com isso, alteramos a warning que indicava a necessidade da migração para indicar a instalação do novo app ("Checkout Mercado Pago") e voltar a receber pagamentos. 

<!--- If your PR is related to any existing issue, don’t forget to link it. Include the issue Fixes #id line, so it closes automatically.-->

### Issue involved

Fixes #<issue>
