### PR TITLE
bugs-27-12

### DIFF
--- a/guides/checkout-bricks/payment-brick/default-rendering.en.md
+++ b/guides/checkout-bricks/payment-brick/default-rendering.en.md
@@ -6,7 +6,7 @@ Before rendering the Payment Brick, first execute the [initialization steps](/de
 >
 > Note
 >
-> To consult the types and specifications of the parameters and responses of the Brick functions, refer to the [technical documentation](https://github.com/mercadopago/sdk-js/blob/main/API/bricks/payment.md).
+> To consult the types and specifications of the parameters and responses of the Brick functions, refer to the [technical documentation](https://github.com/mercadopago/sdk-js/blob/main/docs/bricks/payment.md).
 
 ## Configure the Brick
 

--- a/guides/checkout-bricks/payment-brick/default-rendering.es.md
+++ b/guides/checkout-bricks/payment-brick/default-rendering.es.md
@@ -6,7 +6,7 @@ Antes de realizar la renderización del Payment Brick, primero ejecute los [paso
 >
 > Nota
 >
-> Para consultar los tipos y especificaciones de los parámetros y respuestas de las funciones del Brick, consulte la [documentación técnica](https://github.com/mercadopago/sdk-js/blob/main/API/bricks/payment.md).
+> Para consultar los tipos y especificaciones de los parámetros y respuestas de las funciones del Brick, consulte la [documentación técnica](https://github.com/mercadopago/sdk-js/blob/main/docs/bricks/payment.md).
 
 ## Configurar el Brick
 

--- a/guides/checkout-bricks/payment-brick/default-rendering.pt.md
+++ b/guides/checkout-bricks/payment-brick/default-rendering.pt.md
@@ -6,7 +6,7 @@ Antes de realizar a renderização do Payment Brick, primeiro execute os [passos
 >
 > Nota
 >
-> Para consultar tipagens e especificações dos parâmetros e respostas de funções do Brick, consulte a [documentação técnica](https://github.com/mercadopago/sdk-js/blob/main/API/bricks/payment.md).
+> Para consultar tipagens e especificações dos parâmetros e respostas de funções do Brick, consulte a [documentação técnica](https://github.com/mercadopago/sdk-js/blob/main/docs/bricks/payment.md).
 
 ## Configurar o Brick
 

--- a/guides/checkout-bricks/payment-brick/payment-submission.en.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission.en.md
@@ -12,7 +12,7 @@ Once the request –with all the collected information– is in your backend, it
 >
 > Note
 >
-> To consult the types and specifications that can be sent and received by the Brick in the onSubmit callback, check the [technical documentation](https://github.com/mercadopago/sdk-js/blob/main/API/bricks/payment.md).
+> To consult the types and specifications that can be sent and received by the Brick in the onSubmit callback, check the [technical documentation](https://github.com/mercadopago/sdk-js/blob/main/docs/bricks/payment.md).
 
 For this to work, you should configure your [private key](/developers/en/guides/additional-content/your-integrations/credentials). Also, to interact with our APIs, you should use [Mercado Pago official SDK](/developers/en/docs/sdks-library/landing).
 

--- a/guides/checkout-bricks/payment-brick/payment-submission.es.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission.es.md
@@ -12,7 +12,7 @@ Ya estando en tu backend con toda la información recolectada, es momento de env
 >
 > Nota
 >
-> Para consultar los tipos y especificaciones que podrán ser enviados y recibidos por el Brick en el _callback_ de _onSubmit_, consulta la [documentación técnica](https://github.com/mercadopago/sdk-js/blob/main/API/bricks/payment.md).
+> Para consultar los tipos y especificaciones que podrán ser enviados y recibidos por el Brick en el _callback_ de _onSubmit_, consulta la [documentación técnica](https://github.com/mercadopago/sdk-js/blob/main/docs/bricks/payment.md).
 
 Ten en cuenta que para que este paso funcione es necesario que configures tu [clave privada](/developers/es/guides/additional-content/your-integrations/credentials) y que para interactuar con nuestras APIs recomendamos utilizar la [SDK oficial de Mercado Pago](/developers/es/docs/sdks-library/landing).
 

--- a/guides/checkout-bricks/payment-brick/payment-submission.pt.md
+++ b/guides/checkout-bricks/payment-brick/payment-submission.pt.md
@@ -12,7 +12,7 @@ Já estando no seu backend com toda a informação coletada, é o momento de env
 >
 > Nota
 >
-> Para consultar tipagens e especificações que poderão ser enviados e recebidos pelo Brick no _callback_ de _onSubmit_, consulte a [documentação técnica](https://github.com/mercadopago/sdk-js/blob/main/API/bricks/payment.md).
+> Para consultar tipagens e especificações que poderão ser enviados e recebidos pelo Brick no _callback_ de _onSubmit_, consulte a [documentação técnica](https://github.com/mercadopago/sdk-js/blob/main/docs/bricks/payment.md).
 
 Tenha em conta que para que esse passo funcione é necessário que configure sua [chave privada](/developers/pt/guides/additional-content/your-integrations/credentials) e que para interagir com nossas APIs, recomendamos utilizar o [SDK oficial do Mercado Pago](/developers/pt/docs/sdks-library/landing).
 

--- a/guides/checkout-pro/integration-android-flutter.pt.md
+++ b/guides/checkout-pro/integration-android-flutter.pt.md
@@ -112,7 +112,7 @@ class MyApp extends StatelessWidget {
 >
 > h2
 >
-> Como retornar à sua app
+> Como retornar para sua app
 
 **Deep Links**, também conhecidos como links diretos, são uma forma poderosa de permitir a navegação direta para telas ou seções específicas de uma aplicação móvel.
 

--- a/guides/checkout-pro/integration-android-java-kotlin.pt.md
+++ b/guides/checkout-pro/integration-android-java-kotlin.pt.md
@@ -52,7 +52,7 @@ val url = "URL-PREFERENCE"
 >
 > h2
 >
-> Como retornar à sua app
+> Como retornar para sua app
 
 **Deep Links**, também conhecidos como links diretos, são uma forma poderosa de permitir a navegação direta para telas ou seções específicas de uma aplicação móvel.
 

--- a/guides/checkout-pro/integration-android-reactnative-cli.pt.md
+++ b/guides/checkout-pro/integration-android-reactnative-cli.pt.md
@@ -126,7 +126,7 @@ const ButtonCustomTabs = () => {
 >
 > h2
 >
-> Como retornar ao sua app
+> Como retornar para sua app
 
 **Deep Links**, também conhecidos como links diretos, são uma forma poderosa de permitir a navegação direta para telas ou seções específicas de uma aplicação móvel.
 

--- a/guides/checkout-pro/integration-android-reactnative-expo-go.pt.md
+++ b/guides/checkout-pro/integration-android-reactnative-expo-go.pt.md
@@ -70,7 +70,7 @@ export default function ExpoWebBrowserExample(url) {
 >
 > h2
 >
-> Como retornar ao sua app
+> Como retornar para sua app
 
 **Deep Links**, também conhecidos como links diretos, são uma forma poderosa de permitir a navegação direta para telas ou seções específicas de uma aplicação móvel.
 

--- a/guides/checkout-pro/integration-ios-flutter.pt.md
+++ b/guides/checkout-pro/integration-ios-flutter.pt.md
@@ -112,7 +112,7 @@ class MyApp extends StatelessWidget {
 >
 > h2
 >
-> Como retornar à sua app
+> Como retornar para sua app
 
 **Deep Links**, também conhecidos como links diretos, são uma forma poderosa de permitir a navegação direta para telas ou seções específicas de uma aplicação móvel.
 

--- a/guides/checkout-pro/integration-ios-reactnative-cli.pt.md
+++ b/guides/checkout-pro/integration-ios-reactnative-cli.pt.md
@@ -94,11 +94,9 @@ const ButtonCustomTabs = () => {
 
 > CLIENT_SIDE
 >
-> h2> CLIENT_SIDE
->
 > h2
 >
-> Como retornar ao sua app
+> Como retornar para sua app
 
 **Deep Links**, também conhecidos como links diretos, são uma forma poderosa de permitir a navegação direta para telas ou seções específicas de uma aplicação móvel.
 

--- a/guides/checkout-pro/integration-ios-reactnative-expo-go.pt.md
+++ b/guides/checkout-pro/integration-ios-reactnative-expo-go.pt.md
@@ -70,7 +70,7 @@ export default function ExpoWebBrowserExample(url) {
 >
 > h2
 >
-> Como retornar ao sua app
+> Como retornar para sua app
 
 **Deep Links**, também conhecidos como links diretos, são uma forma poderosa de permitir a navegação direta para telas ou seções específicas de uma aplicação móvel.
 

--- a/guides/checkout-pro/integration-ios-swift.pt.md
+++ b/guides/checkout-pro/integration-ios-swift.pt.md
@@ -94,7 +94,7 @@ class ViewController: UIViewController {
 >
 > h2
 >
-> Como retornar ao sua app
+> Como retornar para sua app
 
 **Deep Links**, também conhecidos como links diretos, são uma forma poderosa de permitir a navegação direta para telas ou seções específicas de uma aplicação móvel.
 


### PR DESCRIPTION
Corregimos los errores de documentación reportados en el canal [#mp-dx-devsite-bugs](https://meli.slack.com/archives/C03D8E8T9S8) el día 26/12.


Arreglamos el título en portugués para la sección Como volver a tu app en las integraciones mobile de chopro