### PR TITLE
feature/disclaimer-wallet-dinero

### DIFF
--- a/guides/checkout-pro/payment-methods.en.md
+++ b/guides/checkout-pro/payment-methods.en.md
@@ -17,7 +17,7 @@ In the table below, we detail the preference attributes and the description of e
 >
 > Important
 >
-> The payment methods 'Cash in account' and 'Wallet' cannot be excluded.
+> The payment methods **Cash in account** and **Wallet** cannot be excluded.
 
 With this information, use one of the SDKs available below to configure the payment methods you want to offer.
 

--- a/guides/checkout-pro/payment-methods.en.md
+++ b/guides/checkout-pro/payment-methods.en.md
@@ -13,6 +13,11 @@ In the table below, we detail the preference attributes and the description of e
 | `installments` | Method that defines the maximum number of installments to be offered. |
 | `purpose` | By indicating the value `wallet_purchase` in this method, Checkout Pro will only accept payments from users registered in Mercado Pago, with card and account balance. |
 
+> WARNING
+>
+> Important
+>
+> The payment methods 'Cash in account' and 'Wallet' cannot be excluded.
 
 With this information, use one of the SDKs available below to configure the payment methods you want to offer.
 

--- a/guides/checkout-pro/payment-methods.es.md
+++ b/guides/checkout-pro/payment-methods.es.md
@@ -14,7 +14,7 @@ Por defecto, todos los métodos de pago se ofrecen en Checkout Pro. A través de
 >
 > Importante
 >
-> Los tipos de pago Dinero en cuenta y Wallet no pueden ser excluidos.
+> Los medios de pago **Dinero en cuenta** y **Wallet** no pueden ser excluidos.
 
 En la siguiente tabla, detallamos los atributos de preferencia y la descripción de cada uno de ellos para que puedas definir qué información quieres cambiar y/o agregar.
 

--- a/guides/checkout-pro/payment-methods.es.md
+++ b/guides/checkout-pro/payment-methods.es.md
@@ -10,6 +10,11 @@ Por defecto, todos los medios de pago se ofrecen en Checkout Pro. A través de l
 Por defecto, todos los métodos de pago se ofrecen en Checkout Pro. A través de la preferencia de pago, puedes configurar un método de pago por defecto, eliminar los no deseados, o elegir un número máximo de mensualidades que se ofrecerán.
 ------------
 
+> WARNING
+>
+> Importante
+>
+> Los tipos de pago Dinero en cuenta y Wallet no pueden ser excluidos.
 
 En la siguiente tabla, detallamos los atributos de preferencia y la descripción de cada uno de ellos para que puedas definir qué información quieres cambiar y/o agregar.
 

--- a/guides/checkout-pro/payment-methods.pt.md
+++ b/guides/checkout-pro/payment-methods.pt.md
@@ -6,7 +6,7 @@ Por padrão, todos os meios de pagamento são oferecidos no Checkout Pro. Por me
 >
 > Importante
 >
-> Os tipos de pagamento 'Dinheiro em conta' e 'Wallet' não podem ser excluídos.
+> Os meios de pagamento **Dinheiro em conta** e **Wallet** não podem ser excluídos.
 
 Na tabela abaixo detalhamos os atributos de preferência e a descrição de cada um deles para que você possa definir qual informação deseja alterar e/ou inserir.
 

--- a/guides/checkout-pro/payment-methods.pt.md
+++ b/guides/checkout-pro/payment-methods.pt.md
@@ -2,6 +2,12 @@
 
 Por padrão, todos os meios de pagamento são oferecidos no Checkout Pro. Por meio da preferência de pagamento, você pode configurar um meio de pagamento padrão para ser renderizado, excluir algum indesejado, ou ainda escolher um número máximo de parcelas a serem ofertadas.
 
+> WARNING
+>
+> Importante
+>
+> Os tipos de pagamento 'Dinheiro em conta' e 'Wallet' não podem ser excluídos.
+
 Na tabela abaixo detalhamos os atributos de preferência e a descrição de cada um deles para que você possa definir qual informação deseja alterar e/ou inserir.
 
 

