### PR TITLE
feature/dateofexpiration-apiref

### DIFF
--- a/guides/checkout-pro/preferences-intro.en.md
+++ b/guides/checkout-pro/preferences-intro.en.md
@@ -2,7 +2,7 @@
 
 You can adapt the Checkout Pro integration to your business model by **configuring preferences attributes**.
 
-Preferences attribute settings allow you to **define installments**, **exclude an unwanted payment method**, **change the due date of a certain payment**, in addition to obtaining business information and **measuring the effectiveness of your ads** on platforms such as Facebook and Google.
+Preferences attribute settings allow you to **define installments** and **exclude an unwanted payment method**, in addition to obtaining business information and **measuring the effectiveness of your ads** on platforms such as Facebook and Google.
 
 See below for a complete example of preference.
 

--- a/guides/checkout-pro/preferences-intro.es.md
+++ b/guides/checkout-pro/preferences-intro.es.md
@@ -2,7 +2,7 @@
 
 Puedes adaptar la integración de Checkout Pro a tu modelo de negocio **configurando atributos de preferencia**.
 
-La configuración de atributos de preferencia te permite **definir cuotas**, **excluir un medio de pago no deseado**, **cambiar la fecha de vencimiento de un determinado pago**, además de obtener información comercial y **medir la efectividad de tus anuncios** en plataformas como Facebook y Google.
+La configuración de atributos de preferencia te permite **definir cuotas** y **excluir un medio de pago no deseado**, además de obtener información comercial y **medir la efectividad de tus anuncios** en plataformas como Facebook y Google.
 
 Mira a continuación un ejemplo completo de preferencia.
 

--- a/guides/checkout-pro/preferences-intro.pt.md
+++ b/guides/checkout-pro/preferences-intro.pt.md
@@ -2,7 +2,7 @@
 
 Você pode adaptar a integração do Checkout Pro ao seu modelo de negócio **configurando atributos de preferência**.
 
-As configurações dos atributos de preferência permitem **definir parcelamentos**, **excluir um meio de pagamento indesejado**, **alterar data de vencimento de determinado pagamento**, além de obter informações de negócio e **mensurar a efetividade dos seus anúncios** em plataformas como Facebook e Google.
+As configurações dos atributos de preferência permitem **definir parcelamentos** e **excluir um meio de pagamento indesejado**, além de obter informações de negócio e **mensurar a efetividade dos seus anúncios** em plataformas como Facebook e Google.
 
 Veja abaixo um exemplo completo de preferência.
 

