### PR TITLE
feature/notifications-chargebacks

### DIFF
--- a/guides/additional-content/chargebacks/how-to-manage.en.md
+++ b/guides/additional-content/chargebacks/how-to-manage.en.md
@@ -4,7 +4,7 @@ A dispute occurs when **you want to argue the chargeback claim** with supporting
 
 All the information necessary to manage chargeback disputes made can be found here:
 
-1. Configure [IPN notifications](/developers/panel/ipn) on your dashboard and enable the **Chargebacks** option
+1. Configure [Webhooks](/developers/en/docs/checkout-pro/additional-content/your-integrations/notifications/webhooks) or [IPN notifications](/developers/panel/ipn) on your dashboard and enable the **Chargebacks** option.
    
 2. Check all the information related to a chargeback using the [Get chargeback request](/developers/en/reference/chargebacks/_chargebacks_id/get)
    1. Check if the chargeback [can be covered](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/294) and assure whether any documentation is required, via the `coverage_eligible` and `documentation_required` fields, respectively.

--- a/guides/additional-content/chargebacks/how-to-manage.es.md
+++ b/guides/additional-content/chargebacks/how-to-manage.es.md
@@ -4,9 +4,9 @@ Se produce una disputa cuando deseas discutir el reclamo de contracargo con info
 
 Toda la información necesaria para gestionar las disputas de contracargos realizadas se puede encontrar aquí:
 
-1. Configura [las notificaciones IPN](/developers/panel/ipn) y habilita la opción **Contracargos**
+1. Configura [notificaciones Webhooks](/developers/es/docs/checkout-pro/additional-content/your-integrations/notifications/webhooks) o [IPN](/developers/panel/ipn) y habilita la opción **Contracargos**.
    
