### PR TITLE
fix/disclaimer-woocommerce

### DIFF
--- a/guides/woocommerce/install-module-manually.en.md
+++ b/guides/woocommerce/install-module-manually.en.md
@@ -1,3 +1,9 @@
+> WARNING
+>
+> Compatibility with WooCommerce Blocks
+>
+> After WooCommerce stores update, we are working to make Mercado Pago plugin compatible with Blocks. If you are having problems, check the [official documentation](https://woo.com/document/cart-checkout-blocks-status/#section-6) and revert momentarily the update of your store.
+
 # How do I install the plugin manually?
 
 To install the plugin manually in Wordpress, follow these steps:

--- a/guides/woocommerce/install-module-manually.es.md
+++ b/guides/woocommerce/install-module-manually.es.md
@@ -1,3 +1,9 @@
+> WARNING
+>
+> Compatibilidad con WooCommerce Blocks
+>
+> Luego de la actualización de tiendas WooCommerce, estamos trabajando para que el plugin de Mercado Pago sea compatible con Blocks. Si estás teniendo problemas, consulta la [documentación oficial](https://woo.com/document/cart-checkout-blocks-status/#section-6) para revertir momentáneamente la actualización de tu tienda.
+
 # ¿Cómo instalo el plugin manualmente?
 
 Para instalar el plugin manualmente en Wordpress, sigue estos pasos:

--- a/guides/woocommerce/install-module-manually.pt.md
+++ b/guides/woocommerce/install-module-manually.pt.md
@@ -1,3 +1,9 @@
+> WARNING
+>
+> Compatibilidade com WooCommerce Blocks
+>
+> Após a atualização das lojas WooCommerce, estamos trablhando para o plugin do Mercado Pago ser compatível com Blocks. Caso esteja enfrentando problemas, consulte a [documentação oficial](https://woo.com/document/cart-checkout-blocks-status/#section-6) para reverter temporariamente a atualização da sua loja.
+
 # Como instalo o plugin manualmente?
 
 Para instalar o plugin manualmente no Wordpress, siga estes passos:

--- a/guides/woocommerce/plugin-configuration.en.md
+++ b/guides/woocommerce/plugin-configuration.en.md
@@ -1,8 +1,14 @@
+> WARNING
+>
+> Compatibility with WooCommerce Blocks
+>
+> After WooCommerce stores update, we are working to make Mercado Pago plugin compatible with Blocks. If you are having problems, check the [official documentation](https://woo.com/document/cart-checkout-blocks-status/#section-6) and revert momentarily the update of your store.
+
 # Integration configuration
 
 Once the Mercado Pago with WooCommerce plugin is installed, it is necessary to configure it. For that, follow these steps:
 
-> > If you have questions regarding installing the plugin, check out more information in the [Prerequisites.](/developers/en/docs/woocommerce/previous-requirements) section
+> If you have questions regarding installing the plugin, check out more information in the [Prerequisites](/developers/en/docs/woocommerce/previous-requirements) section.
 
 1. Go to your [Wordpress](https://wordpress.com/) account.
 2. Access your account Dashboard and click **Plugins > Installed Plugins**.

--- a/guides/woocommerce/plugin-configuration.es.md
+++ b/guides/woocommerce/plugin-configuration.es.md
@@ -1,3 +1,9 @@
+> WARNING
+>
+> Compatibilidad con WooCommerce Blocks
+>
+> Luego de la actualización de tiendas WooCommerce, estamos trabajando para que el plugin de Mercado Pago sea compatible con Blocks. Si estás teniendo problemas, consulta la [documentación oficial](https://woo.com/document/cart-checkout-blocks-status/#section-6) para revertir momentáneamente la actualización de tu tienda.
+
 # Configuración de la integración
 
 Una vez instalado el plugin de Mercado Pago con WooCommerce, es necesario configurarlo. Para eso, sigue estos pasos:

--- a/guides/woocommerce/plugin-configuration.pt.md
+++ b/guides/woocommerce/plugin-configuration.pt.md
@@ -1,3 +1,9 @@
+> WARNING
+>
+> Compatibilidade com WooCommerce Blocks
+>
+> Após a atualização das lojas WooCommerce, estamos trablhando para o plugin do Mercado Pago ser compatível com Blocks. Caso esteja enfrentando problemas, consulte a [documentação oficial](https://woo.com/document/cart-checkout-blocks-status/#section-6) para reverter temporariamente a atualização da sua loja.
+
 # Configuração da integração
 
 Uma vez instalado o plugin Mercado Pago com WooCommerce, é necessário configurá-lo. Para isso, siga estes passos:

--- a/guides/woocommerce/requirements.en.md
+++ b/guides/woocommerce/requirements.en.md
@@ -2,6 +2,12 @@
 
 To use the Mercado Pago integration with WooCommerce on a WordPress site, you must comply with the requirements below.
 
+> WARNING
+>
+> Compatibility with WooCommerce Blocks
+>
+> After WooCommerce stores update, we are working to make Mercado Pago plugin compatible with Blocks. If you are having problems, check the [official documentation](https://woo.com/document/cart-checkout-blocks-status/#section-6) and revert momentarily the update of your store.
+
 | Requirements | Description | Specifications |
 |---|---|---|
 | Additional settings | Recommended tweaks for better performance and proper functioning of PrestaShop and Mercado Pago module. | safe_mode off * memory_limit greater than 256MB (512MB recommended) |

--- a/guides/woocommerce/requirements.es.md
+++ b/guides/woocommerce/requirements.es.md
@@ -2,6 +2,12 @@
 
 Para utilizar la integración de Mercado Pago con WooCommerce en un sitio WordPress, debes cumplir con los requisitos a continuación.
 
+> WARNING
+>
+> Compatibilidad con WooCommerce Blocks
+>
+> Luego de la actualización de tiendas WooCommerce, estamos trabajando para que el plugin de Mercado Pago sea compatible con Blocks. Si estás teniendo problemas, consulta la [documentación oficial](https://woo.com/document/cart-checkout-blocks-status/#section-6) para revertir momentáneamente la actualización de tu tienda.
+
 | Requisitos | Descripción | Especificaciones |
 | --- | --- | --- |
 | Ambiente | Servicio de hospedaje |  MySQL, PHP o servicio equivalente que admita la instalación de WordPress.  |

--- a/guides/woocommerce/requirements.pt.md
+++ b/guides/woocommerce/requirements.pt.md
@@ -2,6 +2,12 @@
 
 Para usar a integração do Mercado Pago com WooCommerce em um site WordPress, é preciso atender aos requisitos abaixo.
 
+> WARNING
+>
+> Compatibilidade com WooCommerce Blocks
+>
+> Após a atualização das lojas WooCommerce, estamos trablhando para o plugin do Mercado Pago ser compatível com Blocks. Caso esteja enfrentando problemas, consulte a [documentação oficial](https://woo.com/document/cart-checkout-blocks-status/#section-6) para reverter temporariamente a atualização da sua loja.
+
 | Requisitos | Descrição | Especificações |
 |---|---|---|
 | Ambiente | Serviço de hospedagem | MySQL, PHP ou serviço equivalente que admite a instalação do WordPress. |


### PR DESCRIPTION
## Description

Agregado de un disclaimer temporal en woocommerce por una incompatibilidad entre la actualización de la tienda y el plugin. Afecta: Requisitos previos, Configuración de la integración, y Cómo instalar módulo manualmente.

Será eliminado el 26/12, cuando esté en producción el fix del plugin.