--- a/reference/api-json/payments.json
+++ b/reference/api-json/payments.json
@@ -4364,9 +4364,9 @@
                     "type": "string",
                     "format": "date",
                     "description": {
-                      "en": "Payment’s expiration date. The valid format of the attribute is as follows - \"yyyy-MM-dd'T'HH:mm:ssz\". Ex - 2022-11-17T09:37:52.000-04:00.",
-                      "pt": "Data de expiração do pagamento. O formato válido do atributo é o seguinte - \"yyyy-MM-dd'T'HH:mm:ssz\". Por exemplo - 2022-11-17T09:37:52.000-04:00.",
-                      "es": "Fecha de vencimiento del pago. El formato válido del atributo es el siguiente - \"yyyy-MM-dd'T'HH:mm:ssz\". Por ejemplo - 2022-11-17T09:37:52.000-04:00."
+                      "en": "Cash payment’s expiration date. The valid format of the attribute is as follows - \"yyyy-MM-dd'T'HH:mm:ssz\". Ex - 2022-11-17T09:37:52.000-04:00. Only valid for payments created from Argentina, Mexico, and Uruguay. Some types of payments may not accept a customizable due date.",
+                      "pt": "Data de expiração do pagamento com dinheiro. O formato válido do atributo é o seguinte - \"yyyy-MM-dd'T'HH:mm:ssz\". Por exemplo - 2022-11-17T09:37:52.000-04:00. Somente válido para pagamentos criados a partir da Argentina, México e Uruguai. Alguns tipos de pagamentos podem não aceitar uma data de vencimento personalizável.",
+                      "es": "Fecha de vencimiento del pago en efectivo. El formato válido del atributo es el siguiente - \"yyyy-MM-dd'T'HH:mm:ssz\". Por ejemplo - 2022-11-17T09:37:52.000-04:00. Sólo válido para pagos creados desde Argentina, México y Uruguay. Algunos tipos de pagos pueden no aceptar una fecha de vencimiento personalizable."
                     }
                   },
                   "status": {

--- a/reference/api-json/payments.json
+++ b/reference/api-json/payments.json
@@ -590,9 +590,9 @@
                     "type": "string",
                     "format": "date",
                     "description": {
-                      "en": "Payment’s expiration date. The valid format of the attribute is as follows - \"yyyy-MM-dd HH:mm:ss.SSSz\". Ex - 2022-11-17T09:37:52.000-04:00.",
-                      "pt": "Data de expiração do pagamento. O formato válido do atributo é o seguinte - \"yyyy-MM-dd HH:mm:ss.SSSz\". Por exemplo - 2022-11-17T09:37:52.000-04:00.",
-                      "es": "Fecha de vencimiento del pago. El formato válido del atributo es el siguiente - \"yyyy-MM-dd HH:mm:ss.SSSz\". Ej - 2022-11-17T09:37:52.000-04:00."
+                      "en": "Cash payment’s expiration date. The valid format of the attribute is as follows - \"yyyy-MM-dd'T'HH:mm:ssz\". Ex - 2022-11-17T09:37:52.000-04:00. Only valid for payments created from Argentina, Mexico, and Uruguay. Some types of payments may not accept a customizable due date.",
+                      "pt": "Data de expiração do pagamento com dinheiro. O formato válido do atributo é o seguinte - \"yyyy-MM-dd'T'HH:mm:ssz\". Por exemplo - 2022-11-17T09:37:52.000-04:00. Somente válido para pagamentos criados a partir da Argentina, México e Uruguai. Alguns tipos de pagamentos podem não aceitar uma data de vencimento personalizável.",
+                      "es": "Fecha de vencimiento del pago en efectivo. El formato válido del atributo es el siguiente - \"yyyy-MM-dd'T'HH:mm:ssz\". Por ejemplo - 2022-11-17T09:37:52.000-04:00. Sólo válido para pagos creados desde Argentina, México y Uruguay. Algunos tipos de pagos pueden no aceptar una fecha de vencimiento personalizable."
                     }
                   },
                   "external_reference": {
@@ -4364,9 +4364,9 @@
                     "type": "string",
                     "format": "date",
                     "description": {
-                      "en": "Cash payment’s expiration date. The valid format of the attribute is as follows - \"yyyy-MM-dd'T'HH:mm:ssz\". Ex - 2022-11-17T09:37:52.000-04:00. Only valid for payments created from Argentina, Mexico, and Uruguay. Some types of payments may not accept a customizable due date.",
-                      "pt": "Data de expiração do pagamento com dinheiro. O formato válido do atributo é o seguinte - \"yyyy-MM-dd'T'HH:mm:ssz\". Por exemplo - 2022-11-17T09:37:52.000-04:00. Somente válido para pagamentos criados a partir da Argentina, México e Uruguai. Alguns tipos de pagamentos podem não aceitar uma data de vencimento personalizável.",
-                      "es": "Fecha de vencimiento del pago en efectivo. El formato válido del atributo es el siguiente - \"yyyy-MM-dd'T'HH:mm:ssz\". Por ejemplo - 2022-11-17T09:37:52.000-04:00. Sólo válido para pagos creados desde Argentina, México y Uruguay. Algunos tipos de pagos pueden no aceptar una fecha de vencimiento personalizable."
+                      "en": "Payment’s expiration date. The valid format of the attribute is as follows - \"yyyy-MM-dd'T'HH:mm:ssz\". Ex - 2022-11-17T09:37:52.000-04:00.",
+                      "pt": "Data de expiração do pagamento. O formato válido do atributo é o seguinte - \"yyyy-MM-dd'T'HH:mm:ssz\". Por exemplo - 2022-11-17T09:37:52.000-04:00.",
+                      "es": "Fecha de vencimiento del pago. El formato válido del atributo es el siguiente - \"yyyy-MM-dd'T'HH:mm:ssz\". Por ejemplo - 2022-11-17T09:37:52.000-04:00."
                     }
                   },
                   "status": {


### PR DESCRIPTION
En Referencia de API, para el endpoint [/v1/payments](mercadopago.com.ar:8443/developers/es/reference/payments/_payments/post):
- Nueva definición para `date_of_expiration`. Se aclara que sólo es válido para tres países y para algunos tipos de pago offline

En la documentación [Preferencias](https://www.mercadopago.com.ar/developers/es/docs/checkout-pro/checkout-customization/preferences):
- Se elimina la mención a "cambiar la fecha de vencimiento de un determinado pago".