### PR TITLE
Atividade - Linkar conteúdos sobre as taxas do Mercado Pago na página de Primeiros passos

### DIFF
--- a/guides/additional-content/getting-started/getting-started-v2.en.md
+++ b/guides/additional-content/getting-started/getting-started-v2.en.md
@@ -39,19 +39,19 @@ bullet_section_with_media:
 
 Solutions for those who sell on websites, through WhatsApp, or social media. The fees, based on the receipt period and/or the number of interest-free installments offered to the buyer, are automatically applied to sales. For further details, please refer to the links below.
 ----[mla, mlm, mpe, mco, mlu, mlc]----
-#### Receiving
-   - [Applicable fees for receiving payments.](https://www.mercadopago[FAKER][URL][DOMAIN]/help/33403)
+#### Receiving payments
+   - [Applicable fees for receiving payments](https://www.mercadopago[FAKER][URL][DOMAIN]/help/33403)
 #### Installments
-   - [Installment costs.](https://www.mercadopago[FAKER][URL][DOMAIN]/help/19032)
-   - [Applicable fees for offering interest-free installments.](https://www.mercadopago[FAKER][URL][DOMAIN]/help/cuotas-sin-interes_3299)
+   - [Installment costs](https://www.mercadopago[FAKER][URL][DOMAIN]/help/19032)
+   - [Applicable fees for offering interest-free installments](https://www.mercadopago[FAKER][URL][DOMAIN]/help/cuotas-sin-interes_3299)
 
 ------------
 ----[mlb]----
-#### Receiving
-   - [Applicable fees for receiving payments.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
+#### Receiving payments
+   - [Applicable fees for receiving payments](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
 #### Installments
-   - [Installment costs.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
-   - [Applicable fees for offering interest-free installments.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
+   - [Installment costs](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
+   - [Applicable fees for offering interest-free installments](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
 
 ------------
 ----[mlb]----

--- a/guides/additional-content/getting-started/getting-started-v2.en.md
+++ b/guides/additional-content/getting-started/getting-started-v2.en.md
@@ -38,14 +38,22 @@ bullet_section_with_media:
 ## Process online payments
 
 Solutions for those who sell on websites, through WhatsApp, or social media. The fees, based on the receipt period and/or the number of interest-free installments offered to the buyer, are automatically applied to sales. For further details, please refer to the links below.
-
+----[mla, mlm, mpe, mco, mlu, mlc]----
 #### Receiving
-   - [Applicable fees for receiving payments](https://www.mercadopago[FAKER][URL][DOMAIN]/help/33403).
-
+   - [Applicable fees for receiving payments.](https://www.mercadopago[FAKER][URL][DOMAIN]/help/33403)
 #### Installments
-   - [Installment costs](https://www.mercadopago[FAKER][URL][DOMAIN]/help/19032).
-   - [Applicable fees for offering interest-free installments](https://www.mercadopago[FAKER][URL][DOMAIN]/help/cuotas-sin-interes_3299).
+   - [Installment costs.](https://www.mercadopago[FAKER][URL][DOMAIN]/help/19032)
+   - [Applicable fees for offering interest-free installments.](https://www.mercadopago[FAKER][URL][DOMAIN]/help/cuotas-sin-interes_3299)
 
+------------
+----[mlb]----
+#### Receiving
+   - [Applicable fees for receiving payments.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
+#### Parcelamento
+   - [Installment costs.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
+   - [Applicable fees for offering interest-free installments.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
+
+------------
 ----[mlb]----
 | Solution | Description | Integration Complexity |
 |:---|:---|:---|

--- a/guides/additional-content/getting-started/getting-started-v2.en.md
+++ b/guides/additional-content/getting-started/getting-started-v2.en.md
@@ -49,7 +49,7 @@ Solutions for those who sell on websites, through WhatsApp, or social media. The
 ----[mlb]----
 #### Receiving
    - [Applicable fees for receiving payments.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
-#### Parcelamento
+#### Installments
    - [Installment costs.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
    - [Applicable fees for offering interest-free installments.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
 

--- a/guides/additional-content/getting-started/getting-started-v2.en.md
+++ b/guides/additional-content/getting-started/getting-started-v2.en.md
@@ -37,7 +37,14 @@ bullet_section_with_media:
 
 ## Process online payments
 
-Solutions for those who sell on websites, through WhatsApp, or social media.
+Solutions for those who sell on websites, through WhatsApp, or social media. The fees, based on the receipt period and/or the number of interest-free installments offered to the buyer, are automatically applied to sales. For further details, please refer to the links below.
+
+#### Receiving
+   - [Applicable fees for receiving payments](https://www.mercadopago[FAKER][URL][DOMAIN]/help/33403).
+
+#### Installments
+   - [Installment costs](https://www.mercadopago[FAKER][URL][DOMAIN]/help/19032).
+   - [Applicable fees for offering interest-free installments](https://www.mercadopago[FAKER][URL][DOMAIN]/help/cuotas-sin-interes_3299).
 
 ----[mlb]----
 | Solution | Description | Integration Complexity |

--- a/guides/additional-content/getting-started/getting-started-v2.es.md
+++ b/guides/additional-content/getting-started/getting-started-v2.es.md
@@ -39,19 +39,30 @@ bullet_section_with_media:
 
 Soluciones para quienes vendan por sitio web, desde WhatsApp o redes sociales. Ofrecemos integración fácil y acceso gratuito a nuestra API. Las tarifas, basadas en el período de recepción y/o en la cantidad de cuotas sin interés ofrecidas al comprador, se aplican automáticamente a las ventas. Para más detalles, consulte los enlaces a continuación.
 
+----[mla, mpe, mco, mlu, mlc]----
 #### Recepción
    - [Tarifas aplicables para recibir pagos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/33403)
-----[mla, mlb, mpe, mco, mlu, mlc]----
 #### Cuotas
    - [Costos de cuotas.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
    - [Tarifas aplicables para ofrecer cuotas sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)
+
 ------------
 ----[mlm]----
+#### Recepción
+   - [Tarifas aplicables para recibir pagos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/33403)
 #### Financiación
    - [Costos de financiación.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
    - [Tarifas aplicables para ofrecer financiación sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)
-------------
 
+------------
+----[mlb]----
+#### Recebimento
+   - [Tarifas aplicables para recibir pagos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
+#### Parcelamento
+   - [Costos de cuotas.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
+   - [Tarifas aplicables para ofrecer cuotas sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
+
+------------
 ----[mlb]----
 | Solución | Descripción | Complejidad de integración |
 |:---|:---|:---|

--- a/guides/additional-content/getting-started/getting-started-v2.es.md
+++ b/guides/additional-content/getting-started/getting-started-v2.es.md
@@ -37,7 +37,20 @@ bullet_section_with_media:
 
 ## Procesa pagos online
 
-Soluciones para quienes vendan por sitio web, desde WhatsApp o redes sociales.
+Soluciones para quienes vendan por sitio web, desde WhatsApp o redes sociales. Ofrecemos integración fácil y acceso gratuito a nuestra API. Las tarifas, basadas en el período de recepción y/o en la cantidad de cuotas sin interés ofrecidas al comprador, se aplican automáticamente a las ventas. Para más detalles, consulte los enlaces a continuación.
+
+#### Recepción
+   - [Tarifas aplicables para recibir pagos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/33403)
+----[mla, mpe, mco, mlu, mlc]----
+#### Cuotas
+   - [Costos de cuotas.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
+   - [Tarifas aplicables para ofrecer cuotas sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)
+------------
+----[mlm]----
+#### Financiación
+   - [Costos de financiación.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
+   - [Tarifas aplicables para ofrecer financiación sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)
+------------
 
 ----[mlb]----
 | Solución | Descripción | Complejidad de integración |

--- a/guides/additional-content/getting-started/getting-started-v2.es.md
+++ b/guides/additional-content/getting-started/getting-started-v2.es.md
@@ -37,30 +37,30 @@ bullet_section_with_media:
 
 ## Procesa pagos online
 
-Soluciones para quienes vendan por sitio web, desde WhatsApp o redes sociales. Ofrecemos integración fácil y acceso gratuito a nuestra API. Las tarifas, basadas en el período de recepción y/o en la cantidad de cuotas sin interés ofrecidas al comprador, se aplican automáticamente a las ventas. Para más detalles, consulte los enlaces a continuación.
+Soluciones para quienes vendan por sitio web, desde WhatsApp o redes sociales. Ofrecemos integraciones sencillas y acceso gratuito a nuestra API. Las tarifas, basadas en el período de recepción de pagos y/o en la cantidad de cuotas sin interés ofrecidas al comprador, se aplican automáticamente a las ventas. Para más detalles, consulta los enlaces a continuación.
 
 ----[mla, mpe, mco, mlu, mlc]----
-#### Recepción
-   - [Tarifas aplicables para recibir pagos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/33403)
+#### Recepción de pagos
+   - [Tarifas aplicables para recibir pagos](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/33403)
 #### Cuotas
-   - [Costos de cuotas.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
-   - [Tarifas aplicables para ofrecer cuotas sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)
+   - [Costos de cuotas](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
+   - [Tarifas aplicables para ofrecer cuotas sin recargo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)
 
 ------------
 ----[mlm]----
-#### Recepción
-   - [Tarifas aplicables para recibir pagos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/33403)
+#### Recepción de pagos
+   - [Tarifas aplicables para recibir pagos](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/33403)
 #### Mensualidades
    - [Costos de mensualidades](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
    - [Tarifas aplicables para ofrecer mensualidades sin recargo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)
 
 ------------
 ----[mlb]----
-#### Recebimento
+#### Recepción de pagos
    - [Tarifas aplicables para recibir pagos](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
 #### Cuotas
-   - [Costos de cuotas.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
-   - [Tarifas aplicables para ofrecer cuotas sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
+   - [Costos de cuotas](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
+   - [Tarifas aplicables para ofrecer cuotas sin recargo](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
 
 ------------
 ----[mlb]----

--- a/guides/additional-content/getting-started/getting-started-v2.es.md
+++ b/guides/additional-content/getting-started/getting-started-v2.es.md
@@ -50,15 +50,15 @@ Soluciones para quienes vendan por sitio web, desde WhatsApp o redes sociales. O
 ----[mlm]----
 #### Recepción
    - [Tarifas aplicables para recibir pagos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/33403)
-#### Financiación
-   - [Costos de financiación.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
-   - [Tarifas aplicables para ofrecer financiación sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)
+#### Mensualidades
+   - [Costos de mensualidades](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
+   - [Tarifas aplicables para ofrecer mensualidades sin recargo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)
 
 ------------
 ----[mlb]----
 #### Recebimento
-   - [Tarifas aplicables para recibir pagos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
-#### Parcelamento
+   - [Tarifas aplicables para recibir pagos](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
+#### Cuotas
    - [Costos de cuotas.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
    - [Tarifas aplicables para ofrecer cuotas sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
 

--- a/guides/additional-content/getting-started/getting-started-v2.es.md
+++ b/guides/additional-content/getting-started/getting-started-v2.es.md
@@ -41,7 +41,7 @@ Soluciones para quienes vendan por sitio web, desde WhatsApp o redes sociales. O
 
 #### Recepción
    - [Tarifas aplicables para recibir pagos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/33403)
-----[mla, mpe, mco, mlu, mlc]----
+----[mla, mlb, mpe, mco, mlu, mlc]----
 #### Cuotas
    - [Costos de cuotas.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/19032)
    - [Tarifas aplicables para ofrecer cuotas sin recargo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/cuotas-sin-interes_3299)

--- a/guides/additional-content/getting-started/getting-started-v2.pt.md
+++ b/guides/additional-content/getting-started/getting-started-v2.pt.md
@@ -39,7 +39,7 @@ bullet_section_with_media:
 
 Soluções para quem vende pelo site, WhatsApp ou redes sociais. Oferecemos integração facilitada e acesso gratuito à nossa API. As taxas, baseadas no período de recebimento e/ou na quantidade de parcelas sem juros oferecidas ao comprador, são automaticamente aplicadas às vendas. Para mais detalhes, consulte os links abaixo.
 ----[mlb]----
-#### Recebimento
+#### Recebimento de pagamentos
    - [Taxas aplicáveis para receber pagamentos](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
 #### Parcelamento
    - [Custos de parcelamento](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
@@ -47,7 +47,7 @@ Soluções para quem vende pelo site, WhatsApp ou redes sociais. Oferecemos inte
 
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
-#### Recebimento
+#### Recebimento de pagamentos
    - [Taxas aplicáveis para receber pagamentos](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/custo-receber-pagamentos_453)
 #### Parcelamento
    - [Custos de parcelamento](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/custos-parcelamento_322)

--- a/guides/additional-content/getting-started/getting-started-v2.pt.md
+++ b/guides/additional-content/getting-started/getting-started-v2.pt.md
@@ -38,13 +38,22 @@ bullet_section_with_media:
 ## Processar pagamentos online
 
 Soluções para quem vende pelo site, WhatsApp ou redes sociais. Oferecemos integração facilitada e acesso gratuito à nossa API. As taxas, baseadas no período de recebimento e/ou na quantidade de parcelas sem juros oferecidas ao comprador, são automaticamente aplicadas às vendas. Para mais detalhes, consulte os links abaixo.
-
+----[mlb]----
 #### Recebimento
    - [Taxas aplicáveis para receber pagamentos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
 #### Parcelamento
    - [Custos de parcelamento.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
    - [Taxas aplicáveis para oferecer parcelamento sem acréscimo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
 
+------------
+----[mla, mlm, mpe, mco, mlu, mlc]----
+#### Recebimento
+   - [Taxas aplicáveis para receber pagamentos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/custo-receber-pagamentos_453)
+#### Parcelamento
+   - [Custos de parcelamento.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/custos-parcelamento_322)
+   - [Taxas aplicáveis para oferecer parcelamento sem acréscimo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/oferecer-parcelas-sem-juros-para-compradores_454)
+   
+------------
 ----[mlb]----
 | Solução | Descrição | Complexidade da integração |
 |:---|:---|:---|

--- a/guides/additional-content/getting-started/getting-started-v2.pt.md
+++ b/guides/additional-content/getting-started/getting-started-v2.pt.md
@@ -37,16 +37,14 @@ bullet_section_with_media:
 
 ## Processar pagamentos online
 
-Soluções para quem vende pelo site, WhatsApp ou redes sociais. Oferecemos integração facilitada e acesso gratuito à nossa API. As taxas, baseadas no período de recebimento, são automaticamente aplicadas às vendas ou aos parcelamentos sem juros oferecidos ao comprador. Para mais detalhes, consulte os links abaixo.
+Soluções para quem vende pelo site, WhatsApp ou redes sociais. Oferecemos integração facilitada e acesso gratuito à nossa API. As taxas, baseadas no período de recebimento e/ou na quantidade de parcelas sem juros oferecidas ao comprador, são automaticamente aplicadas às vendas. Para mais detalhes, consulte os links abaixo.
 
-----[mlb]----
 #### Recebimento
-   - [Taxas aplicáveis para receber pagamentos.](https://www.mercadopago.com.br/ajuda/custo-receber-pagamentos_453)
+   - [Taxas aplicáveis para receber pagamentos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
 #### Parcelamento
-   - [Custos de parcelamento.](https://www.mercadopago.com.br/ajuda/custos-parcelamento_322)
-   - [Taxas aplicáveis para oferecer parcelamento sem acréscimo.](https://www.mercadopago.com.br/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
+   - [Custos de parcelamento.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
+   - [Taxas aplicáveis para oferecer parcelamento sem acréscimo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
 
-------------
 ----[mlb]----
 | Solução | Descrição | Complexidade da integração |
 |:---|:---|:---|

--- a/guides/additional-content/getting-started/getting-started-v2.pt.md
+++ b/guides/additional-content/getting-started/getting-started-v2.pt.md
@@ -40,18 +40,18 @@ bullet_section_with_media:
 Soluções para quem vende pelo site, WhatsApp ou redes sociais. Oferecemos integração facilitada e acesso gratuito à nossa API. As taxas, baseadas no período de recebimento e/ou na quantidade de parcelas sem juros oferecidas ao comprador, são automaticamente aplicadas às vendas. Para mais detalhes, consulte os links abaixo.
 ----[mlb]----
 #### Recebimento
-   - [Taxas aplicáveis para receber pagamentos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
+   - [Taxas aplicáveis para receber pagamentos](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custo-receber-pagamentos_453)
 #### Parcelamento
-   - [Custos de parcelamento.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
-   - [Taxas aplicáveis para oferecer parcelamento sem acréscimo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
+   - [Custos de parcelamento](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/custos-parcelamento_322)
+   - [Taxas aplicáveis para oferecer parcelamento sem acréscimo](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
 
 ------------
 ----[mla, mlm, mpe, mco, mlu, mlc]----
 #### Recebimento
-   - [Taxas aplicáveis para receber pagamentos.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/custo-receber-pagamentos_453)
+   - [Taxas aplicáveis para receber pagamentos](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/custo-receber-pagamentos_453)
 #### Parcelamento
-   - [Custos de parcelamento.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/custos-parcelamento_322)
-   - [Taxas aplicáveis para oferecer parcelamento sem acréscimo.](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/oferecer-parcelas-sem-juros-para-compradores_454)
+   - [Custos de parcelamento](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/custos-parcelamento_322)
+   - [Taxas aplicáveis para oferecer parcelamento sem acréscimo](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/oferecer-parcelas-sem-juros-para-compradores_454)
    
 ------------
 ----[mlb]----

--- a/guides/additional-content/getting-started/getting-started-v2.pt.md
+++ b/guides/additional-content/getting-started/getting-started-v2.pt.md
@@ -37,8 +37,16 @@ bullet_section_with_media:
 
 ## Processar pagamentos online
 
-Soluções para quem vende pelo site, WhatsApp ou redes sociais.
+Soluções para quem vende pelo site, WhatsApp ou redes sociais. Oferecemos integração facilitada e acesso gratuito à nossa API. As taxas, baseadas no período de recebimento, são automaticamente aplicadas às vendas ou aos parcelamentos sem juros oferecidos ao comprador. Para mais detalhes, consulte os links abaixo.
 
+----[mlb]----
+#### Recebimento
+   - [Taxas aplicáveis para receber pagamentos.](https://www.mercadopago.com.br/ajuda/custo-receber-pagamentos_453)
+#### Parcelamento
+   - [Custos de parcelamento.](https://www.mercadopago.com.br/ajuda/custos-parcelamento_322)
+   - [Taxas aplicáveis para oferecer parcelamento sem acréscimo.](https://www.mercadopago.com.br/ajuda/oferecer-parcelas-sem-juros-para-compradores_454)
+
+------------
 ----[mlb]----
 | Solução | Descrição | Complexidade da integração |
 |:---|:---|:---|


### PR DESCRIPTION
A pedido de WCS, incluímos informações sobre as taxas do Mercado Pago na nossa documentação de Primeiros passos, pois muitos tickets são abertos ao suporte em relação a esse tema.