### PR TITLE
discord-feedbacks - Split de pagamentos

### DIFF
--- a/guides/split-payment/configuration.en.md
+++ b/guides/split-payment/configuration.en.md
@@ -7,7 +7,7 @@ To configure the integration with the Split payments solution, you will need to 
 >
 > Important
 >
-> Please note that the Split payments solution can only be integrated with [Checkout Pro](/developers/en/docs/split-payments/landing) and [Checkout API](/developers/en/docs/checkout-api/landing), and is not available for use with other products.
+> Please note that the Split payments solution can only be integrated with [Checkout Pro](/developers/en/docs/split-payments/landing), [Checkout API](/developers/en/docs/checkout-api/landing) and [Checkout Bricks](/developers/en/docs/checkout-bricks/landing), and is not available for use with other products.
 
 ------------ 
 ----[mlb]----
@@ -15,7 +15,7 @@ To configure the integration with the Split payments solution, you will need to 
 >
 > Important
 >
-> Please note that the Split payments solution can only be integrated with [Checkout Pro](/developers/en/docs/split-payments/landing) and [Checkout Transparente](/developers/en/docs/checkout-api/landing), and is not available for use with other products.
+> Please note that the Split payments solution can only be integrated with [Checkout Pro](/developers/en/docs/split-payments/landing), [Checkout Transparente](/developers/en/docs/checkout-api/landing) and [Checkout Bricks](/developers/en/docs/checkout-bricks/landing), and is not available for use with other products.
 
 ------------
 ## Create application

--- a/guides/split-payment/configuration.es.md
+++ b/guides/split-payment/configuration.es.md
@@ -7,7 +7,7 @@ Para configurar la integración con la solución de Split de pagos, deberás [cr
 >
 > Importante
 >
-> Ten en cuenta que la solución de Split de pagos solo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing), [Checkout API](/developers/es/docs/checkout-api/landing) y [Checkout Bricks](/developers/es/docs/checkout-bricks/landing), y no está disponible para otros productos.
+> Ten en cuenta que la solución de Split de pagos sólo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing), [Checkout API](/developers/es/docs/checkout-api/landing) y [Checkout Bricks](/developers/es/docs/checkout-bricks/landing), y no está disponible para otros productos.
 
 ------------ 
 ----[mlb]----
@@ -15,7 +15,7 @@ Para configurar la integración con la solución de Split de pagos, deberás [cr
 >
 > Importante
 >
-> Ten en cuenta que la solución de Split de pagos solo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing), [Checkout Transparente](/developers/es/docs/checkout-api/landing) y [Checkout Bricks](/developers/es/docs/checkout-bricks/landing), y no está disponible para otros productos.
+> Ten en cuenta que la solución de Split de pagos sólo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing), [Checkout Transparente](/developers/es/docs/checkout-api/landing) y [Checkout Bricks](/developers/es/docs/checkout-bricks/landing), y no está disponible para otros productos.
 
 ------------
 ## Crear aplicación

--- a/guides/split-payment/configuration.es.md
+++ b/guides/split-payment/configuration.es.md
@@ -15,7 +15,7 @@ Para configurar la integración con la solución de Split de pagos, deberás [cr
 >
 > Importante
 >
-> Ten en cuenta que la solución de Split de pagos solo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing), [Checkout Transparente](/developers/es/docs/checkout-api/landing) y [Checkout Bricks](/developers/pt/docs/checkout-bricks/landing), y no está disponible para otros productos.
+> Ten en cuenta que la solución de Split de pagos solo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing), [Checkout Transparente](/developers/es/docs/checkout-api/landing) y [Checkout Bricks](/developers/es/docs/checkout-bricks/landing), y no está disponible para otros productos.
 
 ------------
 ## Crear aplicación

--- a/guides/split-payment/configuration.es.md
+++ b/guides/split-payment/configuration.es.md
@@ -7,7 +7,7 @@ Para configurar la integración con la solución de Split de pagos, deberás [cr
 >
 > Importante
 >
-> Ten en cuenta que la solución de Split de pagos solo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing) o [Checkout API](/developers/es/docs/checkout-api/landing) y no está disponible para otros productos.
+> Ten en cuenta que la solución de Split de pagos solo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing), [Checkout API](/developers/es/docs/checkout-api/landing) y [Checkout Bricks](/developers/es/docs/checkout-bricks/landing), y no está disponible para otros productos.
 
 ------------ 
 ----[mlb]----
