### PR TITLE
fix/id parameter type correction

### DIFF
--- a/reference/api-json/test_user.json
+++ b/reference/api-json/test_user.json
@@ -117,7 +117,7 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "integer",
+                      "type": "number",
                       "example": 123,
                       "description": {
                         "en": "Unique ID that identifies the test user.",


### PR DESCRIPTION
## Description

Devido à recente alteração para os campos de ID de usuário terem passado de `int32` a `int64` iniciamos um quick win para o endpoint de Test Users alterando o tipo do parâmetro de resposta `Id` de `Integer` para `number`.