--- a/reference/api-json/preferences.json
+++ b/reference/api-json/preferences.json
@@ -305,9 +305,9 @@
                       "excluded_payment_methods": {
                         "type": "array",
                         "description": {
-                          "en": "Payment methods excluded from the payment process (except account_money, which is always allowed). The payment methods included here will not be available at checkout.",
-                          "pt": "Métodos de pagamento excluídos do checkout (exceto account_money, que estará sempre disponível). Os métodos de pagamento aqui incluídos não estarão disponíveis no checkout.",
-                          "es": "Métodos de pago excluidos del proceso de pago (excepto account_money, que siempre estará disponible). Los métodos de pago incluidos aquí no estarán disponibles en el checkout."
+                          "en": "Payment methods excluded from the payment process (except account_money and wallet, which is always allowed). The payment methods included here will not be available at checkout.",
+                          "pt": "Métodos de pagamento excluídos do checkout (exceto account_money e wallet, que estará sempre disponível). Os métodos de pagamento aqui incluídos não estarão disponíveis no checkout.",
+                          "es": "Métodos de pago excluidos del proceso de pago (excepto account_money y wallet, que siempre estará disponible). Los métodos de pago incluidos aquí no estarán disponibles en el checkout."
                         },
                         "items": {
                           "type": "object",
@@ -326,9 +326,9 @@
                       "excluded_payment_types": {
                         "type": "array",
                         "description": {
-                          "en": "Payment types excluded from the payment process. The payment types included here will not be available at checkout. The payment methods Wallet and Cash in account cannot be excluded.",
-                          "pt": "Tipos de pagamento excluídos do processo de pagamento. Os tipos de pagamento incluídos aqui não estarão disponíveis no checkout. Os tipos de pagamento Wallet e Dinero em conta não podem ser excluídos.",
-                          "es": "Tipos de pago excluidos del proceso de pago. Los tipos de pago incluidos aquí no estarán disponibles en el checkout. Los tipos de pago Wallet y Dinero en cuenta no pueden ser excluídos."
+                          "en": "Payment types excluded from the payment process. The payment types included here will not be available at checkout.",
+                          "pt": "Tipos de pagamento excluídos do processo de pagamento. Os tipos de pagamento incluídos aqui não estarão disponíveis no checkout.",
+                          "es": "Tipos de pago excluidos del proceso de pago. Los tipos de pago incluidos aquí no estarán disponibles en el checkout."
                         },
                         "items": {
                           "type": "object",

--- a/reference/api-json/preferences.json
+++ b/reference/api-json/preferences.json
@@ -307,7 +307,7 @@
                         "description": {
                           "en": "Payment methods excluded from the payment process (except account_money and wallet, which is always allowed). The payment methods included here will not be available at checkout.",
                           "pt": "Métodos de pagamento excluídos do checkout (exceto account_money e wallet, que estará sempre disponível). Os métodos de pagamento aqui incluídos não estarão disponíveis no checkout.",
-                          "es": "Métodos de pago excluidos del proceso de pago (excepto account_money y wallet, que siempre estará disponible). Los métodos de pago incluidos aquí no estarán disponibles en el checkout."
+                          "es": "Métodos de pago excluidos del proceso de pago (excepto account_money y wallet, que siempre estarán disponibles). Los métodos de pago incluidos aquí no estarán disponibles en el checkout."
                         },
                         "items": {
                           "type": "object",

--- a/reference/api-json/preferences.json
+++ b/reference/api-json/preferences.json
@@ -326,9 +326,9 @@
                       "excluded_payment_types": {
                         "type": "array",
                         "description": {
-                          "en": "Payment types excluded from the payment process. The payment types included here will not be available at checkout.",
-                          "pt": "Tipos de pagamento excluídos do processo de pagamento. Os tipos de pagamento incluídos aqui não estarão disponíveis no checkout.",
-                          "es": "Tipos de pago excluidos del proceso de pago. Los tipos de pago incluidos aquí no estarán disponibles en el checkout."
+                          "en": "Payment types excluded from the payment process. The payment types included here will not be available at checkout. The payment methods Wallet and Cash in account cannot be excluded.",
+                          "pt": "Tipos de pagamento excluídos do processo de pagamento. Os tipos de pagamento incluídos aqui não estarão disponíveis no checkout. Os tipos de pagamento Wallet e Dinero em conta não podem ser excluídos.",
+                          "es": "Tipos de pago excluidos del proceso de pago. Los tipos de pago incluidos aquí no estarán disponibles en el checkout. Los tipos de pago Wallet y Dinero en cuenta no pueden ser excluídos."
                         },
                         "items": {
                           "type": "object",

--- a/reference/api-json/preferences.json
+++ b/reference/api-json/preferences.json
@@ -306,7 +306,7 @@
                         "type": "array",
                         "description": {
                           "en": "Payment methods excluded from the payment process (except account_money and wallet, which is always allowed). The payment methods included here will not be available at checkout.",
-                          "pt": "Métodos de pagamento excluídos do checkout (exceto account_money e wallet, que estará sempre disponível). Os métodos de pagamento aqui incluídos não estarão disponíveis no checkout.",
+                          "pt": "Métodos de pagamento excluídos do checkout (exceto account_money e wallet, que estarão sempre disponíveis). Os métodos de pagamento aqui incluídos não estarão disponíveis no checkout.",
                           "es": "Métodos de pago excluidos del proceso de pago (excepto account_money y wallet, que siempre estarán disponibles). Los métodos de pago incluidos aquí no estarán disponibles en el checkout."
                         },
                         "items": {


### PR DESCRIPTION
## Description

**Checkout Pro y Referencia de API**
Se agrega el aviso de que los tipos de pago wallet y dinero en cuenta no pueden ser excluidos