@@ -15,7 +15,7 @@ Para configurar la integración con la solución de Split de pagos, deberás [cr
 >
 > Importante
 >
-> Ten en cuenta que la solución de Split de pagos solo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing) o [Checkout Transparente](/developers/es/docs/checkout-api/landing) y no está disponible para otros productos.
+> Ten en cuenta que la solución de Split de pagos solo se puede integrar con [Checkout Pro](/developers/es/docs/split-payments/landing), [Checkout Transparente](/developers/es/docs/checkout-api/landing) y [Checkout Bricks](/developers/pt/docs/checkout-bricks/landing), y no está disponible para otros productos.
 
 ------------
 ## Crear aplicación

--- a/guides/split-payment/configuration.pt.md
+++ b/guides/split-payment/configuration.pt.md
@@ -7,7 +7,7 @@ Para configurar a integração com a solução Split de pagamentos, você dever�
 >
 > Importante
 >
-> Tenha em mente que a solução Split de pagamentos só pode ser integrada com o [Checkout Pro](/developers/pt/docs/split-payments/landing) e o [Checkout API](/developers/pt/docs/checkout-api/landing), não estando disponível para uso com outros produtos.
+> Tenha em mente que a solução Split de pagamentos só pode ser integrada com o [Checkout Pro](/developers/pt/docs/split-payments/landing), [Checkout API](/developers/pt/docs/checkout-api/landing) e [Checkout Bricks](/developers/pt/docs/checkout-bricks/landing), não estando disponível para uso com outros produtos.
 
 ------------ 
 ----[mlb]----
@@ -15,7 +15,7 @@ Para configurar a integração com a solução Split de pagamentos, você dever�
 >
 > Importante
 >
-> Tenha em mente que a solução Split de pagamentos só pode ser integrada com o [Checkout Pro](/developers/pt/docs/split-payments/landing) e o [Checkout Transparente](/developers/pt/docs/checkout-api/landing), não estando disponível para uso com outros produtos.
+> Tenha em mente que a solução Split de pagamentos só pode ser integrada com o [Checkout Pro](/developers/pt/docs/split-payments/landing), [Checkout Transparente](/developers/pt/docs/checkout-api/landing) e [Checkout Bricks](/developers/pt/docs/checkout-bricks/landing), não estando disponível para uso com outros produtos.
 
 ------------
 ## Criar aplicação

--- a/guides/split-payment/integrate-marketplace.en.md
+++ b/guides/split-payment/integrate-marketplace.en.md
@@ -63,3 +63,9 @@ To perform the integration, you will need to follow the usual integration flow o
 ```
 
 Upon completing these steps, the checkout will have been integrated into the marketplace and will be ready to process payments.
+
+> WARNING
+>
+> Important
+>
+> In case of a refund, the amount due to the final customer will be divided and subtracted from the seller's account and the Marketplace's account, being **proportional** to the parties involved. Additionally, in 1:1 models, the Marketplace cannot issue a full refund if the seller does not have funds in their account. In this case, the Marketplace's account must refund the equivalent of its share and decide whether to return the remaining amount, which is the seller's responsibility, by other means.

--- a/guides/split-payment/integrate-marketplace.en.md
+++ b/guides/split-payment/integrate-marketplace.en.md
@@ -68,4 +68,4 @@ Upon completing these steps, the checkout will have been integrated into the mar
 >
 > Important
 >
-> In case of a refund, the amount due to the final customer will be divided and subtracted from the seller's account and the Marketplace's account, being **proportional** to the parties involved. Additionally, in 1:1 models, the Marketplace cannot issue a full refund if the seller does not have funds in their account. In this case, the Marketplace's account must refund the equivalent of its share and decide whether to return the remaining amount, which is the seller's responsibility, by other means.
+> In case of a refund, the amount due to the final customer will be divided and subtracted from the seller's account and the Marketplace's account, in a **proportional** way to the parties involved. Additionally, in 1:1 models, the Marketplace cannot issue a full refund if the seller does not have sufficient funds in their account. In this case, the Marketplace's account must refund the equivalent of its share and decide whether to return the remaining amount, which is the seller's responsibility, by other means of payment.

--- a/guides/split-payment/integrate-marketplace.es.md
+++ b/guides/split-payment/integrate-marketplace.es.md
@@ -63,3 +63,9 @@ Para realizar la integración deberás seguir el flujo de integración habitual 
 ```
 
 Al completar estos pasos, el checkout se habrá integrado en el _marketplace_ y estará listo para procesar pagos.
