### PR TITLE
Docs: advertencia por rechazo `cc_rejected_high_risk` al realizar pagos duplicados

### DIFF
--- a/guides/additional-content/how-tos/payment-rejections.en.md
+++ b/guides/additional-content/how-tos/payment-rejections.en.md
@@ -79,7 +79,7 @@ When our fraud prevention system detects a suspicious payment, the API’s respo
 
 > WARNING
 > 
-> Attention
+> Attention 
 >
 > `cc_rejected_other_reason` is a status given by the bank that doesn’t mention the reason of the rejection, but indicates a fraude risk estimation. However, there may be other reasons why this status is returned. In case of doubt, it is recommended to choose other payment method to fulfill the transaction or to get in touch with the issuer bank institution.
 ```json
@@ -93,3 +93,10 @@ When our fraud prevention system detects a suspicious payment, the API’s respo
 }
 ```
 
+> WARNING
+> 
+> Attention
+>
+> In some cases, the `cc_rejected_high_risk` response may occur when two consecutive payments are made with the same items or with very similar parameters (such as identical `external_reference` or `items` values). This can trigger the anti-fraud engine, which may flag the attempt as a duplicate and reject it as a precaution. As a result, subsequent payments might be temporarily blocked.
+>
+> It is recommended to implement controls to avoid immediate retries using the same payment data.

--- a/guides/additional-content/how-tos/payment-rejections.en.md
+++ b/guides/additional-content/how-tos/payment-rejections.en.md
@@ -97,6 +97,6 @@ When our fraud prevention system detects a suspicious payment, the API’s respo
 > 
 > Attention
 >
-> In some cases, the `cc_rejected_high_risk` response may occur when two consecutive payments are made with the same items or with very similar parameters (such as identical `external_reference` or `items` values). This can trigger the anti-fraud engine, which may flag the attempt as a duplicate and reject it as a precaution. As a result, subsequent payments might be temporarily blocked.
+> In some cases, the `cc_rejected_high_risk` response may occur when two consecutive payments are made with the same items or with very similar parameters (such as identical `payer` and `items` values in both payments made). This can trigger the anti-fraud engine, which may flag the attempt as a duplicate and reject it as a precaution. As a result, subsequent payments might be temporarily blocked.
 >
 > It is recommended to implement controls to avoid immediate retries using the same payment data.

--- a/guides/additional-content/how-tos/payment-rejections.es.md
+++ b/guides/additional-content/how-tos/payment-rejections.es.md
@@ -99,6 +99,6 @@ Cuando los sistemas de prevención detectan un pago sospechoso, la respuesta de 
 > 
 > Atención
 >
-> En algunos casos, la respuesta `cc_rejected_high_risk` puede aparecer cuando se intentan realizar dos pagos consecutivos con los mismos ítems o con parámetros similares (como `external_reference` o `items` idénticos). Esto puede hacer que el motor antifraude lo interprete como un intento duplicado y lo rechace por precaución, bloqueando todos los pagos posteriores temporalmente.
+> En algunos casos, la respuesta `cc_rejected_high_risk` puede aparecer cuando se intentan realizar dos pagos consecutivos con los mismos ítems o con parámetros muy similares (como `payer` e `items` idénticos en ambos pagos realizados). Esto puede hacer que el motor antifraude lo interprete como un intento duplicado y lo rechace por precaución, bloqueando todos los pagos posteriores temporalmente.
 >
 > Se recomienda implementar controles para evitar reintentos inmediatos con los mismos datos.

--- a/guides/additional-content/how-tos/payment-rejections.es.md
+++ b/guides/additional-content/how-tos/payment-rejections.es.md
@@ -84,7 +84,6 @@ Cuando los sistemas de prevención detectan un pago sospechoso, la respuesta de 
 > Atención
 >
 > La respuesta `cc_rejected_other_reason` es un status que proviene del banco emisor y, si bien no explicita el motivo de rechazo, se trata de una estimación de riesgo de fraude. Igualmente, hay otros motivos por los cuales este status puede ser devuelto. En caso de duda, es recomendable elegir otro medio de pago o ponerse en contacto con la entidad bancaria.
-
 ```json
  {
     "status": "rejected",
@@ -96,3 +95,10 @@ Cuando los sistemas de prevención detectan un pago sospechoso, la respuesta de 
 }
 ```
 
+> WARNING
+> 
+> Atención
+>
+> En algunos casos, la respuesta `cc_rejected_high_risk` puede aparecer cuando se intentan realizar dos pagos consecutivos con los mismos ítems o con parámetros similares (como `external_reference` o `items` idénticos). Esto puede hacer que el motor antifraude lo interprete como un intento duplicado y lo rechace por precaución, bloqueando todos los pagos posteriores temporalmente.
+>
+> Se recomienda implementar controles para evitar reintentos inmediatos con los mismos datos.

--- a/guides/additional-content/how-tos/payment-rejections.pt.md
+++ b/guides/additional-content/how-tos/payment-rejections.pt.md
@@ -95,6 +95,6 @@ Quando o nosso sistema de prevenção de fraude detectar um pagamento suspeito, 
 > 
 > Atenção
 >
-> Em alguns casos, a resposta `cc_rejected_high_risk` pode ocorrer quando dois pagamentos consecutivos são realizados com os mesmos itens ou com parâmetros muito semelhantes (como valores em `external_reference` ou `items` idênticos). Isso pode acionar o motor antifraude, que pode interpretar a tentativa como duplicada e rejeitá-la por precaução. Como consequência, os pagamentos subsequentes podem ser temporariamente bloqueados.
+> Em alguns casos, a resposta `cc_rejected_high_risk` pode ocorrer quando dois pagamentos consecutivos são realizados com os mesmos itens ou com parâmetros muito semelhantes (como valores em `payer` e `items` idênticos em ambos os pagamentos realizados). Isso pode acionar o motor antifraude, que pode interpretar a tentativa como duplicada e rejeitá-la por precaução. Como consequência, os pagamentos subsequentes podem ser temporariamente bloqueados.
 >
 > É recomendável implementar controles para evitar novas tentativas imediatas com os mesmos dados de pagamento.

--- a/guides/additional-content/how-tos/payment-rejections.pt.md
+++ b/guides/additional-content/how-tos/payment-rejections.pt.md
@@ -91,3 +91,10 @@ Quando o nosso sistema de prevenção de fraude detectar um pagamento suspeito, 
 }
 ```
 
+> WARNING
+> 
+> Atenção
+>
+> Em alguns casos, a resposta `cc_rejected_high_risk` pode ocorrer quando dois pagamentos consecutivos são realizados com os mesmos itens ou com parâmetros muito semelhantes (como valores em `external_reference` ou `items` idênticos). Isso pode acionar o motor antifraude, que pode interpretar a tentativa como duplicada e rejeitá-la por precaução. Como consequência, os pagamentos subsequentes podem ser temporariamente bloqueados.
+>
+> É recomendável implementar controles para evitar novas tentativas imediatas com os mesmos dados de pagamento.


### PR DESCRIPTION
## Description

Se agrega una advertencia en la documentación de errores de pago sobre los posibles motivos del rechazo `cc_rejected_high_risk`.

Además, se aclara que este rechazo también puede dispararse cuando el mismo usuario intenta pagar varias veces con distintos medios de pago en poco tiempo, o si se repiten los ítems en múltiples intentos.

**Importante**: Al obtener este error, todos los pagos se bloquean temporalmente, lo que puede afectar la capacidad de realizar pagos adicionales temporalmente.