### PR TITLE
update/apiref-payments-search-posid

### DIFF
--- a/reference/api-json/stores.json
+++ b/reference/api-json/stores.json
@@ -353,7 +353,7 @@
                           "spa": "Número",
                           "por": "O Número"
                         },
-                        "example": 3039
+                        "example": "3039"
                       },
                       "street_name": {
                         "type": "string",

--- a/reference/api/payments.yaml
+++ b/reference/api/payments.yaml
@@ -3170,11 +3170,11 @@ paths:
             example: 47792478
         - name: pos_id
           in: query
-          description: Parameter used to filter the payment search by POS identifier, physical points of sale that use a card machine for sales.
+          description: Parameter used to filter payment searches by the Point of Sale (POS) identifier, physical sales points that use a card machine for sales and/or QR codes.
           x-description-i18n:
-            eng: Parameter used to filter the payment search by POS identifier, physical points of sale that use a card machine for sales.
-            spa: Parámetro utilizado para filtrar la búsqueda de pagos por el identificador del PDV, puntos de venta físicos que utilizan una máquina de tarjetas para la venta.
-            por: Parâmetro utilizado para filtrar a busca de pagamentos pelo identificador do PDV, pontos de vendas físicos que utilizam maquininha de cartão para vendas.
+            eng: Parameter used to filter payment searches by the Point of Sale (POS) identifier, physical sales points that use a card machine for sales and/or QR codes.
+            spa: Parámetro utilizado para filtrar la búsqueda de pagos por el identificador del PDV, puntos de venta físicos que utilizan una máquina de tarjetas para la venta y/o códigos QR.
+            por: Parâmetro utilizado para filtrar a busca de pagamentos pelo identificador do ponto de venda (PDV), pontos de venda físicos que utilizam uma máquina de cartão para vendas e/ou códigos QR.
           required: false
           schema:
             type: string

--- a/reference/api/stores.yaml
+++ b/reference/api/stores.yaml
@@ -235,7 +235,7 @@ paths:
                         eng: Street number.
                         spa: Número
                         por: O Número
-                      example: 3039
+                      example: "3039"
                     street_name:
                       type: string
                       description: Street name.
@@ -670,7 +670,7 @@ paths:
                         eng: Street number.
                         spa: Número
                         por: O Número
-                      example: 3040
+                      example: "3040"
                     street_name:
                       type: string
                       description: Street name.


### PR DESCRIPTION
## Description

Se actualiza el parámetro pos_id en el get del endpoint payments/search. Este cambio surge de la necesidad de aclarar que pos_id no es solo para las integraciones que usan las máquinas de tarjetas (Point), sino que también es para las integraciones con QR.