+
+> WARNING
+>
+> Importante
+>
+> En caso de reembolso, el valor debido al cliente final será dividido y restado de la cuenta del vendedor y de la cuenta del Marketplace, siendo **proporcional** para las partes involucradas. Además, en modelos 1:1, el Marketplace no podrá realizar el reembolso total si el vendedor no tiene dinero en la cuenta. En ese caso, corresponde a la cuenta del Marketplace reembolsar el equivalente a su parte y decidir si devolverá el resto, que es responsabilidad del vendedor, por otro medio.

--- a/guides/split-payment/integrate-marketplace.es.md
+++ b/guides/split-payment/integrate-marketplace.es.md
@@ -68,4 +68,4 @@ Al completar estos pasos, el checkout se habrá integrado en el _marketplace_ y 
 >
 > Importante
 >
-> En caso de reembolso, el valor debido al cliente final será dividido y restado de la cuenta del vendedor y de la cuenta del Marketplace, siendo **proporcional** para las partes involucradas. Además, en modelos 1:1, el Marketplace no podrá realizar el reembolso total si el vendedor no tiene dinero en la cuenta. En ese caso, corresponde a la cuenta del Marketplace reembolsar el equivalente a su parte y decidir si devolverá el resto, que es responsabilidad del vendedor, por otro medio.
+> En caso de reembolso, el valor adeudado al cliente final será dividido y restado de la cuenta del vendedor y de la cuenta del Marketplace, de forma **proporcional** para las partes involucradas. Además, en modelos 1:1, el Marketplace no podrá realizar el reembolso total si el vendedor no tuviera dinero en la cuenta. En ese caso, corresponde a la cuenta del Marketplace reembolsar el equivalente a su parte y decidir si devolverá el restante, que es responsabilidad del vendedor, por otro medio.

--- a/guides/split-payment/integrate-marketplace.pt.md
+++ b/guides/split-payment/integrate-marketplace.pt.md
@@ -64,8 +64,8 @@ Para realizar a integração você precisará seguir o fluxo de integração usu
 
 Ao finalizar essas etapas, a integração do checkout com o _marketplace_ estará concluída e pronta para processar os pagamentos.
 
-> NOTE
+> WARNING
 >
 > Importante
 >
-> A comissão do Mercado Pago é descontada do valor recebido pelo vendedor. Ou seja, primeiro, a comissão do Mercado Pago é descontada e, em seguida, a comissão do Marketplace é descontada sobre o valor restante.
+> Em caso de reembolso, o valor devido ao cliente final será dividido e subtraído da conta do vendedor e da conta do Marketplace, sendo **proporcional** para as partes envolvidas. Além disso, em modelos 1:1, o Marketplace não poderá realizar o reembolso total se o vendedor não tiver dinheiro na conta. Nesse caso, cabe à conta do Marketplace reembolsar o equivalente à sua parte e decidir se devolverá o restante, que é responsabilidade do vendedor, por outro meio.

--- a/guides/split-payment/integrate-marketplace.pt.md
+++ b/guides/split-payment/integrate-marketplace.pt.md
@@ -63,3 +63,9 @@ Para realizar a integração você precisará seguir o fluxo de integração usu
 ```
 
 Ao finalizar essas etapas, a integração do checkout com o _marketplace_ estará concluída e pronta para processar os pagamentos.
+
+> NOTE
+>
+> Importante
+>
+> A comissão do Mercado Pago é descontada do valor recebido pelo vendedor. Ou seja, primeiro, a comissão do Mercado Pago é descontada e, em seguida, a comissão do Marketplace é descontada sobre o valor restante.


### PR DESCRIPTION
Incluímos Checkout Bricks no _warning_ sobre quais checkouts podem ser integrados com Split de pagos e, além disso, incluímos outro _warning_ trazendo informações sobre o funcionamento do reembolso em Split.