### PR TITLE
Complementar do aviso em IPN

### DIFF
--- a/guides/additional-content/your-integrations/ipn.en.md
+++ b/guides/additional-content/your-integrations/ipn.en.md
@@ -6,7 +6,7 @@ Instant Payment Notification (IPN) is a mechanism that allows your application t
 >
 > Important
 >
-> IPN notifications will be discontinued. Additionally, despite receiving the `x-Signature` header, they do not allow validation through the secret key to confirm they were sent by Mercado Pago. If you wish to perform this origin validation, we recommend migrating to [Webhooks notifications](/developers/en/docs/your-integrations/notifications/webhooks).   
+> IPN notifications will be discontinued. Additionally, despite receiving the `x-Signature` header, they do not allow validation through the secret key to confirm they were sent by Mercado Pago. If you wish to perform this origin validation, we recommend migrating to [Webhooks notifications](/developers/en/docs/your-integrations/notifications/webhooks), which now also send the `merchant_order` and `chargebacks` topics.   
 
 IPN notifications can be configured in two ways: 
 

--- a/guides/additional-content/your-integrations/ipn.es.md
+++ b/guides/additional-content/your-integrations/ipn.es.md
@@ -6,7 +6,7 @@ IPN (Instant Payment Notification) es un mecanismo que permite que tu aplicació
 >
 > Importante
 >
-> Las notificaciones IPN van a ser descontinuadas. Además, a pesar de recibir el *header* `x-Signature`, no permiten la validación mediante la clave secreta para confirmar que las mismas fueron enviadas por Mercado Pago. Si deseas realizar esta validación, recomendamos migrar a [notificaciones Webhooks](/developers/es/docs/your-integrations/notifications/webhooks).   
+> Las notificaciones IPN van a ser descontinuadas. Además, a pesar de recibir el *header* `x-Signature`, no permiten la validación mediante la clave secreta para confirmar que las mismas fueron enviadas por Mercado Pago. Si deseas realizar esta validación, recomendamos migrar a [notificaciones Webhooks](/developers/es/docs/your-integrations/notifications/webhooks), que ahora también envían los tópicos `merchant_order` y `chargebacks`.   
 
 
 Las notificaciones IPN pueden ser configuradas de dos maneras:

--- a/guides/additional-content/your-integrations/ipn.pt.md
+++ b/guides/additional-content/your-integrations/ipn.pt.md
@@ -6,7 +6,7 @@ IPN (Instant Payment Notification) é um mecanismo que permite que uma aplicaç�
 >
 > Importante
 >
-> As notificações IPN serão descontinuadas. Além disso, apesar de receber o _header_ `x-Signature`, elas não permitem a validação por meio da chave secreta para confirmar que foram enviadas pelo Mercado Pago. Para realizar essa validação de origem, recomendamos migrar para as [notificações Webhooks](/developers/pt/docs/your-integrations/notifications/webhooks).   
+> As notificações IPN serão descontinuadas. Além disso, apesar de receber o _header_ `x-Signature`, elas não permitem a validação por meio da chave secreta para confirmar que foram enviadas pelo Mercado Pago. Para realizar essa validação de origem, recomendamos migrar para as [notificações Webhooks](/developers/pt/docs/your-integrations/notifications/webhooks), que agora também enviam os tópicos `merchant_order` e `chargebacks`.   
 
 As notificações IPN podem ser configuradas de duas maneiras: 
 


### PR DESCRIPTION
Na doc de IPN, complementamos o primeiro aviso: "agora também enviam os tópicos `merchant_order` e `chargebacks`".   