-2. Verifica toda la información relacionada con un contracargo utilizando la solicitud [Obtener contracargo](/developers/es/reference/chargebacks/_chargebacks_id/get)
+2. Consulta toda la información relacionada con un contracargo utilizando la solicitud [Obtener contracargo](/developers/es/reference/chargebacks/_chargebacks_id/get).
    1. Verifica si el [contracargo se puede cubrir](https://www.mercadopago[FAKER][URL][DOMAIN]/ayuda/294) y si se requiere alguna documentación, a través de los campos `coverage_eligible` y `documentation_required`, respectivamente.
 
 > WARNING

--- a/guides/additional-content/chargebacks/how-to-manage.pt.md
+++ b/guides/additional-content/chargebacks/how-to-manage.pt.md
@@ -4,7 +4,7 @@ Uma disputa ocorre quando **você deseja argumentar** o pedido de contestação 
 
 Abaixo você encontra as informações necessárias para o gerenciamento das disputas das contestações feitas.
 
-1. Configure as [notificações IPN](/developers/panel/ipn) no painel e ative a opção **Contestações (chargebacks)**
+1. Configure as [notificações Webhooks](/developers/pt/docs/checkout-pro/additional-content/your-integrations/notifications/webhooks) ou [IPN](/developers/panel/ipn) no painel e ative a opção **Chargebacks**.
    
 2. Consulte todas as informações de uma contestação com o método [Obter estorno](/developers/pt/reference/chargebacks/_chargebacks_id/get)
    1. Identifique se a contestação é [elegível a cobertura](https://www.mercadopago[FAKER][URL][DOMAIN]/ajuda/294) e se é necessário apresentar alguma documentação, através dos campos `coverage_elegible` e `documentation_required`, respectivamente.

--- a/guides/additional-content/your-integrations/notification-additional-info.en.md
+++ b/guides/additional-content/your-integrations/notification-additional-info.en.md
@@ -127,6 +127,33 @@ In cases where notifications for the topic `topic_claims_integration_wh` have be
 | `type` | Type of notification received, according to the previously selected topic. In this case, it will always be `claim`. |
 | `user_id `| User identifier for whom the notification is sent. |
 
+## Chargebacks
+
+In cases where notifications for the topic `topic_chargebacks_wh` have been activated, a Webhooks notification will be sent when a chargeback is initiated or its status is changed, as shown below:
+
+```json
+{
+    "actions":["changed_case_status"],
+    "api_version":"v1",
+    "application_id":9007201037432480,
+    "data":{
+        "checkout":"PRO",
+        "date_updated":"0001-01-01T00:00:00Z",
+        "id":217000061307271000,
+        "payment_id":81034165129,
+        "product_id":"BC32A57TRPP001U8NHHG",
+        "site_id":"MLA",
+        "transaction_intent_id":""
+        },
+    "date_created":"2024-07-02T22:03:24-04:00",
+    "id":114544942708,
+    "live_mode":true,
+    "type":"topic_chargebacks_wh",
+    "user_id":425424311,
+    "version":1720427447
+}
+```
+
 ## Offline payment methods
 
 If you have integrated payments with offline payment methods and configured your notifications with the payments topic, you should know that all changes in payment status will be notified to you.

--- a/guides/additional-content/your-integrations/notification-additional-info.es.md
+++ b/guides/additional-content/your-integrations/notification-additional-info.es.md
@@ -128,6 +128,34 @@ En los casos en los que se hayan activado las notificaciones para el tópico `to
 | `type` | Tipo de notificación recibida, de acuerdo al tópico seleccionado previamente. En este caso, será siempre `claim`. |
 | `user_id `| Identificador del usuario para el que se envía la notificación. |
 
+## Contracargos
+
+En los casos en los que se hayan activado las notificaciones para el tópico `topic_chargebacks_wh`, se enviará una notificación Webhooks cuando se inicie un contracargo o cambie su estado, tal como se muestra a continuación:
+
+```json
+{
+    "actions":["changed_case_status"],
+    "api_version":"v1",
+    "application_id":9007201037432480,
+    "data":{
+        "checkout":"PRO",
+        "date_updated":"0001-01-01T00:00:00Z",
+        "id":217000061307271000,
+        "payment_id":81034165129,
+        "product_id":"BC32A57TRPP001U8NHHG",
+        "site_id":"MLA",
+        "transaction_intent_id":""
+        },
+    "date_created":"2024-07-02T22:03:24-04:00",
+    "id":114544942708,
+    "live_mode":true,
+    "type":"topic_chargebacks_wh",
+    "user_id":425424311,
+    "version":1720427447
+}
+```
+
+
 ## Medios de pago offline
 
 En caso de haber integrado medios de pago offline y configurado tus notificaciones con el tópico `payments`, todos los cambios de estado de un pago te serán notificados.

--- a/guides/additional-content/your-integrations/notification-additional-info.pt.md
+++ b/guides/additional-content/your-integrations/notification-additional-info.pt.md
@@ -129,6 +129,34 @@ Nos casos em que as notificações para o tópico `topic_claims_integration_wh` 
 | `type` | Tipo de notificação recebida, conforme o tópico selecionado anteriormente. Neste caso, será sempre `claim`. |
 | `user_id `| Identificador do usuário para quem a notificação está sendo enviada. |
 
+## Chargebacks
+
+Nos casos em que as notificações para o tópico `topic_chargebacks_wh` estiverem ativadas, uma notificação Webhooks será enviada quando um _chargeback_ for iniciado, ou seu status atualizado, conforme mostrado abaixo:
+
+```json
+{
+    "actions":["changed_case_status"],
+    "api_version":"v1",
+    "application_id":9007201037432480,
+    "data":{
+        "checkout":"PRO",
+        "date_updated":"0001-01-01T00:00:00Z",
+        "id":217000061307271000,
+        "payment_id":81034165129,
+        "product_id":"BC32A57TRPP001U8NHHG",
+        "site_id":"MLA",
+        "transaction_intent_id":""
+        },
+    "date_created":"2024-07-02T22:03:24-04:00",
+    "id":114544942708,
+    "live_mode":true,
+    "type":"topic_chargebacks_wh",
+    "user_id":425424311,
+    "version":1720427447
+}
+```
+
+
 ## Meios de pagamento offline
 
 Se você integrou meios de pagamento offline e configurou suas notificações com o tópico `payments`, todas as mudanças de status de um pagamento serão notificadas a você.


### PR DESCRIPTION

## Description
Se agrega un ejemplo del tópico chargebacks en "Información adicional sobre notificaciones", y la mención a Webhooks dentro de "Cómo gestionar disputas de contracargos". Esto es parte de la actividad de doc [DEVCOMMS-2560](https://mercadolibre.atlassian.net/browse/DEVCOMMS-2560)


[DEVCOMMS-2560]: https://mercadolibre.atlassian.net/browse/DEVCOMMS-2560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