### PR TITLE
[Fix] PUT Preferences API

### DIFF
--- a/reference/api-json/preferences.json
+++ b/reference/api-json/preferences.json
@@ -4168,11 +4168,7 @@
                               }
                             },
                             "country_name": {
-                              "type": {
-                                "en": "Country name.",
-                                "pt": "Nome do país",
-                                "es": "Nombre del país"
-                              },
+                              "type": "string",
                               "description": {
                                 "en": "Country name.",
                                 "pt": "Nome do país",

--- a/reference/api/preferences.yaml
+++ b/reference/api/preferences.yaml
@@ -2982,11 +2982,7 @@ paths:
                               spa: Estado
                               por: Estado
                           country_name:
-                            type: Country name.
-                            x-type-i18n:
-                              eng: Country name.
-                              spa: Nombre del país
-                              por: Nome do país
+                            type: string
                             description: Country name.
                             x-description-i18n:
                               eng: Country name.


### PR DESCRIPTION
## Description

Correção de erro que estava quebrando a documentação de [PUT de Preferences](https://www.mercadopago.com.br/developers/pt/reference/preferences/_checkout_preferences_id/put).
O type de uma propriedade estava com um objeto ao invés de uma string esperada.

[Slack](https://meli.slack.com/archives/C03D8E8T9S8/p1700592474064819)

### BEFORE
![image](https://github.com/mercadopago/devsite-docs/assets/37806526/806765d6-f98b-44f1-9b62-5a9303fee0a7)

### AFTER
![image](https://github.com/mercadopago/devsite-docs/assets/37806526/ab511086-d734-4e6c-a3f1-996fbc6382ba)
