### PR TITLE
fix/removed validate notification origin from webhooks doc

### DIFF
--- a/guides/additional-content/your-integrations/webhooks.es.md
+++ b/guides/additional-content/your-integrations/webhooks.es.md
@@ -47,53 +47,6 @@ A continuación explicaremos cómo: indicar las URL que serán notificadas, conf
 > </br></br>
 > La clave generada no tiene fecha de caducidad y, aunque no es obligatorio, recomendamos renovar periódicamente la **clave secreta**. Para hacerlo, simplemente haz clic en el botón de restablecimiento junto a la clave.
 
-### Validar origen de la notificación
-
-En el momento en que la URL registrada reciba una notificación, podrás validar si el contenido enviado en el _header_ `x-signature` (ejemplo: `ts=1704908010,v1=618c85345248dd820d5fd456117c2ab2ef8eda45a0282ff693eac24131a5e839`) fue enviado por Mercado Pago, con el fin de obtener mayor seguridad en la recepción de tus notificaciones. A continuación, te indicamos cómo configurar esta validación.
-
-1. Extrae el _timestamp_ (`ts`) y la clave del _header_ `x-signature`. Para hacer esto, divide el contenido del _header_ por el carácter `,`, lo que resultará en una lista de elementos.
-2. Luego, divide cada elemento de la lista por el carácter `=`, lo que resultará en un par de prefijos y los valores. El valor para el prefijo `ts` es el _timestamp_ de la notificación y `v1` es la clave encriptada.
-3. Utilizando el _template_ a continuación, sustituye los parámetros con los datos recibidos en tu notificación.
-
-```template
-post;[urlpath];data.id=[data.id_url];type=[topic_url];user-agent:mercadopago webhook v1.0;[timestamp];action:[json_action];api_version:[json_apiversion];date_created:[json_datecreated_RFC3339];id:[id_json];live_mode:[livemode_json];type:[type_json];user_id:[userid_json];
-```
-
-En el _template_, los valores entre `[]` deben ser reemplazados por los valores de la notificación, como:
-
-- Los parámetros con el sufijo `_url` provienen de _query params_. Ejemplo: `[topic_url]` se sustituirá por el valor `payment`` (sin corchetes).
-- Los parámetros con el sufijo `_json` provienen del _body_ de la solicitud.
-- `[urlpath]` será solo el dominio + el _path_ de la URL (sin "http://" o "https://").
-- `[timestamp]` será el valor ts extraído del _header_ `x-signature`.
-
-> Si alguno de los valores presentados en el _header_ a continuación no está presente en tu notificación, deberás eliminarlos de la plantilla.
-
-4. En el [Panel del desarrollador](/developers/panel/app), selecciona la aplicación integrada, ve a la sección de Webhooks y revela la clave secreta generada.
-5. Genera la contraclave para la validación. Para hacer esto, calcula un [HMAC](https://es.wikipedia.org/wiki/HMAC) con la función de `hash SHA256` en base hexadecimal, utilizando la **clave secreta** como clave y el _template_ poblada con los valores como mensaje. Ejemplo:
-
-[[[
-```php
-$cyphedSignature = hash_hmac('sha256', $data, $key);
-```
-```node
-const crypto = require('crypto');
-const cyphedSignature = crypto
-    .createHmac('sha256', secret)
-    .update(signatureTemplateParsed)
-    .digest('hex'); 
-```
-```java
-String cyphedSignature = new HmacUtils("HmacSHA256", secret).hmacHex(signedTemplate);
-```
-```python
-import hashlib, hmac, binascii
-
-cyphedSignature = binascii.hexlify(hmac_sha256(secret.encode(), signedTemplate.encode()))
-```
-]]]
-
-6. Finalmente, compara la clave generada con la clave extraída del _header_, asegurándote de que tengan una correspondencia exacta. Además, puedes usar el _timestamp_ extraído del _header_ para compararlo con un timestamp generado en el momento de la recepción de la notificación, con el fin de establecer una tolerancia de demora en la recepción del mensaje.
-
 ### Simular la recepción de la notificación
 
 1. Después de configurar las URLs y los Eventos, haz clic en **Simular** para experimentar y probar si la URL indicada está recibiendo las notificaciones correctamente.

--- a/guides/additional-content/your-integrations/webhooks.pt.md
+++ b/guides/additional-content/your-integrations/webhooks.pt.md
@@ -47,53 +47,6 @@ Abaixo explicaremos como: indicar as URLs que serão notificadas, configurar os 
 > </br></br>
 > A assinatura gerada não tem prazo de validade e, embora não seja obrigatório, recomendamos renovar periodicamente a **assinatura secreta**. Para isso, basta clicar no botão de redefinição ao lado da assinatura.
 
-### Validar origem da notificação
-
-No momento em que a URL cadastrada receber uma notificação, você poderá validar se o conteúdo enviado no _header_ `x-signature` (exemplo: `ts=1704908010,v1=618c85345248dd820d5fd456117c2ab2ef8eda45a0282ff693eac24131a5e839`) foi enviado pelo Mercado Pago, a fim de obter mais segurança no recebimento das suas notificações. Veja abaixo como configurar essa validação.
-
-1. Extraia o _timestamp_ (`ts`) e a assinatura do _header_ `x-signature`. Para isso, divida o conteúdo do _header_ pelo caractere `,`, o que resultará em uma lista de elementos. 
-2. Em seguida, divida cada elemento da lista pelo caractere `=`, o que resultará em um par de prefixos e os valores. O valor para o prefixo `ts` é o _timestamp_ da notificação e `v1` é a assinatura encriptada.
-3. Utilizando o _template_ abaixo, substitua os parâmetros pelos dados recebidos na sua notificação. 
-
-```template
-post;[urlpath];data.id=[data.id_url];type=[topic_url];user-agent:mercadopago webhook v1.0;[timestamp];action:[json_action];api_version:[json_apiversion];date_created:[json_datecreated_RFC3339];id:[id_json];live_mode:[livemode_json];type:[type_json];user_id:[userid_json];
-```
-
-No _template_, os valores englobados por `[]` devem ser trocados pelos valores da notificação, como:
-
-- Parâmetros com sufixo `_url` são provenientes de _query params_. Exemplo: `[topic_url]` será substituido pelo valor `payment` (sem os colchetes).
-- Parâmetros com sufixo `_json` são provenientes do _body_ da requisição.
-- `[urlpath]` será somente o domíno + o _path_ da URL (sem "http://" ou "https://").
-- `[timestamp]` será o valor `ts` extraído do _header_ `x-signature`.
-
-> Caso algum dos valores apresentados no _template_ abaixo não esteja presente em sua notificação, você deverá removê-los do template.
-
-4. No [Painel do desenvolvedor](/developers/panel/app), selecione a aplicação integrada, navegue até a seção Webhooks e **revele a assinatura secreta** gerada.
-5. Gere a contra chave para validação. Para isso, calcule um [HMAC](https://pt.wikipedia.org/wiki/HMAC) com a função de `hash SHA256` em base hexadecimal, utilize a **assinatura secreta** como chave e o _template_ populado com os valores como mensagem. Exemplo:
-
-[[[
-```php
-$cyphedSignature = hash_hmac('sha256', $data, $key);
-```
-```node
-const crypto = require('crypto');
-const cyphedSignature = crypto
-    .createHmac('sha256', secret)
-    .update(signatureTemplateParsed)
-    .digest('hex'); 
-```
-```java
-String cyphedSignature = new HmacUtils("HmacSHA256", secret).hmacHex(signedTemplate);
-```
-```python
-import hashlib, hmac, binascii
-
-cyphedSignature = binascii.hexlify(hmac_sha256(secret.encode(), signedTemplate.encode()))
-```
-]]]
-
-6. Por fim, compare a chave gerada com a chave extraída do cabeçalho, considerando elas devem ter uma correspondência exata. Além disso, é possível usar o _timestamp_ extraído do _header_ para comparação com um _timestamp_ gerado na hora do recebimento da notificação, a fim de estipular uma tolerância de atraso no recebimento da mensagem.
-
 ### Simular o recebimento da notificação
 
 1. Após configurar as URLs e os Eventos, clique em **Simular** para experimentar e testar se a URL indicada está recebendo as notificações corretamente.


### PR DESCRIPTION
## Description

Removemos a seção `Validar origem da notificação` da documentação cross de Webhooks. Mais detalhes sobre a tomada desta decisão podem ser encontrados nesta thread: https://meli.slack.com/archives/C018WPMAZHR/p1706019600249799
